### PR TITLE
update to G304 which adds binary expressions and file joining

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -297,7 +297,6 @@ func FindIdentities(n *ast.BinaryExpr) ([]*ast.Ident, bool) {
 	if len(identities) > 0 {
 		return identities, true
 		// if nil or error, return false
-	} else {
-		return nil, false
 	}
+		return nil, false
 }

--- a/helpers.go
+++ b/helpers.go
@@ -282,21 +282,32 @@ func ConcatString(n *ast.BinaryExpr) (string, bool) {
 	return s, true
 }
 
-// FindIdentities returns array of all identities in a given binary expression
-func FindIdentities(n *ast.BinaryExpr) ([]*ast.Ident, bool) {
+// FindVarIdentities returns array of all variable identities in a given binary expression
+func FindVarIdentities(n *ast.BinaryExpr, c *Context) ([]*ast.Ident, bool) {
 	identities := []*ast.Ident{}
 	// sub expressions are found in X object, Y object is always the last term
 	if rightOperand, ok := n.Y.(*ast.Ident); ok {
-		identities = append(identities, rightOperand)
-	}
-	if leftOperand, ok := n.X.(*ast.BinaryExpr); ok {
-		if leftIdentities, ok := FindIdentities(leftOperand); ok {
-			identities = append(identities, leftIdentities...)
+		obj := c.Info.ObjectOf(rightOperand)
+		if _, ok := obj.(*types.Var); ok && !TryResolve(rightOperand, c) {
+			identities = append(identities, rightOperand)
 		}
 	}
+	if leftOperand, ok := n.X.(*ast.BinaryExpr); ok {
+		if leftIdentities, ok := FindVarIdentities(leftOperand, c); ok {
+			identities = append(identities, leftIdentities...)
+		}
+	} else {
+		if leftOperand, ok := n.X.(*ast.Ident); ok {
+			obj := c.Info.ObjectOf(leftOperand)
+			if _, ok := obj.(*types.Var); ok && !TryResolve(leftOperand, c) {
+				identities = append(identities, leftOperand)
+			}
+		}
+	}
+
 	if len(identities) > 0 {
 		return identities, true
-		// if nil or error, return false
 	}
-		return nil, false
+	// if nil or error, return false
+	return nil, false
 }

--- a/helpers.go
+++ b/helpers.go
@@ -281,3 +281,23 @@ func ConcatString(n *ast.BinaryExpr) (string, bool) {
 	}
 	return s, true
 }
+
+// FindIdentities returns array of all identities in a given binary expression
+func FindIdentities(n *ast.BinaryExpr) ([]*ast.Ident, bool) {
+	identities := []*ast.Ident{}
+	// sub expressions are found in X object, Y object is always the last term
+	if rightOperand, ok := n.Y.(*ast.Ident); ok {
+		identities = append(identities, rightOperand)
+	}
+	if leftOperand, ok := n.X.(*ast.BinaryExpr); ok {
+		if leftIdentities, ok := FindIdentities(leftOperand); ok {
+			identities = append(identities, leftIdentities...)
+		}
+	}
+	if len(identities) > 0 {
+		return identities, true
+		// if nil or error, return false
+	} else {
+		return nil, false
+	}
+}

--- a/rules/readfile.go
+++ b/rules/readfile.go
@@ -69,7 +69,7 @@ func (r *readfile) Match(n ast.Node, c *gosec.Context) (*gosec.Issue, error) {
 			}
 			// handles binary string concatenation eg. ioutil.Readfile("/tmp/" + file + "/blob")
 			if binExp, ok := arg.(*ast.BinaryExpr); ok {
-				// iterate and resolve all found identites from the BinaryExpr
+				// resolve all found identites from the BinaryExpr
 				if _, ok := gosec.FindVarIdentities(binExp, c); ok {
 					return gosec.NewIssue(c, n, r.ID(), r.What, r.Severity, r.Confidence), nil
 				}

--- a/rules/readfile.go
+++ b/rules/readfile.go
@@ -24,6 +24,7 @@ import (
 type readfile struct {
 	gosec.MetaData
 	gosec.CallList
+	pathJoin gosec.CallList
 }
 
 // ID returns the identifier for this rule
@@ -68,6 +69,7 @@ func (r *readfile) Match(n ast.Node, c *gosec.Context) (*gosec.Issue, error) {
 // NewReadFile detects cases where we read files
 func NewReadFile(id string, conf gosec.Config) (gosec.Rule, []ast.Node) {
 	rule := &readfile{
+		pathJoin: gosec.NewCallList(),
 		CallList: gosec.NewCallList(),
 		MetaData: gosec.MetaData{
 			ID:         id,
@@ -76,6 +78,8 @@ func NewReadFile(id string, conf gosec.Config) (gosec.Rule, []ast.Node) {
 			Confidence: gosec.High,
 		},
 	}
+	rule.pathJoin.Add("filepath", "Join")
+  rule.pathJoin.Add("path", "Join")
 	rule.Add("io/ioutil", "ReadFile")
 	rule.Add("os", "Open")
 	return rule, []ast.Node{(*ast.CallExpr)(nil)}

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -500,7 +500,7 @@ import (
 
 func main() {
 	http.HandleFunc("/bar", func(w http.ResponseWriter, r *http.Request) {
-		title := r.URL.Query().Get("title")
+  	title := r.URL.Query().Get("title")
 		f, err := os.Open(title)
 		if err != nil {
 			fmt.Printf("Error: %v\n", err)
@@ -512,6 +512,65 @@ func main() {
 		fmt.Fprintf(w, "%s", body)
 	})
 	log.Fatal(http.ListenAndServe(":3000", nil))
+}`, 1}, {`
+package main
+
+import (
+	"log"
+	"os"
+	"io/ioutil"
+)
+
+	func main() {
+		f2 := os.Getenv("tainted_file2")
+		body, err := ioutil.ReadFile("/tmp/" + f2)
+		if err != nil {
+		log.Printf("Error: %v\n", err)
+	  }
+		log.Print(body)
+ }`, 1}, {`
+ package main
+
+ import (
+	 "bufio"
+	 "fmt"
+	 "os"
+	 "path/filepath"
+ )
+
+func main() {
+	reader := bufio.NewReader(os.Stdin)
+  fmt.Print("Please enter file to read: ")
+	file, _ := reader.ReadString('\n')
+	file = file[:len(file)-1]
+	f, err := os.Open(filepath.Join("/tmp/service/", file))
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+	}
+	contents := make([]byte, 15)
+  if _, err = f.Read(contents); err != nil {
+		fmt.Printf("Error: %v\n", err)
+	}
+  fmt.Println(string(contents))
+}`, 1}, {`
+package main
+
+import (
+	"log"
+	"os"
+	"io/ioutil"
+	"path/filepath"
+)
+
+func main() {
+	dir := os.Getenv("server_root")
+	f3 := os.Getenv("tainted_file3")
+	// edge case where both a binary expression and file Join are used.
+	body, err := ioutil.ReadFile(filepath.Join("/var/"+dir, f3))
+	if err != nil {
+		log.Printf("Error: %v\n", err)
+	}
+	log.Print(body)
 }`, 1}}
 
 	// SampleCodeG305 - File path traversal when extracting zip archives

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -500,7 +500,7 @@ import (
 
 func main() {
 	http.HandleFunc("/bar", func(w http.ResponseWriter, r *http.Request) {
-  	title := r.URL.Query().Get("title")
+  		title := r.URL.Query().Get("title")
 		f, err := os.Open(title)
 		if err != nil {
 			fmt.Printf("Error: %v\n", err)


### PR DESCRIPTION
This update to rule G304 gives gosec the ability to evaluate two path joining functions as well as binary expressions when inside `ioutil.Readfile` or `os.Open`. Gosec can now flag cases like:
`ioutil.Readfile("/tmp/" + input + "/blob")` and `os.Open(filepath.Join("/tmp/", file))`. To do this, a new function called `FindVarIdentities` was added to helpers.go. The function will return all variable identities found in a binary expression. 