### PR TITLE
Remove redundant unit test for rule G304

### DIFF
--- a/testutils/source.go
+++ b/testutils/source.go
@@ -795,22 +795,6 @@ func main() {
 	})
 	log.Fatal(http.ListenAndServe(":3000", nil))
 }`}, 1, gosec.NewConfig()}, {[]string{`
-package main
-
-import (
-	"log"
-	"os"
-	"io/ioutil"
-)
-
-	func main() {
-		f2 := os.Getenv("tainted_file2")
-		body, err := ioutil.ReadFile("/tmp/" + f2)
-		if err != nil {
-		log.Printf("Error: %v\n", err)
-	  }
-		log.Print(body)
- }`}, 1, gosec.NewConfig()}, {[]string{`
  package main
 
  import (


### PR DESCRIPTION
There are two identical unit tests for rule G304.

The first and the third one in `testutils/source.go`

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>