### PR TITLE
Add flag to handle '#nosec' alternative

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -251,8 +251,15 @@ func (gosec *Analyzer) AppendError(file string, err error) {
 // ignore a node (and sub-tree) if it is tagged with a "#nosec" comment
 func (gosec *Analyzer) ignore(n ast.Node) ([]string, bool) {
 	if groups, ok := gosec.context.Comments[n]; ok && !gosec.ignoreNosec {
+
+		// Checks if an alternative for #nosec is set and, if not, uses the default.
+		noSecAlternative, err := gosec.config.GetGlobal(NoSecAlternative)
+		if err != nil {
+			noSecAlternative = "#nosec"
+		}
+
 		for _, group := range groups {
-			if strings.Contains(group.Text(), "#nosec") {
+			if strings.Contains(group.Text(), noSecAlternative) {
 				gosec.stats.NumNosec++
 
 				// Pull out the specific rules that are listed to be ignored.

--- a/cmd/gosec/main.go
+++ b/cmd/gosec/main.go
@@ -65,6 +65,9 @@ var (
 	// format output
 	flagFormat = flag.String("fmt", "text", "Set output format. Valid options are: json, yaml, csv, junit-xml, html, sonarqube, or text")
 
+	// #nosec alternative tag
+	flagAlternativeNoSec = flag.String("nosec-tag", "", "Set an alternative string for #nosec. Some examples: #dontanalyze, #falsepositive")
+
 	// output file
 	flagOutput = flag.String("out", "", "Set output file for results")
 
@@ -147,6 +150,9 @@ func loadConfig(configFile string) (gosec.Config, error) {
 	}
 	if *flagIgnoreNoSec {
 		config.SetGlobal(gosec.Nosec, "true")
+	}
+	if *flagAlternativeNoSec != "" {
+		config.SetGlobal(gosec.NoSecAlternative, *flagAlternativeNoSec)
 	}
 	return config, nil
 }

--- a/config.go
+++ b/config.go
@@ -22,6 +22,8 @@ const (
 	Nosec GlobalOption = "nosec"
 	// Audit global option which indicates that gosec runs in audit mode
 	Audit GlobalOption = "audit"
+	// NoSecAlternative global option alternative for #nosec directive
+	NoSecAlternative GlobalOption = "#nosec"
 )
 
 // Config is used to provide configuration and customization to each of the rules.


### PR DESCRIPTION
## Closes #344 

This PR aims to add a new flag to Gosec that allows users to change the directive for ignoring vulnerabilities.

### Changes:
* `analyzer.go`: Add logic to check if the default directive has changed.
* `analyzer_test.go`: Add test cases to cover the addition.
* `cmd/gosec/main.go`: Add `nosec-tag` flag.
* `config.go`: Creates a new global variable, `NoSecAlternative `, to hold the directive for ignoring vulnerabilities.