### PR TITLE
fix no-fail flag logic

### DIFF
--- a/cmd/gosec/main.go
+++ b/cmd/gosec/main.go
@@ -352,7 +352,7 @@ func main() {
 	logWriter.Close() // #nosec
 
 	// Do we have an issue? If so exit 1 unless NoFail is set
-	if issuesFound && !*flagNoFail || len(errors) != 0 {
+	if (issuesFound || len(errors) != 0) && !*flagNoFail {
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Reading https://github.com/securego/gosec/pull/284 , I think this is a good idea, but I do not think we should fail if there were errors if the no-fail flag is present.

It's great that it errors are added to the output, but someone using the no-fail flag will likely be looking at the output anyway. So failing is not necessary / logic.

I found that while I was trying to follow a fail issue that I first thought was related to cgo imports (https://github.com/securego/gosec/issues/289) but actually was due to this `no-fail` logic change