### PR TITLE
Report for Golang errors

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -64,6 +64,7 @@ type Analyzer struct {
 	logger      *log.Logger
 	issues      []*Issue
 	stats       *Metrics
+	errors      map[string][]Error
 }
 
 // NewAnalyzer builds a new analyzer.
@@ -83,6 +84,7 @@ func NewAnalyzer(conf Config, logger *log.Logger) *Analyzer {
 		logger:      logger,
 		issues:      make([]*Issue, 0, 16),
 		stats:       &Metrics{},
+		errors:      make(map[string][]Error),
 	}
 }
 
@@ -129,6 +131,27 @@ func (gosec *Analyzer) Process(buildTags []string, packagePaths ...string) error
 	if err != nil {
 		return err
 	}
+	for _, packageInfo := range builtPackage.AllPackages {
+		if len(packageInfo.Errors) != 0 {
+			for _, packErr := range packageInfo.Errors {
+				// infoErr contains information about the error
+				// at index 0 is the file path
+				// at index 1 is the line; index 2 is for column
+				// at index 3 is the actual error
+				infoErr := strings.Split(packErr.Error(), ":")
+				newErr := NewError(infoErr[1], infoErr[2], strings.TrimSpace(infoErr[3]))
+				filePath := infoErr[0]
+
+				if errSlice, ok := gosec.errors[filePath]; ok {
+					gosec.errors[filePath] = append(errSlice, *newErr)
+				} else {
+					errSlice = make([]Error, 0)
+					gosec.errors[filePath] = append(errSlice, *newErr)
+				}
+			}
+		}
+	}
+	sortErrors(gosec.errors) // sorts errors by line and column in the file
 
 	for _, pkg := range builtPackage.Created {
 		gosec.logger.Println("Checking package:", pkg.String())
@@ -233,8 +256,8 @@ func (gosec *Analyzer) Visit(n ast.Node) ast.Visitor {
 }
 
 // Report returns the current issues discovered and the metrics about the scan
-func (gosec *Analyzer) Report() ([]*Issue, *Metrics) {
-	return gosec.issues, gosec.stats
+func (gosec *Analyzer) Report() ([]*Issue, *Metrics, map[string][]Error) {
+	return gosec.issues, gosec.stats, gosec.errors
 }
 
 // Reset clears state such as context, issues and metrics from the configured analyzer

--- a/analyzer.go
+++ b/analyzer.go
@@ -64,7 +64,7 @@ type Analyzer struct {
 	logger      *log.Logger
 	issues      []*Issue
 	stats       *Metrics
-	errors      map[string][]Error
+	errors      map[string][]Error // keys are file paths; values are the golang errors in those files
 }
 
 // NewAnalyzer builds a new analyzer.

--- a/analyzer.go
+++ b/analyzer.go
@@ -26,6 +26,7 @@ import (
 	"path"
 	"reflect"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"golang.org/x/tools/go/loader"
@@ -139,8 +140,16 @@ func (gosec *Analyzer) Process(buildTags []string, packagePaths ...string) error
 				// at index 1 is the line; index 2 is for column
 				// at index 3 is the actual error
 				infoErr := strings.Split(packErr.Error(), ":")
-				newErr := NewError(infoErr[1], infoErr[2], strings.TrimSpace(infoErr[3]))
 				filePath := infoErr[0]
+				line, err := strconv.Atoi(infoErr[1])
+				if err != nil {
+					return err
+				}
+				column, err := strconv.Atoi(infoErr[2])
+				if err != nil {
+					return err
+				}
+				newErr := NewError(line, column, strings.TrimSpace(infoErr[3]))
 
 				if errSlice, ok := gosec.errors[filePath]; ok {
 					gosec.errors[filePath] = append(errSlice, *newErr)

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Analyzer", func() {
 			pkg.Build()
 			err := analyzer.Process(buildTags, pkg.Path)
 			Expect(err).ShouldNot(HaveOccurred())
-			_, metrics := analyzer.Report()
+			_, metrics, _ := analyzer.Report()
 			Expect(metrics.NumFiles).To(Equal(2))
 		})
 
@@ -90,7 +90,7 @@ var _ = Describe("Analyzer", func() {
 			pkg2.Build()
 			err := analyzer.Process(buildTags, pkg1.Path, pkg2.Path)
 			Expect(err).ShouldNot(HaveOccurred())
-			_, metrics := analyzer.Report()
+			_, metrics, _ := analyzer.Report()
 			Expect(metrics.NumFiles).To(Equal(2))
 		})
 
@@ -106,7 +106,7 @@ var _ = Describe("Analyzer", func() {
 			controlPackage.AddFile("md5.go", source)
 			controlPackage.Build()
 			analyzer.Process(buildTags, controlPackage.Path)
-			controlIssues, _ := analyzer.Report()
+			controlIssues, _, _ := analyzer.Report()
 			Expect(controlIssues).Should(HaveLen(sample.Errors))
 
 		})
@@ -124,7 +124,7 @@ var _ = Describe("Analyzer", func() {
 			nosecPackage.Build()
 
 			analyzer.Process(buildTags, nosecPackage.Path)
-			nosecIssues, _ := analyzer.Report()
+			nosecIssues, _, _ := analyzer.Report()
 			Expect(nosecIssues).Should(BeEmpty())
 		})
 
@@ -141,7 +141,7 @@ var _ = Describe("Analyzer", func() {
 			nosecPackage.Build()
 
 			analyzer.Process(buildTags, nosecPackage.Path)
-			nosecIssues, _ := analyzer.Report()
+			nosecIssues, _, _ := analyzer.Report()
 			Expect(nosecIssues).Should(BeEmpty())
 		})
 
@@ -158,7 +158,7 @@ var _ = Describe("Analyzer", func() {
 			nosecPackage.Build()
 
 			analyzer.Process(buildTags, nosecPackage.Path)
-			nosecIssues, _ := analyzer.Report()
+			nosecIssues, _, _ := analyzer.Report()
 			Expect(nosecIssues).Should(HaveLen(sample.Errors))
 		})
 
@@ -175,7 +175,7 @@ var _ = Describe("Analyzer", func() {
 			nosecPackage.Build()
 
 			analyzer.Process(buildTags, nosecPackage.Path)
-			nosecIssues, _ := analyzer.Report()
+			nosecIssues, _, _ := analyzer.Report()
 			Expect(nosecIssues).Should(BeEmpty())
 		})
 
@@ -212,7 +212,7 @@ var _ = Describe("Analyzer", func() {
 		nosecPackage.Build()
 
 		customAnalyzer.Process(buildTags, nosecPackage.Path)
-		nosecIssues, _ := customAnalyzer.Report()
+		nosecIssues, _, _ := customAnalyzer.Report()
 		Expect(nosecIssues).Should(HaveLen(sample.Errors))
 
 	})

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,34 @@
+package gosec
+
+import (
+	"sort"
+)
+
+// Error is used when there are golang errors while parsing the AST
+type Error struct {
+	Line   string `json:"line"`
+	Column string `json:"column"`
+	Err    string `json:"error"`
+}
+
+// NewError creates Error object
+func NewError(line, column, err string) *Error {
+	return &Error{
+		Line:   line,
+		Column: column,
+		Err:    err,
+	}
+}
+
+// sortErros sorts the golang erros by line
+func sortErrors(allErrors map[string][]Error) {
+
+	for _, errors := range allErrors {
+		sort.Slice(errors, func(i, j int) bool {
+			if errors[i].Line == errors[j].Line {
+				return errors[i].Column <= errors[j].Column
+			}
+			return errors[i].Line < errors[j].Line
+		})
+	}
+}

--- a/errors.go
+++ b/errors.go
@@ -6,13 +6,13 @@ import (
 
 // Error is used when there are golang errors while parsing the AST
 type Error struct {
-	Line   string `json:"line"`
-	Column string `json:"column"`
+	Line   int    `json:"line"`
+	Column int    `json:"column"`
 	Err    string `json:"error"`
 }
 
 // NewError creates Error object
-func NewError(line, column, err string) *Error {
+func NewError(line, column int, err string) *Error {
 	return &Error{
 		Line:   line,
 		Column: column,

--- a/output/formatter.go
+++ b/output/formatter.go
@@ -47,7 +47,7 @@ var text = `Results:
 {{range $filePath,$fileErrors := .Errors}}
 Golang errors in file: [{{ $filePath }}]:
 {{range $index, $error := $fileErrors}}
-  > [line{{$error.Line}} : column{{$error.Column}}] - {{$error.Err}}
+  > [line {{$error.Line}} : column {{$error.Column}}] - {{$error.Err}}
 {{end}}
 {{end}}
 {{ range $index, $issue := .Issues }}

--- a/output/formatter.go
+++ b/output/formatter.go
@@ -44,6 +44,12 @@ const (
 )
 
 var text = `Results:
+{{range $filePath,$fileErrors := .Errors}}
+Golang errors in file: [{{ $filePath }}]:
+{{range $index, $error := $fileErrors}}
+  > [line{{$error.Line}} : column{{$error.Column}}] - {{$error.Err}}
+{{end}}
+{{end}}
 {{ range $index, $issue := .Issues }}
 [{{ $issue.File }}:{{ $issue.Line }}] - {{ $issue.RuleID }}: {{ $issue.What }} (Confidence: {{ $issue.Confidence}}, Severity: {{ $issue.Severity }})
   > {{ $issue.Code }}
@@ -58,14 +64,16 @@ Summary:
 `
 
 type reportInfo struct {
+	Errors map[string][]gosec.Error `json:"Golang errors"`
 	Issues []*gosec.Issue
 	Stats  *gosec.Metrics
 }
 
 // CreateReport generates a report based for the supplied issues and metrics given
 // the specified format. The formats currently accepted are: json, csv, html and text.
-func CreateReport(w io.Writer, format string, issues []*gosec.Issue, metrics *gosec.Metrics) error {
+func CreateReport(w io.Writer, format string, issues []*gosec.Issue, metrics *gosec.Metrics, errors map[string][]gosec.Error) error {
 	data := &reportInfo{
+		Errors: errors,
 		Issues: issues,
 		Stats:  metrics,
 	}

--- a/rules/rules_test.go
+++ b/rules/rules_test.go
@@ -47,7 +47,7 @@ var _ = Describe("gosec rules", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 				err = analyzer.Process(buildTags, pkg.Path)
 				Expect(err).ShouldNot(HaveOccurred())
-				issues, _ := analyzer.Report()
+				issues, _, _ := analyzer.Report()
 				if len(issues) != sample.Errors {
 					fmt.Println(sample.Code)
 				}


### PR DESCRIPTION
Right now if you use Gosec to scan invalid go file and if you report the result in a text, JSON, CSV or another file format you will always receive 0 issues.
The reason for that is that Gosec can't parse the AST of invalid go files and thus will not report anything.

The real problem here is that the user will never know about the issue if he generates the output in a file.

I fix this problem in this patch and I added those Golang errors in the output.
Now when there are Golang errors found Gosec will exit with code 1.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>