### PR TITLE
bump Dockerfile golang from 1.10 to 1.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.10.4-alpine3.8 as build
+FROM golang:1.11.1-alpine3.8 as build
 WORKDIR /go/src/github.com/securego/gosec
 COPY . .
 RUN apk add -U git make
 RUN go get -u github.com/golang/dep/cmd/dep
 RUN make
 
-FROM golang:1.10.4-alpine3.8
+FROM golang:1.11.1-alpine3.8
 RUN apk add -U gcc musl-dev
 COPY --from=build /go/src/github.com/securego/gosec/gosec /usr/local/bin/gosec
 ENTRYPOINT ["gosec"]


### PR DESCRIPTION
Update the golang in `Dockerfile` from 1.10 to latest 1.11.

Stuff still works:
```
$ make image
Building the Docker image...
docker build -t securego/gosec:1.1.0-12-g1ecd47e .
[+] Building 0.7s (13/13) FINISHED
 => [internal] load .dockerignore                                          0.0s
 => => transferring context: 2B                                            0.0s
 => [internal] load Dockerfile                                             0.0s
 => => transferring dockerfile: 38B                                        0.0s
 => [internal] load metadata for docker.io/library/golang:1.11.1-alpine3.  0.6s
 => [internal] load build context                                          0.0s
 => => transferring context: 15.52kB                                       0.0s
 => [stage-1 1/3] FROM docker.io/library/golang:1.11.1-alpine3.8@sha256:9  0.0s
 => [internal] helper image for file operations                            0.0s
 => CACHED [stage-1 2/3] RUN apk add -U gcc musl-dev                       0.0s
 => CACHED [build 2/5] COPY . .                                            0.0s
 => CACHED [build 3/5] RUN apk add -U git make                             0.0s
 => CACHED [build 4/5] RUN go get -u github.com/golang/dep/cmd/dep         0.0s
 => CACHED [build 5/5] RUN make                                            0.0s
 => CACHED [stage-1 3/3] COPY --from=build /go/src/github.com/securego/go  0.0s
 => exporting to image                                                     0.0s
 => => exporting layers                                                    0.0s
 => => writing image sha256:16b1a1f887e0747d0f4751b276afbfb7aa7aab55d097b  0.0s
 => => naming to docker.io/securego/gosec:1.1.0-12-g1ecd47e                0.0s
docker tag securego/gosec:1.1.0-12-g1ecd47e securego/gosec:latest
touch image
$ make bootstrap
dep ensure
$ docker run --rm -it \
  -v "$GOPATH/src/github.com/securego/gosec:/go/src/github.com/securego/gosec" \
  -w /go/src/github.com/securego/gosec \
  securego/gosec:latest ./...
[gosec] 2018/10/03 00:30:58 including rules: default
[gosec] 2018/10/03 00:30:58 excluding rules: default
[gosec] 2018/10/03 00:30:58 Searching directory: /go/src/github.com/securego/gosec
...
Results:

Summary:
   Files: 44
   Lines: 5689
   Nosec: 16
  Issues: 0