### PR TITLE
Refactor the analyzer to process one package at the time

### DIFF
--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -219,7 +219,6 @@ var _ = Describe("Analyzer", func() {
 	})
 
 	It("should be possible to overwrite nosec comments, and report issues", func() {
-
 		// Rule for MD5 weak crypto usage
 		sample := testutils.SampleCodeG401[0]
 		source := sample.Code[0]


### PR DESCRIPTION
This avoids loading all packages in memory before running the checks.

fixes #303 #305 