### PR TITLE
Document #nosec use with a list of rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ that are not considered build artifacts by the compiler (so test files).
 
 As with all automated detection tools there will be cases of false positives. In cases where gosec reports a failure that has been manually verified as being safe it is possible to annotate the code with a '#nosec' comment.
 
-The annotation causes gosec  to stop processing any further nodes within the
-AST so can apply to a whole block or more granularly to a single expression.
+The annotation causes gosec to stop processing any further nodes within the
+AST so can apply to a whole block or more granularly to a single expression. 
 
 ```go
 
@@ -95,6 +95,8 @@ func main(){
 }
 
 ```
+
+When a specific false positive has been identified and verified as safe, you may wish to suppress only that single rule (or a specific set of rules) within a section of code, while continuing to scan for other problems. To do this, you can list the rule(s) to be suppressed within the `#nosec` annotation, e.g: `/* #nosec G401 */` or `// #nosec G201 G202 G203 `
 
 In some cases you may also want to revisit places where #nosec annotations
 have been used. To run the scanner and ignore any #nosec annotations you


### PR DESCRIPTION
Extend the readme to document the ability to prevent some, but not all, rules from being enforced within an AST node. (Addresses the issue I opened at https://github.com/securego/gosec/issues/224)