### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ You can run the `gosec` tool in a container against your local Go project. You j
 `GOPATH` of the container:
 
 ```
-docker run -it -v $GOPATH/src/<YOUR PROJECT PATH>:/go/src/<YOUR PORJECT PATH> securego/gosec /go/src/<YOUR PROJECT PATH>
+docker run -it -v $GOPATH/src/<YOUR PROJECT PATH>:/go/src/<YOUR PROJECT PATH> securego/gosec /go/src/<YOUR PROJECT PATH>
 ```
 
 #### Generate TLS rule


### PR DESCRIPTION
Only a basic change, `PORJECT` -> `PROJECT` in the Docker image example.