### PR TITLE
Fix false positives for SQL string concatenation with constants from another file

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -39,6 +39,7 @@ type Context struct {
 	Comments ast.CommentMap
 	Info     *types.Info
 	Pkg      *types.Package
+	PkgFiles []*ast.File
 	Root     *ast.File
 	Config   map[string]interface{}
 	Imports  *ImportTracker
@@ -139,6 +140,7 @@ func (gosec *Analyzer) Process(buildTags []string, packagePaths ...string) error
 			gosec.context.Root = file
 			gosec.context.Info = &pkg.Info
 			gosec.context.Pkg = pkg.Pkg
+			gosec.context.PkgFiles = pkg.Files
 			gosec.context.Imports = NewImportTracker()
 			gosec.context.Imports.TrackPackages(gosec.context.Pkg.Imports()...)
 			ast.Walk(gosec, file)

--- a/resolve.go
+++ b/resolve.go
@@ -56,7 +56,7 @@ func resolveCallExpr(n *ast.CallExpr, c *Context) bool {
 
 // TryResolve will attempt, given a subtree starting at some ATS node, to resolve
 // all values contained within to a known constant. It is used to check for any
-// unkown values in compound expressions.
+// unknown values in compound expressions.
 func TryResolve(n ast.Node, c *Context) bool {
 	switch node := n.(type) {
 	case *ast.BasicLit:

--- a/rules/sql.go
+++ b/rules/sql.go
@@ -55,11 +55,11 @@ func (s *sqlStrConcat) checkObject(n *ast.Ident, c *gosec.Context) bool {
 	if n.Obj != nil {
 		return n.Obj.Kind != ast.Var && n.Obj.Kind != ast.Fun
 	}
+
+	// Try to resolve unresolved identifiers using other files in same package
 	for _, file := range c.PkgFiles {
 		if node, ok := file.Scope.Objects[n.String()]; ok {
-			if node.Kind == ast.Con {
-				return true
-			}
+			return node.Kind == ast.Con
 		}
 	}
 	return false

--- a/rules/sql.go
+++ b/rules/sql.go
@@ -59,7 +59,7 @@ func (s *sqlStrConcat) checkObject(n *ast.Ident, c *gosec.Context) bool {
 	// Try to resolve unresolved identifiers using other files in same package
 	for _, file := range c.PkgFiles {
 		if node, ok := file.Scope.Objects[n.String()]; ok {
-			return node.Kind == ast.Con
+			return node.Kind != ast.Var && node.Kind != ast.Fun
 		}
 	}
 	return false

--- a/rules/sql.go
+++ b/rules/sql.go
@@ -55,7 +55,14 @@ func (s *sqlStrConcat) checkObject(n *ast.Ident, c *gosec.Context) bool {
 	if n.Obj != nil {
 		return n.Obj.Kind != ast.Var && n.Obj.Kind != ast.Fun
 	}
-	return gosec.TryResolve(n, c)
+	for _, file := range c.PkgFiles {
+		if node, ok := file.Scope.Objects[n.String()]; ok {
+			if node.Kind == ast.Con {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // Look for "SELECT * FROM table WHERE " + " ' OR 1=1"

--- a/rules/sql.go
+++ b/rules/sql.go
@@ -51,11 +51,11 @@ func (s *sqlStrConcat) ID() string {
 }
 
 // see if we can figure out what it is
-func (s *sqlStrConcat) checkObject(n *ast.Ident) bool {
+func (s *sqlStrConcat) checkObject(n *ast.Ident, c *gosec.Context) bool {
 	if n.Obj != nil {
 		return n.Obj.Kind != ast.Var && n.Obj.Kind != ast.Fun
 	}
-	return false
+	return gosec.TryResolve(n, c)
 }
 
 // Look for "SELECT * FROM table WHERE " + " ' OR 1=1"
@@ -69,7 +69,7 @@ func (s *sqlStrConcat) Match(n ast.Node, c *gosec.Context) (*gosec.Issue, error)
 				if _, ok := node.Y.(*ast.BasicLit); ok {
 					return nil, nil // string cat OK
 				}
-				if second, ok := node.Y.(*ast.Ident); ok && s.checkObject(second) {
+				if second, ok := node.Y.(*ast.Ident); ok && s.checkObject(second, c) {
 					return nil, nil
 				}
 				return gosec.NewIssue(c, n, s.ID(), s.What, s.Severity, s.Confidence), nil

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -296,7 +296,7 @@ func main(){
 				panic(err)
 		}
 		defer rows.Close()
-}`, 0}, {`
+}`, 0, false}, {`
 // Format string false positive, quoted formatter argument.
 package main
 import (
@@ -317,7 +317,7 @@ func main(){
 		panic(err)
 	}
 	defer rows.Close()
-}`, 0}}
+}`, 0, false}}
 
 	// SampleCodeG202 - SQL query string building via string concatenation
 	SampleCodeG202 = []CodeSample{

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -1,9 +1,13 @@
 package testutils
 
 // CodeSample encapsulates a snippet of source code that compiles, and how many errors should be detected
+// Setting SupportingCode to true means that that snippet will not be scanned against
+// the rules, but will be added to the same package with the other snippets.
+// See SampleCodeG202 for an example.
 type CodeSample struct {
-	Code   string
-	Errors int
+	Code           string
+	Errors         int
+	SupportingCode bool
 }
 
 var (
@@ -15,7 +19,7 @@ func main() {
 	username := "admin"
 	password := "f62e5bcda4fae4f82370da0c6f20697b8f8447ef"
 	fmt.Println("Doing something with: ", username, password)
-}`, 1}, {`
+}`, 1, false}, {`
 // Entropy check should not report this error by default
 package main
 import "fmt"
@@ -23,21 +27,21 @@ func main() {
 	username := "admin"
 	password := "secret"
 	fmt.Println("Doing something with: ", username, password)
-}`, 0}, {`
+}`, 0, false}, {`
 package main
 import "fmt"
 var password = "f62e5bcda4fae4f82370da0c6f20697b8f8447ef"
 func main() {
 	username := "admin"
 	fmt.Println("Doing something with: ", username, password)
-}`, 1}, {`
+}`, 1, false}, {`
 package main
 import "fmt"
 const password = "f62e5bcda4fae4f82370da0c6f20697b8f8447ef"
 func main() {
 	username := "admin"
 	fmt.Println("Doing something with: ", username, password)
-}`, 1}, {`
+}`, 1, false}, {`
 package main
 import "fmt"
 const (
@@ -46,12 +50,12 @@ const (
 )
 func main() {
 	fmt.Println("Doing something with: ", username, password)
-}`, 1}, {`
+}`, 1, false}, {`
 package main
 var password string
 func init() {
 	password = "f62e5bcda4fae4f82370da0c6f20697b8f8447ef"
-}`, 1}, {`
+}`, 1, false}, {`
 package main
 const (
 	ATNStateSomethingElse = 1
@@ -59,14 +63,14 @@ const (
 )
 func main() {
 	println(ATNStateTokenStart)
-}`, 0}, {`
+}`, 0, false}, {`
 package main
 const (
 	ATNStateTokenStart = "f62e5bcda4fae4f82370da0c6f20697b8f8447ef"
 )
 func main() {
 	println(ATNStateTokenStart)
-}`, 1}}
+}`, 1, false}}
 
 	// SampleCodeG102 code snippets for network binding
 	SampleCodeG102 = []CodeSample{
@@ -83,7 +87,7 @@ func main() {
 		log.Fatal(err)
 	}
 	defer l.Close()
-}`, 1},
+}`, 1, false},
 
 		// Bind to all networks implicitly (default if host omitted)
 		{`
@@ -98,7 +102,7 @@ func main() {
 		log.Fatal(err)
 	}
 	defer l.Close()
-}`, 1},
+}`, 1, false},
 	}
 	// SampleCodeG103 find instances of unsafe blocks for auditing purposes
 	SampleCodeG103 = []CodeSample{
@@ -120,7 +124,7 @@ func main() {
    	addressHolder := uintptr(unsafe.Pointer(intPtr)) + unsafe.Sizeof(intArray[0])
    	intPtr = (*int)(unsafe.Pointer(addressHolder))
    	fmt.Printf("\nintPtr=%p, *intPtr=%d.\n\n", intPtr, *intPtr)
-}`, 3}}
+}`, 3, false}}
 
 	// SampleCodeG104 finds errors that aren't being handled
 	SampleCodeG104 = []CodeSample{
@@ -133,7 +137,7 @@ func test() (int,error) {
 func main() {
 	v, _ := test()
 	fmt.Println(v)
-}`, 1}, {`
+}`, 1, false}, {`
 package main
 import (
 	"io/ioutil"
@@ -155,7 +159,7 @@ func main() {
 	a()
 	b()
 	c()
-}`, 3}, {`
+}`, 3, false}, {`
 package main
 import "fmt"
 func test() error {
@@ -164,7 +168,7 @@ func test() error {
 func main() {
 	e := test()
 	fmt.Println(e)
-}`, 0}}
+}`, 0, false}}
 
 	// SampleCodeG105 - bignum overflow
 	SampleCodeG105 = []CodeSample{{`
@@ -181,7 +185,7 @@ func main() {
    	m := new(big.Int)
     m = m.SetUint64(0)
     z = z.Exp(x, y, m)
-}`, 1}}
+}`, 1, false}}
 
 	// SampleCodeG106 - ssh InsecureIgnoreHostKey
 	SampleCodeG106 = []CodeSample{{`
@@ -191,7 +195,7 @@ import (
 )
 func main() {
         _ =  ssh.InsecureIgnoreHostKey()
-}`, 1}}
+}`, 1, false}}
 
 	// SampleCodeG107 - SSRF via http requests with variable url
 	SampleCodeG107 = []CodeSample{{`
@@ -214,7 +218,7 @@ func main() {
     		panic(err)
   	}
   	fmt.Printf("%s", body)
-}`, 1}, {`
+}`, 1, false}, {`
 package main
 
 import (
@@ -228,7 +232,7 @@ func main() {
 		fmt.Println(err)
     	}
       	fmt.Println(resp.Status)
-}`, 0}}
+}`, 0, false}}
 	// SampleCodeG201 - SQL injection via format string
 	SampleCodeG201 = []CodeSample{
 		{`
@@ -252,7 +256,7 @@ func main(){
 		panic(err)
 	}
 	defer rows.Close()
-}`, 1}, {`
+}`, 1, false}, {`
 // Format string false positive, safe string spec.
 package main
 import (
@@ -273,7 +277,7 @@ func main(){
 		panic(err)
 	}
 	defer rows.Close()
-}`, 0}, {
+}`, 0, false}, {
 			`
 // Format string false positive
 package main
@@ -292,7 +296,7 @@ func main(){
 				panic(err)
 		}
 		defer rows.Close()
-}`, 0}}
+}`, 0, false}}
 
 	// SampleCodeG202 - SQL query string building via string concatenation
 	SampleCodeG202 = []CodeSample{
@@ -313,7 +317,7 @@ func main(){
 		panic(err)
 	}
 	defer rows.Close()
-}`, 1}, {`
+}`, 1, false}, {`
 // false positive
 package main
 import (
@@ -323,15 +327,15 @@ import (
 var staticQuery = "SELECT * FROM foo WHERE age < "
 func main(){
 	db, err := sql.Open("sqlite3", ":memory:")
-    if err != nil {
+	if err != nil {
 		panic(err)
 	}
 	rows, err := db.Query(staticQuery + "32")
 	if err != nil {
 		panic(err)
 	}
-    defer rows.Close()
-}`, 0}, {`
+	defer rows.Close()
+}`, 0, false}, {`
 package main
 import (
 		"database/sql"
@@ -350,7 +354,29 @@ func main(){
 		}
 		defer rows.Close()
 }
-`, 0}}
+`, 0, false}, {`
+package main
+const gender = "M"
+`, 0, true}, {`
+package main
+import (
+		"database/sql"
+		//_ "github.com/mattn/go-sqlite3"
+)
+const age = "32"
+var staticQuery = "SELECT * FROM foo WHERE age < "
+func main(){
+		db, err := sql.Open("sqlite3", ":memory:")
+		if err != nil {
+				panic(err)
+		}
+		rows, err := db.Query("SELECT * FROM foo WHERE gender = " + gender)
+		if err != nil {
+				panic(err)
+		}
+		defer rows.Close()
+}
+`, 0, false}}
 
 	// SampleCodeG203 - Template checks
 	SampleCodeG203 = []CodeSample{
@@ -370,7 +396,7 @@ func main() {
 		"Body":     template.HTML("<script>alert(1)</script>"),
 	}
 	t.Execute(os.Stdout, v)
-}`, 0}, {
+}`, 0, false}, {
 			`
 // Using a variable to initialize could potentially be dangerous. Under the
 // current model this will likely produce some false positives.
@@ -388,7 +414,7 @@ func main() {
 		"Body":     template.HTML(a),
 	}
 	t.Execute(os.Stdout, v)
-}`, 1}, {
+}`, 1, false}, {
 			`
 package main
 import (
@@ -404,7 +430,7 @@ func main() {
 		"Body":     template.JS(a),
 	}
 	t.Execute(os.Stdout, v)
-}`, 1}, {
+}`, 1, false}, {
 			`
 package main
 import (
@@ -420,7 +446,7 @@ func main() {
 		"Body":     template.URL(a),
 	}
 	t.Execute(os.Stdout, v)
-}`, 1}}
+}`, 1, false}}
 
 	// SampleCodeG204 - Subprocess auditing
 	SampleCodeG204 = []CodeSample{{`
@@ -428,7 +454,7 @@ package main
 import "syscall"
 func main() {
 	syscall.Exec("/bin/cat", []string{ "/etc/passwd" }, nil)
-}`, 1}, {`
+}`, 1, false}, {`
 package main
 import (
 	"log"
@@ -443,7 +469,7 @@ func main() {
 	log.Printf("Waiting for command to finish...")
   	err = cmd.Wait()
   	log.Printf("Command finished with error: %v", err)
-}`, 1}, {`
+}`, 1, false}, {`
 package main
 import (
 	"log"
@@ -456,7 +482,7 @@ func main() {
 		log.Fatal(err)
 	}
   	log.Printf("Command finished with error: %v", err)
-}`, 1}, {`
+}`, 1, false}, {`
 package main
 import (
 	"log"
@@ -473,7 +499,7 @@ func main() {
 	log.Printf("Waiting for command to finish...")
 	err = cmd.Wait()
 	log.Printf("Command finished with error: %v", err)
-}`, 1}}
+}`, 1, false}}
 
 	// SampleCodeG301 - mkdir permission check
 	SampleCodeG301 = []CodeSample{{`
@@ -483,7 +509,7 @@ func main() {
 	os.Mkdir("/tmp/mydir", 0777)
 	os.Mkdir("/tmp/mydir", 0600)
 	os.MkdirAll("/tmp/mydir/mysubidr", 0775)
-}`, 2}}
+}`, 2, false}}
 
 	// SampleCodeG302 - file create / chmod permissions check
 	SampleCodeG302 = []CodeSample{{`
@@ -494,7 +520,7 @@ func main() {
 	os.Chmod("/tmp/someotherfile", 0600)
 	os.OpenFile("/tmp/thing", os.O_CREATE|os.O_WRONLY, 0666)
 	os.OpenFile("/tmp/thing", os.O_CREATE|os.O_WRONLY, 0600)
-}`, 2}}
+}`, 2, false}}
 
 	// SampleCodeG303 - bad tempfile permissions & hardcoded shared path
 	SampleCodeG303 = []CodeSample{{`
@@ -507,7 +533,7 @@ func main() {
 	file1, _ := os.Create("/tmp/demo1")
 	defer file1.Close()
 	ioutil.WriteFile("/tmp/demo2", []byte("This is some data"), 0644)
-}`, 2}}
+}`, 2, false}}
 
 	// SampleCodeG304 - potential file inclusion vulnerability
 	SampleCodeG304 = []CodeSample{{`
@@ -525,7 +551,7 @@ if err != nil {
 }
 log.Print(body)
 
-}`, 1}, {`
+}`, 1, false}, {`
 package main
 
 import (
@@ -549,7 +575,7 @@ func main() {
 		fmt.Fprintf(w, "%s", body)
 	})
 	log.Fatal(http.ListenAndServe(":3000", nil))
-}`, 1}, {`
+}`, 1, false}, {`
 package main
 
 import (
@@ -565,7 +591,7 @@ import (
 		log.Printf("Error: %v\n", err)
 	  }
 		log.Print(body)
- }`, 1}, {`
+ }`, 1, false}, {`
  package main
 
  import (
@@ -589,7 +615,7 @@ func main() {
 		fmt.Printf("Error: %v\n", err)
 	}
   fmt.Println(string(contents))
-}`, 1}, {`
+}`, 1, false}, {`
 package main
 
 import (
@@ -608,7 +634,7 @@ func main() {
 		log.Printf("Error: %v\n", err)
 	}
 	log.Print(body)
-}`, 1}}
+}`, 1, false}}
 
 	// SampleCodeG305 - File path traversal when extracting zip archives
 	SampleCodeG305 = []CodeSample{{`
@@ -656,7 +682,7 @@ func unzip(archive, target string) error {
 	}
 
 	return nil
-}`, 1}, {`
+}`, 1, false}, {`
 package unzip
 
 import (
@@ -702,7 +728,7 @@ func unzip(archive, target string) error {
 	}
 
 	return nil
-}`, 1}}
+}`, 1, false}}
 
 	// SampleCodeG401 - Use of weak crypto MD5
 	SampleCodeG401 = []CodeSample{
@@ -727,7 +753,7 @@ func main() {
 		log.Fatal(err)
 	}
 	fmt.Printf("%x", h.Sum(nil))
-}`, 1}}
+}`, 1, false}}
 
 	// SampleCodeG401b - Use of weak crypto SHA1
 	SampleCodeG401b = []CodeSample{
@@ -752,7 +778,7 @@ func main() {
 		log.Fatal(err)
 	}
 	fmt.Printf("%x", h.Sum(nil))
-}`, 1}}
+}`, 1, false}}
 
 	// SampleCodeG402 - TLS settings
 	SampleCodeG402 = []CodeSample{{`
@@ -773,7 +799,7 @@ func main() {
 	if err != nil {
 		fmt.Println(err)
 	}
-}`, 1}, {
+}`, 1, false}, {
 		`
 // Insecure minimum version
 package main
@@ -791,7 +817,7 @@ func main() {
 	if err != nil {
 		fmt.Println(err)
 	}
-}`, 1}, {`
+}`, 1, false}, {`
 // Insecure max version
 package main
 import (
@@ -809,7 +835,7 @@ func main() {
 		fmt.Println(err)
 	}
 }
-`, 1}, {
+`, 1, false}, {
 		`
 // Insecure ciphersuite selection
 package main
@@ -830,7 +856,7 @@ func main() {
 	if err != nil {
 		fmt.Println(err)
 	}
-}`, 1}}
+}`, 1, false}}
 
 	// SampleCodeG403 - weak key strength
 	SampleCodeG403 = []CodeSample{
@@ -848,7 +874,7 @@ func main() {
 		fmt.Println(err)
 	}
 	fmt.Println(pvk)
-}`, 1}}
+}`, 1, false}}
 
 	// SampleCodeG404 - weak random number
 	SampleCodeG404 = []CodeSample{
@@ -858,13 +884,13 @@ import "crypto/rand"
 func main() {
 	good, _ := rand.Read(nil)
 	println(good)
-}`, 0}, {`
+}`, 0, false}, {`
 package main
 import "math/rand"
 func main() {
 	bad := rand.Int()
 	println(bad)
-}`, 1}, {`
+}`, 1, false}, {`
 package main
 import (
 	"crypto/rand"
@@ -875,7 +901,7 @@ func main() {
 	println(good)
 	i := mrand.Int31()
 	println(i)
-}`, 0}}
+}`, 0, false}}
 
 	// SampleCodeG501 - Blacklisted import MD5
 	SampleCodeG501 = []CodeSample{
@@ -890,7 +916,7 @@ func main() {
 	for _, arg := range os.Args {
 		fmt.Printf("%x - %s\n", md5.Sum([]byte(arg)), arg)
 	}
-}`, 1}}
+}`, 1, false}}
 
 	// SampleCodeG502 - Blacklisted import DES
 	SampleCodeG502 = []CodeSample{
@@ -918,7 +944,7 @@ func main() {
 	stream := cipher.NewCFBEncrypter(block, iv)
 	stream.XORKeyStream(ciphertext[des.BlockSize:], plaintext)
 	fmt.Println("Secret message is: %s", hex.EncodeToString(ciphertext))
-}`, 1}}
+}`, 1, false}}
 
 	// SampleCodeG503 - Blacklisted import RC4
 	SampleCodeG503 = []CodeSample{{`
@@ -937,7 +963,7 @@ func main() {
 	ciphertext := make([]byte, len(plaintext))
 	cipher.XORKeyStream(ciphertext, plaintext)
 	fmt.Println("Secret message is: %s", hex.EncodeToString(ciphertext))
-}`, 1}}
+}`, 1, false}}
 
 	// SampleCodeG504 - Blacklisted import CGI
 	SampleCodeG504 = []CodeSample{{`
@@ -948,7 +974,7 @@ import (
  )
 func main() {
 	cgi.Serve(http.FileServer(http.Dir("/usr/share/doc")))
-}`, 1}}
+}`, 1, false}}
 	// SampleCodeG505 - Blacklisted import SHA1
 	SampleCodeG505 = []CodeSample{
 		{`
@@ -962,7 +988,7 @@ func main() {
 	for _, arg := range os.Args {
 		fmt.Printf("%x - %s\n", sha1.Sum([]byte(arg)), arg)
 	}
-}`, 1}}
+}`, 1, false}}
 	// SampleCode601 - Go build tags
 	SampleCode601 = []CodeSample{{`
 // +build test
@@ -970,5 +996,5 @@ func main() {
 package main
 func main() {
   fmt.Println("no package imported error")
-}`, 1}}
+}`, 1, false}}
 )


### PR DESCRIPTION
Fixes #169. Sorry, it's been a while, was busy with work. 😅 

This PR aims to handle the following case:

main.go
```go
package main

func main() {
  ...
  rows, err := db.Query("SELECT * FROM foo WHERE gender = " + gender)
  ...
}
```

constants.go (for example)
```go
package main

...
const gender = "M"
...

```

Currently, gosec will flag this this out as an issue in `main.go` as the `gender` identifier is unresolved. 

This PR will add `pkg.Files` to `gosec.context` so that we will be able to resolve that identifier if it happens to be in the global scope of that package.