### PR TITLE
Removed wrapping feature from G107 (for now)

### DIFF
--- a/rules/ssrf.go
+++ b/rules/ssrf.go
@@ -40,17 +40,6 @@ func (r *ssrf) Match(n ast.Node, c *gosec.Context) (*gosec.Issue, error) {
 			return gosec.NewIssue(c, n, r.ID(), r.What, r.Severity, r.Confidence), nil
 		}
 	}
-	// Look at the last selector identity for methods matching net/http's
-	if node, ok := n.(*ast.CallExpr); ok {
-		if selExpr, ok := node.Fun.(*ast.SelectorExpr); ok {
-			// Pull last selector's identity name and compare to net/http methods
-			if r.Contains("net/http", selExpr.Sel.Name) {
-				if r.ResolveVar(node, c) {
-					return gosec.NewIssue(c, n, r.ID(), r.What, r.Severity, r.Confidence), nil
-				}
-			}
-		}
-	}
 	return nil, nil
 }
 

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -228,39 +228,7 @@ func main() {
 		fmt.Println(err)
     	}
       	fmt.Println(resp.Status)
-}`, 0}, {`
-package main
-
-import (
-	"net/http"
-	"fmt"
-	"os"
-	"strconv"
-)
-
-type httpWrapper struct {
-	DesiredCode string
-}
-
-func (c *httpWrapper) Get(url string) (*http.Response, error) {
-	return http.Get(url)
-}
-
-func main() {
-	code := os.Getenv("STATUS_CODE")
-	var url = os.Getenv("URL")
-	client := httpWrapper{code}
-	resp1, err1 := client.Get(url)
-	if err1 != nil {
-		fmt.Println(err1)
-		os.Exit(1)
-  	}
-	if strconv.Itoa(resp1.StatusCode) == client.DesiredCode {
-    		fmt.Println("True")
-	} else {
-		fmt.Println("False")
-	}
-}`, 2}}
+}`, 0}}
 	// SampleCodeG201 - SQL injection via format string
 	SampleCodeG201 = []CodeSample{
 		{`


### PR DESCRIPTION
I removed the second check from G107 that looks just at the selectors based on issue 237. From my testing, it yielded just as many false positives as the other rules but I guess my testing wasn't broad enough. I want to add the go-resty library to G107 but I need to play around with `GetCallInfo` a little bit more. @ccojocar Sorry for the confusion.   

fixes #237 