### PR TITLE
Fix -conf example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ A number of global settings can be provided in a configuration file as follows:
 {
     "global": {
         "nosec": "enabled",
-        "audit": "enabled",
+        "audit": "enabled"
     }
 }
 ```
@@ -105,7 +105,7 @@ A number of global settings can be provided in a configuration file as follows:
 
 ```bash
 # Run with a global configuration file
-$ goesc -config config.json
+$ goesc -conf config.json .
 ```
 
 ### Excluding files


### PR DESCRIPTION
1. Example config json included a trailing comma, even though as we obviously know this is how things should be, JSON does not agree and the parser fails miserably
2. Flag was incorrectly stated as -config in the README, the correct flag is -conf
3. Example command did not work as did not include final dot to examine the current pkg.