### PR TITLE
Small update to G201 and added ConcatString Function

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -261,19 +261,19 @@ func GetPkgAbsPath(pkgPath string) (string, error) {
 func ConcatString(n *ast.BinaryExpr) (string, bool) {
 	var s string
 	// sub expressions are found in X object, Y object is always last BasicLit
-	if right_operand, ok := n.Y.(*ast.BasicLit); ok {
-		if str, err := GetString(right_operand); err == nil {
+	if rightOperand, ok := n.Y.(*ast.BasicLit); ok {
+		if str, err := GetString(rightOperand); err == nil {
 			s = str + s
 		}
 	} else {
 		return "", false
 	}
-	if left_operand, ok := n.X.(*ast.BinaryExpr); ok {
-		if recursion, ok := ConcatString(left_operand); ok {
+	if leftOperand, ok := n.X.(*ast.BinaryExpr); ok {
+		if recursion, ok := ConcatString(leftOperand); ok {
 			s = recursion + s
 		}
-	} else if left_operand, ok := n.X.(*ast.BasicLit); ok {
-		if str, err := GetString(left_operand); err == nil {
+	} else if leftOperand, ok := n.X.(*ast.BasicLit); ok {
+		if str, err := GetString(leftOperand); err == nil {
 			s = str + s
 		}
 	} else {

--- a/helpers.go
+++ b/helpers.go
@@ -256,3 +256,28 @@ func GetPkgAbsPath(pkgPath string) (string, error) {
 	}
 	return absPath, nil
 }
+
+// ConcatString recusively concatanates strings from a binary expression
+func ConcatString(n *ast.BinaryExpr) (string, bool) {
+	var s string
+	// sub expressions are found in X object, Y object is always last BasicLit
+	if right_operand, ok := n.Y.(*ast.BasicLit); ok {
+		if str, err := GetString(right_operand); err == nil {
+			s = str + s
+		}
+	} else {
+		return "", false
+	}
+	if left_operand, ok := n.X.(*ast.BinaryExpr); ok {
+		if recursion, ok := ConcatString(left_operand); ok {
+			s = recursion + s
+		}
+	} else if left_operand, ok := n.X.(*ast.BasicLit); ok {
+		if str, err := GetString(left_operand); err == nil {
+			s = str + s
+		}
+	} else {
+		return "", false
+	}
+	return s, true
+}

--- a/helpers.go
+++ b/helpers.go
@@ -257,7 +257,7 @@ func GetPkgAbsPath(pkgPath string) (string, error) {
 	return absPath, nil
 }
 
-// ConcatString recusively concatanates strings from a binary expression
+// ConcatString recusively concatenates strings from a binary expression
 func ConcatString(n *ast.BinaryExpr) (string, bool) {
 	var s string
 	// sub expressions are found in X object, Y object is always last BasicLit

--- a/rules/sql.go
+++ b/rules/sql.go
@@ -84,7 +84,7 @@ func NewSQLStrConcat(id string, conf gosec.Config) (gosec.Rule, []ast.Node) {
 	return &sqlStrConcat{
 		sqlStatement: sqlStatement{
 			patterns: []*regexp.Regexp{
-				regexp.MustCompile(`(?i)(SELECT|DELETE|INSERT|UPDATE|INTO|FROM|WHERE) `),
+				regexp.MustCompile(`(?)(SELECT|DELETE|INSERT|UPDATE|INTO|FROM|WHERE) `),
 			},
 			MetaData: gosec.MetaData{
 				ID:         id,
@@ -129,7 +129,7 @@ func NewSQLStrFormat(id string, conf gosec.Config) (gosec.Rule, []ast.Node) {
 		calls: gosec.NewCallList(),
 		sqlStatement: sqlStatement{
 			patterns: []*regexp.Regexp{
-				regexp.MustCompile("(?i)(SELECT|DELETE|INSERT|UPDATE|INTO|FROM|WHERE) "),
+				regexp.MustCompile("(?)(SELECT|DELETE|INSERT|UPDATE|INTO|FROM|WHERE) "),
 				regexp.MustCompile("%[^bdoxXfFp]"),
 			},
 			MetaData: gosec.MetaData{

--- a/rules/sql.go
+++ b/rules/sql.go
@@ -107,9 +107,9 @@ func (s *sqlStrFormat) Match(n ast.Node, c *gosec.Context) (*gosec.Issue, error)
 	// TODO(gm) improve confidence if database/sql is being used
 	if node := s.calls.ContainsCallExpr(n, c); node != nil {
 		// concats callexpr arg strings together if needed before regex evaluation
-		if arg_expr, ok := node.Args[0].(*ast.BinaryExpr); ok {
-			if full_str, ok := gosec.ConcatString(arg_expr); ok {
-				if s.MatchPatterns(full_str) {
+		if argExpr, ok := node.Args[0].(*ast.BinaryExpr); ok {
+			if fullStr, ok := gosec.ConcatString(argExpr); ok {
+				if s.MatchPatterns(fullStr) {
 					return gosec.NewIssue(c, n, s.ID(), s.What, s.Severity, s.Confidence),
 						nil
 				}


### PR DESCRIPTION
This is a small update to the sql ruleset. `ConcatString` takes a binary expression and forms a string of all of its literals. In rules/sql.go, the function is used when evaluating format string vulnerabilities if the first argument in `fmt.Sprintf` is a binary expression. eg. `fmt.Sprintf("SELECT *" + " FROM foo" + " WHERE user='%s'", user)`