### PR TITLE
Display filtered number of issues instead of total in stats

### DIFF
--- a/cmd/gosec/main.go
+++ b/cmd/gosec/main.go
@@ -320,6 +320,9 @@ func main() {
 
 	// Filter the issues by severity and confidence
 	issues = filterIssues(issues, failSeverity, failConfidence)
+	if metrics.NumFound != len(issues) {
+		metrics.NumFound = len(issues)
+	}
 
 	// Exit quietly if nothing was found
 	if len(issues) == 0 && *flagQuiet {


### PR DESCRIPTION
This takes into account the filtered number of issues instead of
the total number. This number is more relevant to developers, as
the intention was to not take certain issues into account anyway.

Closes #331