### PR TITLE
Prevent null pointer exception in Sonarqube

### DIFF
--- a/output/formatter.go
+++ b/output/formatter.go
@@ -117,8 +117,8 @@ func reportSonarqube(rootPaths []string, w io.Writer, data *reportInfo) error {
 	return err
 }
 
-func convertToSonarIssues(rootPaths []string, data *reportInfo) (sonarIssues, error) {
-	var si sonarIssues
+func convertToSonarIssues(rootPaths []string, data *reportInfo) (*sonarIssues, error) {
+	si := &sonarIssues{[]sonarIssue{}}
 	for _, issue := range data.Issues {
 		var sonarFilePath string
 		for _, rootPath := range rootPaths {

--- a/output/formatter_test.go
+++ b/output/formatter_test.go
@@ -127,7 +127,7 @@ var _ = Describe("Formatter", func() {
 					NumFound: 0,
 				},
 			}
-			want := sonarIssues{
+			want := &sonarIssues{
 				SonarIssues: []sonarIssue{},
 			}
 

--- a/output/formatter_test.go
+++ b/output/formatter_test.go
@@ -128,14 +128,14 @@ var _ = Describe("Formatter", func() {
 				},
 			}
 			want := sonarIssues{
-				SonarIssues: [],
+				SonarIssues: []sonarIssue{},
 			}
 
 			rootPath := "/home/src/project2"
 
 			issues, err := convertToSonarIssues([]string{rootPath}, data)
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(issues).To(Equal(want))
+			Expect(*issues).To(Equal(*want))
 		})
 
 		It("it should parse the report info for multiple projects projects", func() {

--- a/output/formatter_test.go
+++ b/output/formatter_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Formatter", func() {
 					NumFound: 0,
 				},
 			}
-			want := sonarIssues{
+			want := &sonarIssues{
 				SonarIssues: []sonarIssue{
 					{
 						EngineID: "gosec",
@@ -56,7 +56,7 @@ var _ = Describe("Formatter", func() {
 
 			issues, err := convertToSonarIssues([]string{rootPath}, data)
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(issues).To(Equal(want))
+			Expect(*issues).To(Equal(*want))
 		})
 
 		It("it should parse the report info with files in subfolders", func() {
@@ -80,7 +80,7 @@ var _ = Describe("Formatter", func() {
 					NumFound: 0,
 				},
 			}
-			want := sonarIssues{
+			want := &sonarIssues{
 				SonarIssues: []sonarIssue{
 					{
 						EngineID: "gosec",
@@ -104,7 +104,7 @@ var _ = Describe("Formatter", func() {
 
 			issues, err := convertToSonarIssues([]string{rootPath}, data)
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(issues).To(Equal(want))
+			Expect(*issues).To(Equal(*want))
 		})
 		It("it should not parse the report info for files from other projects", func() {
 			data := &reportInfo{
@@ -128,7 +128,7 @@ var _ = Describe("Formatter", func() {
 				},
 			}
 			want := sonarIssues{
-				SonarIssues: nil,
+				SonarIssues: [],
 			}
 
 			rootPath := "/home/src/project2"
@@ -168,7 +168,7 @@ var _ = Describe("Formatter", func() {
 					NumFound: 0,
 				},
 			}
-			want := sonarIssues{
+			want := &sonarIssues{
 				SonarIssues: []sonarIssue{
 					{
 						EngineID: "gosec",
@@ -207,7 +207,7 @@ var _ = Describe("Formatter", func() {
 
 			issues, err := convertToSonarIssues(rootPaths, data)
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(issues).To(Equal(want))
+			Expect(*issues).To(Equal(*want))
 		})
 	})
 })


### PR DESCRIPTION
The json encoding of uninitialized arrays is `null`. This causes a NPE in sonarqube tool. We should return an empty array rather than a null value here.

Example of this behaviour is: https://play.golang.org/p/UUvP9JwsYlm

Relates to: #333