### PR TITLE
Rule ssrf

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ or to specify a set of rules to explicitly exclude using the '-exclude=' flag.
   - G104: Audit errors not checked
   - G105: Audit the use of math/big.Int.Exp
   - G106: Audit the use of ssh.InsecureIgnoreHostKey
+  - G107: Url provided to HTTP request as taint input
   - G201: SQL query construction using format string
   - G202: SQL query construction using string concatenation
   - G203: Use of unescaped data in HTML templates

--- a/rules/rulelist.go
+++ b/rules/rulelist.go
@@ -67,6 +67,7 @@ func Generate(filters ...RuleFilter) RuleList {
 		{"G104", "Audit errors not checked", NewNoErrorCheck},
 		{"G105", "Audit the use of big.Exp function", NewUsingBigExp},
 		{"G106", "Audit the use of ssh.InsecureIgnoreHostKey function", NewSSHHostKey},
+		{"G107", "Url provided to HTTP request as taint input", NewSSRFCheck},
 
 		// injection
 		{"G201", "SQL query construction using format string", NewSQLStrFormat},

--- a/rules/rules_test.go
+++ b/rules/rules_test.go
@@ -69,6 +69,10 @@ var _ = Describe("gas rules", func() {
 			runner("G106", testutils.SampleCodeG106)
 		})
 
+		It("should detect of ssrf via http requests with variable url", func() {
+			runner("G107", testutils.SampleCodeG107)
+		})
+
 		It("should detect sql injection via format strings", func() {
 			runner("G201", testutils.SampleCodeG201)
 		})

--- a/rules/ssrf.go
+++ b/rules/ssrf.go
@@ -1,0 +1,70 @@
+// (c) Copyright 2016 Hewlett Packard Enterprise Development LP
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rules
+
+import (
+	"go/ast"
+	"go/types"
+
+	"github.com/GoASTScanner/gas"
+)
+
+type ssrf struct {
+	gas.MetaData
+	gas.CallList
+}
+
+// ID returns the identifier for this rule
+func (r *ssrf) ID() string {
+	return r.MetaData.ID
+}
+
+//	TODO(jovon) identify these calls from type `http.Client`
+//		- https://github.com/go-resty/resty -- looks well maintained and popular
+//
+// Match inspects AST nodes to determine if certain net/http methods are called with variable input
+func (r *ssrf) Match(n ast.Node, c *gas.Context) (*gas.Issue, error) {
+	if node := r.ContainsCallExpr(n, c); node != nil {
+		for _, arg := range node.Args {
+			if ident, ok := arg.(*ast.Ident); ok {
+				obj := c.Info.ObjectOf(ident)
+				if _, ok := obj.(*types.Var); ok && !gas.TryResolve(ident, c) {
+					return gas.NewIssue(c, n, r.What, r.Severity, r.Confidence), nil
+				}
+			}
+		}
+	}
+	return nil, nil
+}
+
+// NewSSRFCheck detects cases where HTTP requests are sent
+func NewSSRFCheck(id string, conf gas.Config) (gas.Rule, []ast.Node) {
+	rule := &readfile{
+		CallList: gas.NewCallList(),
+		MetaData: gas.MetaData{
+			ID:         id,
+			What:       "Potential HTTP request made with variable url",
+			Severity:   gas.Medium,
+			Confidence: gas.High,
+		},
+	}
+	rule.Add("net/http", "Do")
+	rule.Add("net/http", "Get")
+	rule.Add("net/http", "Head")
+	rule.Add("net/http", "Post")
+	rule.Add("net/http", "PostForm")
+	rule.Add("net/http", "RoundTrip")
+	return rule, []ast.Node{(*ast.CallExpr)(nil)}
+}

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -192,6 +192,29 @@ import (
 func main() {
         _ =  ssh.InsecureIgnoreHostKey()
 }`, 1}}
+
+	// SampleCodeG107 - SSRF via http requests with variable url
+	SampleCodeG107 = []CodeSample{{`
+package main
+import (
+        "net/http"
+	"io/ioutil"
+	"fmt"
+)
+func main() {
+	url := os.Getenv("tainted_url")
+	resp, err := http.Get(url)
+	if err != nil {
+		panic(err)
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%s", body)
+}`, 1}}
+
 	// SampleCodeG201 - SQL injection via format string
 	SampleCodeG201 = []CodeSample{
 		{`


### PR DESCRIPTION
This rule is very basic. I'd like to fine-tune it to reduce the number of false positives. The default Go HTTP request clients are of type `http.Client`. Currently the rule looks for `http.(Get|Post|Do)..` to identify potential vulns. This by itself is not complete, because other methods (`http.RoundTrip`) can also use `http.Client` underneath to issue http requests. 

@cosmincojocar  do you have any recommendations to identify request methods attached to a `http.Client` type?

I also have a TODO to look up popular Go packages that perform http requests and include them in this rule.

Thanks, Jovon