### PR TITLE
reconfigure renovatebot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
-    "config:base"
-  ],
-  "automerge": true
+    "config:semverAllMonthly",
+    ":enableVulnerabilityAlertsWithLabel(vulnerablity)",
+    ":docker"
+  ]
 }


### PR DESCRIPTION
I *think* this schedule only monthly semver updates but still give us
vulnerability alerts.

See: https://docs.renovatebot.com/presets for more information.