### PR TITLE
G107 - SSRF

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,13 @@ or to specify a set of rules to explicitly exclude using the '-exclude=' flag.
   - G104: Audit errors not checked
   - G105: Audit the use of math/big.Int.Exp
   - G106: Audit the use of ssh.InsecureIgnoreHostKey
+  - G107: Url provided to HTTP request as taint input
   - G201: SQL query construction using format string
   - G202: SQL query construction using string concatenation
   - G203: Use of unescaped data in HTML templates
   - G204: Audit use of command execution
   - G301: Poor file permissions used when creating a directory
-  - G302: Poor file permisions used with chmod
+  - G302: Poor file permissions used with chmod
   - G303: Creating tempfile using a predictable path
   - G304: File path provided as taint input
   - G305: File traversal when extracting zip archive
@@ -79,7 +80,7 @@ that are not considered build artifacts by the compiler (so test files).
 As with all automated detection tools there will be cases of false positives. In cases where gosec reports a failure that has been manually verified as being safe it is possible to annotate the code with a '#nosec' comment.
 
 The annotation causes gosec to stop processing any further nodes within the
-AST so can apply to a whole block or more granularly to a single expression. 
+AST so can apply to a whole block or more granularly to a single expression.
 
 ```go
 
@@ -178,7 +179,7 @@ You can build the docker image as follows:
 make image
 ```
 
-You can run the `gosec` tool in a container against your local Go project. You just have to mount the project in the 
+You can run the `gosec` tool in a container against your local Go project. You just have to mount the project in the
 `GOPATH` of the container:
 
 ```

--- a/cmd/tlsconfig/tlsconfig.go
+++ b/cmd/tlsconfig/tlsconfig.go
@@ -62,7 +62,7 @@ type goTLSConfiguration struct {
 
 // getTLSConfFromURL retrieves the json containing the TLS configurations from the specified URL.
 func getTLSConfFromURL(url string) (*ServerSideTLSJson, error) {
-	r, err := http.Get(url)
+	r, err := http.Get(url) // #nosec G107
 	if err != nil {
 		return nil, err
 	}

--- a/rules/rulelist.go
+++ b/rules/rulelist.go
@@ -65,6 +65,7 @@ func Generate(filters ...RuleFilter) RuleList {
 		{"G104", "Audit errors not checked", NewNoErrorCheck},
 		{"G105", "Audit the use of big.Exp function", NewUsingBigExp},
 		{"G106", "Audit the use of ssh.InsecureIgnoreHostKey function", NewSSHHostKey},
+		{"G107", "Url provided to HTTP request as taint input", NewSSRFCheck},
 
 		// injection
 		{"G201", "SQL query construction using format string", NewSQLStrFormat},

--- a/rules/rules_test.go
+++ b/rules/rules_test.go
@@ -71,6 +71,10 @@ var _ = Describe("gosec rules", func() {
 			runner("G106", testutils.SampleCodeG106)
 		})
 
+		It("should detect ssrf via http requests with variable url", func() {
+			runner("G107", testutils.SampleCodeG107)
+		})
+
 		It("should detect sql injection via format strings", func() {
 			runner("G201", testutils.SampleCodeG201)
 		})

--- a/rules/ssrf.go
+++ b/rules/ssrf.go
@@ -17,38 +17,40 @@ func (r *ssrf) ID() string {
 	return r.MetaData.ID
 }
 
-// ResolveVar tries to resolve the arguments of a callexpression
+// ResolveVar tries to resolve the first argument of a callexpression
+// The first argument is the url,
 func (r *ssrf) ResolveVar(n *ast.CallExpr, c *gosec.Context) bool {
-  // iterate through the all arguments (almost always 1) of the call expression
-  for _, arg := range n.Args {
-    if ident, ok := arg.(*ast.Ident); ok {
-      obj := c.Info.ObjectOf(ident)
-      if _, ok := obj.(*types.Var); ok && !gosec.TryResolve(ident, c) {
-        return true
-      }
-    }
-  }
-  return false
+	if len(n.Args) > 0 {
+		arg := n.Args[0]
+
+		if ident, ok := arg.(*ast.Ident); ok {
+			obj := c.Info.ObjectOf(ident)
+			if _, ok := obj.(*types.Var); ok && !gosec.TryResolve(ident, c) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // Match inspects AST nodes to determine if certain net/http methods are called with variable input
 func (r *ssrf) Match(n ast.Node, c *gosec.Context) (*gosec.Issue, error) {
 	// Call expression is using http package directly
 	if node := r.ContainsCallExpr(n, c); node != nil {
-    if r.ResolveVar(node, c) {
-      return gosec.NewIssue(c, n, r.ID(), r.What, r.Severity, r.Confidence), nil
-    }
+		if r.ResolveVar(node, c) {
+			return gosec.NewIssue(c, n, r.ID(), r.What, r.Severity, r.Confidence), nil
+		}
 	}
 	// Look at the last selector identity for methods matching net/http's
 	if node, ok := n.(*ast.CallExpr); ok {
 		if selExpr, ok := node.Fun.(*ast.SelectorExpr); ok {
 			// Pull last selector's identity name
-				if r.Contains("net/http", selExpr.Sel.Name) {
-          // Try and resolve arguments
-          if r.ResolveVar(node, c) {
-					  return gosec.NewIssue(c, n, r.ID(), r.What, r.Severity, r.Confidence), nil
-				  }
-      }
+			if r.Contains("net/http", selExpr.Sel.Name) {
+				// Try and resolve arguments
+				if r.ResolveVar(node, c) {
+					return gosec.NewIssue(c, n, r.ID(), r.What, r.Severity, r.Confidence), nil
+				}
+			}
 		}
 	}
 	return nil, nil

--- a/rules/ssrf.go
+++ b/rules/ssrf.go
@@ -1,0 +1,47 @@
+package rules
+
+import (
+	"github.com/GoASTScanner/gas"
+	"go/ast"
+	"go/types"
+)
+
+type ssrf struct {
+	gas.MetaData
+	gas.CallList
+}
+
+// ID returns the identifier for this rule
+func (r *ssrf) ID() string {
+	return r.MetaData.ID
+}
+
+// Match inspects AST nodes to determine if certain net/http methods are called with variable input
+func (r *ssrf) Match(n ast.Node, c *gas.Context) (*gas.Issue, error) {
+	if node := r.ContainsCallExpr(n, c); node != nil {
+		for _, arg := range node.Args {
+			if ident, ok := arg.(*ast.Ident); ok {
+				obj := c.Info.ObjectOf(ident)
+				if _, ok := obj.(*types.Var); ok && !gas.TryResolve(ident, c) {
+					return gas.NewIssue(c, n, r.What, r.Severity, r.Confidence), nil
+				}
+			}
+		}
+	}
+	return nil, nil
+}
+
+// NewSSRFCheck detects cases where HTTP requests are sent
+func NewSSRFCheck(id string, conf gas.Config) (gas.Rule, []ast.Node) {
+	rule := &ssrf{
+		CallList: gas.NewCallList(),
+		MetaData: gas.MetaData{
+			ID:         id,
+			What:       "Potential HTTP request made with variable url",
+			Severity:   gas.Medium,
+			Confidence: gas.Medium,
+		},
+	}
+	rule.Add("net/http", "Do", "Get", "Head", "Post", "PostForm", "RoundTrip")
+	return rule, []ast.Node{(*ast.CallExpr)(nil)}
+}

--- a/rules/ssrf.go
+++ b/rules/ssrf.go
@@ -17,12 +17,11 @@ func (r *ssrf) ID() string {
 	return r.MetaData.ID
 }
 
-// ResolveVar tries to resolve the first argument of a callexpression
-// The first argument is the url,
+// ResolveVar tries to resolve the first argument of a call expression
+// The first argument is the url
 func (r *ssrf) ResolveVar(n *ast.CallExpr, c *gosec.Context) bool {
 	if len(n.Args) > 0 {
 		arg := n.Args[0]
-
 		if ident, ok := arg.(*ast.Ident); ok {
 			obj := c.Info.ObjectOf(ident)
 			if _, ok := obj.(*types.Var); ok && !gosec.TryResolve(ident, c) {
@@ -44,9 +43,8 @@ func (r *ssrf) Match(n ast.Node, c *gosec.Context) (*gosec.Issue, error) {
 	// Look at the last selector identity for methods matching net/http's
 	if node, ok := n.(*ast.CallExpr); ok {
 		if selExpr, ok := node.Fun.(*ast.SelectorExpr); ok {
-			// Pull last selector's identity name
+			// Pull last selector's identity name and compare to net/http methods
 			if r.Contains("net/http", selExpr.Sel.Name) {
-				// Try and resolve arguments
 				if r.ResolveVar(node, c) {
 					return gosec.NewIssue(c, n, r.ID(), r.What, r.Severity, r.Confidence), nil
 				}

--- a/rules/ssrf.go
+++ b/rules/ssrf.go
@@ -1,14 +1,15 @@
 package rules
 
 import (
-	"github.com/GoASTScanner/gas"
 	"go/ast"
 	"go/types"
+
+	"github.com/securego/gosec"
 )
 
 type ssrf struct {
-	gas.MetaData
-	gas.CallList
+	gosec.MetaData
+	gosec.CallList
 }
 
 // ID returns the identifier for this rule
@@ -16,32 +17,54 @@ func (r *ssrf) ID() string {
 	return r.MetaData.ID
 }
 
+// ResolveVar tries to resolve the arguments of a callexpression
+func (r *ssrf) ResolveVar(n *ast.CallExpr, c *gosec.Context) bool {
+  // iterate through the all arguments (almost always 1) of the call expression
+  for _, arg := range n.Args {
+    if ident, ok := arg.(*ast.Ident); ok {
+      obj := c.Info.ObjectOf(ident)
+      if _, ok := obj.(*types.Var); ok && !gosec.TryResolve(ident, c) {
+        return true
+      }
+    }
+  }
+  return false
+}
+
 // Match inspects AST nodes to determine if certain net/http methods are called with variable input
-func (r *ssrf) Match(n ast.Node, c *gas.Context) (*gas.Issue, error) {
+func (r *ssrf) Match(n ast.Node, c *gosec.Context) (*gosec.Issue, error) {
+	// Call expression is using http package directly
 	if node := r.ContainsCallExpr(n, c); node != nil {
-		for _, arg := range node.Args {
-			if ident, ok := arg.(*ast.Ident); ok {
-				obj := c.Info.ObjectOf(ident)
-				if _, ok := obj.(*types.Var); ok && !gas.TryResolve(ident, c) {
-					return gas.NewIssue(c, n, r.What, r.Severity, r.Confidence), nil
-				}
-			}
+    if r.ResolveVar(node, c) {
+      return gosec.NewIssue(c, n, r.ID(), r.What, r.Severity, r.Confidence), nil
+    }
+	}
+	// Look at the last selector identity for methods matching net/http's
+	if node, ok := n.(*ast.CallExpr); ok {
+		if selExpr, ok := node.Fun.(*ast.SelectorExpr); ok {
+			// Pull last selector's identity name
+				if r.Contains("net/http", selExpr.Sel.Name) {
+          // Try and resolve arguments
+          if r.ResolveVar(node, c) {
+					  return gosec.NewIssue(c, n, r.ID(), r.What, r.Severity, r.Confidence), nil
+				  }
+      }
 		}
 	}
 	return nil, nil
 }
 
 // NewSSRFCheck detects cases where HTTP requests are sent
-func NewSSRFCheck(id string, conf gas.Config) (gas.Rule, []ast.Node) {
+func NewSSRFCheck(id string, conf gosec.Config) (gosec.Rule, []ast.Node) {
 	rule := &ssrf{
-		CallList: gas.NewCallList(),
-		MetaData: gas.MetaData{
+		CallList: gosec.NewCallList(),
+		MetaData: gosec.MetaData{
 			ID:         id,
 			What:       "Potential HTTP request made with variable url",
-			Severity:   gas.Medium,
-			Confidence: gas.Medium,
+			Severity:   gosec.Medium,
+			Confidence: gosec.Medium,
 		},
 	}
-	rule.Add("net/http", "Do", "Get", "Head", "Post", "PostForm", "RoundTrip")
+	rule.AddAll("net/http", "Do", "Get", "Head", "Post", "PostForm", "RoundTrip")
 	return rule, []ast.Node{(*ast.CallExpr)(nil)}
 }

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -229,44 +229,6 @@ func main() {
     	}
       	fmt.Println(resp.Status)
 }`, 0}, {`
-// Flag both normal and enhanced goresty GET requests
-package main
-import (
-	"gopkg.in/resty.v1"
-	"fmt"
-	"log"
-	"net/http"
-)
-func main () {
-
-	http.HandleFunc("/httpbar", func(w http.ResponseWriter, r *http.Request) {
-		url1 := r.URL.Query().Get("openUrl")
-		// short go resty request
-	  	resp3, err3 := resty.R().Get(url1)
-	  	if err3 != nil {
-			fmt.Println(err3)
-	  	}
-
-  	url2 := r.URL.Query().Get("authUrl")
-		resp4, err4 := resty.R().
-      	SetQueryParams(map[string]string{
-		"page_no": "1",
-		"limit": "20",
-		"sort":"name",
-		"order": "asc",
-		"random": "10",
-        }).
-      	SetHeader("Accept", "application/json").
-      	SetAuthToken("notarealauthtoken").
-      	Get(url2)
-
-	if err4 != nil {
-		fmt.Println("Error!", err4)
-	}
-	  	fmt.Fprintf(w, "%s \n %s", resp3.StatusCode(), resp4.StatusCode())
-  	})
-  	log.Fatal(http.ListenAndServe(":3000", nil))
-}`, 2}, {`
 package main
 
 import (

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -223,82 +223,82 @@ import (
 )
 const url = "http://127.0.0.1"
 func main() {
-	resp, err := http.Get(url)
-        if err != nil {
-                fmt.Println(err)
-        }
-        fmt.Println(resp.Status)
+  resp, err := http.Get(url)
+    if err != nil {
+      fmt.Println(err)
+    }
+      fmt.Println(resp.Status)
 }`, 0}, {`
 // Flag both normal and enhanced goresty GET requests
 package main
 import (
-	"gopkg.in/resty.v1"
+  "gopkg.in/resty.v1"
 	"fmt"
 	"log"
-	"net/http"
+  "net/http"
 )
 func main () {
 
-	http.HandleFunc("/httpbar", func(w http.ResponseWriter, r *http.Request) {
-		url1 := r.URL.Query().Get("openUrl")
+  http.HandleFunc("/httpbar", func(w http.ResponseWriter, r *http.Request) {
+	  url1 := r.URL.Query().Get("openUrl")
 		// short go resty request
-	 resp3, err3 := resty.R().Get(url1)
-	 if err3 != nil {
-					 fmt.Println(err3)
-	 }
+	  resp3, err3 := resty.R().Get(url1)
+	  if err3 != nil {
+		  fmt.Println(err3)
+	  }
 
-	 url2 := r.URL.Query().Get("authUrl")
-	 resp4, err4 := resty.R().
-     SetQueryParams(map[string]string{
-		   "page_no": "1",
-		   "limit": "20",
-		   "sort":"name",
-		   "order": "asc",
-		   "random": "10",
-     }).
-     SetHeader("Accept", "application/json").
-     SetAuthToken("notarealauthtoken").
-     Get(url2)
+  url2 := r.URL.Query().Get("authUrl")
+	  resp4, err4 := resty.R().
+      SetQueryParams(map[string]string{
+		    "page_no": "1",
+		    "limit": "20",
+		    "sort":"name",
+		    "order": "asc",
+		    "random": "10",
+      }).
+      SetHeader("Accept", "application/json").
+      SetAuthToken("notarealauthtoken").
+      Get(url2)
 
- if err4 != nil {
-					 fmt.Println("Error!", err4)
-	 }
-		fmt.Fprintf(w, "%s \n %s", resp3.StatusCode(), resp4.StatusCode())
-	})
-	log.Fatal(http.ListenAndServe(":3000", nil))
+  if err4 != nil {
+	  fmt.Println("Error!", err4)
+	}
+	  fmt.Fprintf(w, "%s \n %s", resp3.StatusCode(), resp4.StatusCode())
+  })
+  log.Fatal(http.ListenAndServe(":3000", nil))
 }`, 2}, {`
-	package main
+package main
 
-	import (
-		"net/http"
-		"fmt"
-		"os"
-		"strconv"
-	)
+import (
+  "net/http"
+  "fmt"
+  "os"
+  "strconv"
+)
 
-	type httpWrapper struct {
-		DesiredCode string
+type httpWrapper struct {
+	DesiredCode string
+}
+
+func (c *httpWrapper) Get(url string) (*http.Response, error) {
+	return http.Get(url)
+}
+
+func main() {
+	code := os.Getenv("STATUS_CODE")
+  var url = os.Getenv("URL")
+	client := httpWrapper{code}
+  resp1, err1 := client.Get(url)
+  if err1 != nil {
+    fmt.Println(err1)
+		  os.Exit(1)
+  }
+	if strconv.Itoa(resp1.StatusCode) == client.DesiredCode {
+    fmt.Println("True")
+	} else {
+		fmt.Println("False")
 	}
-
-	func (c *httpWrapper) Get(url string) (*http.Response, error) {
-		return http.Get(url)
-	}
-
-	func main() {
-		code := os.Getenv("STATUS_CODE")
-		var url = os.Getenv("URL")
-		client := httpWrapper{code}
-        resp1, err1 := client.Get(url)
-        if err1 != nil {
-                fmt.Println(err1)
-								os.Exit(1)
-        }
-				if strconv.Itoa(resp1.StatusCode) == client.DesiredCode {
-        fmt.Println("True")
-			} else {
-				fmt.Println("False")
-			}
-	}`, 2}}
+}`, 2}}
 	// SampleCodeG201 - SQL injection via format string
 	SampleCodeG201 = []CodeSample{
 		{`

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -197,83 +197,83 @@ func main() {
 	SampleCodeG107 = []CodeSample{{`
 package main
 import (
-  "net/http"
-  "io/ioutil"
-  "fmt"
+	"net/http"
+	"io/ioutil"
+	"fmt"
 	"os"
 )
 func main() {
-  url := os.Getenv("tainted_url")
-  resp, err := http.Get(url)
-  if err != nil {
-	  panic(err)
-  }
-  defer resp.Body.Close()
-  body, err := ioutil.ReadAll(resp.Body)
-  if err != nil {
-	  panic(err)
-  }
-  fmt.Printf("%s", body)
+	url := os.Getenv("tainted_url")
+	resp, err := http.Get(url)
+	if err != nil {
+		panic(err)
+	}
+  	defer resp.Body.Close()
+  	body, err := ioutil.ReadAll(resp.Body)
+  	if err != nil {
+    		panic(err)
+  	}
+  	fmt.Printf("%s", body)
 }`, 1}, {`
 package main
 
 import (
- "fmt"
- "net/http"
+	"fmt"
+	"net/http"
 )
 const url = "http://127.0.0.1"
 func main() {
-  resp, err := http.Get(url)
-    if err != nil {
-      fmt.Println(err)
-    }
-      fmt.Println(resp.Status)
+	resp, err := http.Get(url)
+	if err != nil {
+		fmt.Println(err)
+    	}
+      	fmt.Println(resp.Status)
 }`, 0}, {`
 // Flag both normal and enhanced goresty GET requests
 package main
 import (
-  "gopkg.in/resty.v1"
+	"gopkg.in/resty.v1"
 	"fmt"
 	"log"
-  "net/http"
+	"net/http"
 )
 func main () {
 
-  http.HandleFunc("/httpbar", func(w http.ResponseWriter, r *http.Request) {
-	  url1 := r.URL.Query().Get("openUrl")
+	http.HandleFunc("/httpbar", func(w http.ResponseWriter, r *http.Request) {
+		url1 := r.URL.Query().Get("openUrl")
 		// short go resty request
-	  resp3, err3 := resty.R().Get(url1)
-	  if err3 != nil {
-		  fmt.Println(err3)
-	  }
+	  	resp3, err3 := resty.R().Get(url1)
+	  	if err3 != nil {
+			fmt.Println(err3)
+	  	}
 
-  url2 := r.URL.Query().Get("authUrl")
-	  resp4, err4 := resty.R().
-      SetQueryParams(map[string]string{
-		    "page_no": "1",
-		    "limit": "20",
-		    "sort":"name",
-		    "order": "asc",
-		    "random": "10",
-      }).
-      SetHeader("Accept", "application/json").
-      SetAuthToken("notarealauthtoken").
-      Get(url2)
+  	url2 := r.URL.Query().Get("authUrl")
+		resp4, err4 := resty.R().
+      	SetQueryParams(map[string]string{
+		"page_no": "1",
+		"limit": "20",
+		"sort":"name",
+		"order": "asc",
+		"random": "10",
+        }).
+      	SetHeader("Accept", "application/json").
+      	SetAuthToken("notarealauthtoken").
+      	Get(url2)
 
-  if err4 != nil {
-	  fmt.Println("Error!", err4)
+	if err4 != nil {
+		fmt.Println("Error!", err4)
 	}
-	  fmt.Fprintf(w, "%s \n %s", resp3.StatusCode(), resp4.StatusCode())
-  })
-  log.Fatal(http.ListenAndServe(":3000", nil))
+	  	fmt.Fprintf(w, "%s \n %s", resp3.StatusCode(), resp4.StatusCode())
+  	})
+  	log.Fatal(http.ListenAndServe(":3000", nil))
 }`, 2}, {`
 package main
 
 import (
-  "net/http"
-  "fmt"
-  "os"
-  "strconv"
+	"net/http"
+	"fmt"
+	"os"
+	"strconv"
 )
 
 type httpWrapper struct {
@@ -286,15 +286,15 @@ func (c *httpWrapper) Get(url string) (*http.Response, error) {
 
 func main() {
 	code := os.Getenv("STATUS_CODE")
-  var url = os.Getenv("URL")
+	var url = os.Getenv("URL")
 	client := httpWrapper{code}
-  resp1, err1 := client.Get(url)
-  if err1 != nil {
-    fmt.Println(err1)
-		  os.Exit(1)
-  }
+	resp1, err1 := client.Get(url)
+	if err1 != nil {
+		fmt.Println(err1)
+		os.Exit(1)
+  	}
 	if strconv.Itoa(resp1.StatusCode) == client.DesiredCode {
-    fmt.Println("True")
+    		fmt.Println("True")
 	} else {
 		fmt.Println("False")
 	}

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -197,23 +197,108 @@ func main() {
 	SampleCodeG107 = []CodeSample{{`
 package main
 import (
-"net/http"
-"io/ioutil"
-"fmt"
+  "net/http"
+  "io/ioutil"
+  "fmt"
+	"os"
 )
 func main() {
-url := os.Getenv("tainted_url")
-resp, err := http.Get(url)
-if err != nil {
-	panic(err)
-}
-defer resp.Body.Close()
-body, err := ioutil.ReadAll(resp.Body)
-if err != nil {
-	panic(err)
-}
-fmt.Printf("%s", body)
-}`, 1}}
+  url := os.Getenv("tainted_url")
+  resp, err := http.Get(url)
+  if err != nil {
+	  panic(err)
+  }
+  defer resp.Body.Close()
+  body, err := ioutil.ReadAll(resp.Body)
+  if err != nil {
+	  panic(err)
+  }
+  fmt.Printf("%s", body)
+}`, 1}, {`
+package main
+
+import (
+ "fmt"
+ "net/http"
+)
+const url = "http://127.0.0.1"
+func main() {
+	resp, err := http.Get(url)
+        if err != nil {
+                fmt.Println(err)
+        }
+        fmt.Println(resp.Status)
+}`, 0}, {`
+// Flag both normal and enhanced goresty GET requests
+package main
+import (
+	"gopkg.in/resty.v1"
+	"fmt"
+	"log"
+	"net/http"
+)
+func main () {
+
+	http.HandleFunc("/httpbar", func(w http.ResponseWriter, r *http.Request) {
+		url1 := r.URL.Query().Get("openUrl")
+		// short go resty request
+	 resp3, err3 := resty.R().Get(url1)
+	 if err3 != nil {
+					 fmt.Println(err3)
+	 }
+
+	 url2 := r.URL.Query().Get("authUrl")
+	 resp4, err4 := resty.R().
+     SetQueryParams(map[string]string{
+		   "page_no": "1",
+		   "limit": "20",
+		   "sort":"name",
+		   "order": "asc",
+		   "random": "10",
+     }).
+     SetHeader("Accept", "application/json").
+     SetAuthToken("notarealauthtoken").
+     Get(url2)
+
+ if err4 != nil {
+					 fmt.Println("Error!", err4)
+	 }
+		fmt.Fprintf(w, "%s \n %s", resp3.StatusCode(), resp4.StatusCode())
+	})
+	log.Fatal(http.ListenAndServe(":3000", nil))
+}`, 2}, {`
+	package main
+
+	import (
+		"net/http"
+		"fmt"
+		"os"
+		"strconv"
+	)
+
+	type httpWrapper struct {
+		DesiredCode string
+	}
+
+	func (c *httpWrapper) Get(url string) (*http.Response, error) {
+		return http.Get(url)
+	}
+
+	func main() {
+		code := os.Getenv("STATUS_CODE")
+		var url = os.Getenv("URL")
+		client := httpWrapper{code}
+        resp1, err1 := client.Get(url)
+        if err1 != nil {
+                fmt.Println(err1)
+								os.Exit(1)
+        }
+				if strconv.Itoa(resp1.StatusCode) == client.DesiredCode {
+        fmt.Println("True")
+			} else {
+				fmt.Println("False")
+			}
+	}`, 2}}
 	// SampleCodeG201 - SQL injection via format string
 	SampleCodeG201 = []CodeSample{
 		{`

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -192,6 +192,28 @@ import (
 func main() {
         _ =  ssh.InsecureIgnoreHostKey()
 }`, 1}}
+
+	// SampleCodeG107 - SSRF via http requests with variable url
+	SampleCodeG107 = []CodeSample{{`
+package main
+import (
+"net/http"
+"io/ioutil"
+"fmt"
+)
+func main() {
+url := os.Getenv("tainted_url")
+resp, err := http.Get(url)
+if err != nil {
+	panic(err)
+}
+defer resp.Body.Close()
+body, err := ioutil.ReadAll(resp.Body)
+if err != nil {
+	panic(err)
+}
+fmt.Printf("%s", body)
+}`, 1}}
 	// SampleCodeG201 - SQL injection via format string
 	SampleCodeG201 = []CodeSample{
 		{`


### PR DESCRIPTION
This PR is implementing the SSRF rule from PR 189. I have many small changes and added the ability to look at the last selector in a Call expression and compare that to the selectors passed in from net/http. This will catch wrapped clients as well as other libraries exposing GET/POST/HEAD/PUT methods. One downside is that it cannot resolve that selector's originating type and therefore may flag false positives. The current way of resolving the url variable also leads to some false positives but I have some ideas to fix this later. 

Please let me know what you think. 