### PR TITLE
408 - [regression] Gas don't analyse files if the "C" import is used

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -174,6 +174,10 @@ func (gosec *Analyzer) load(pkgPath string, conf *packages.Config) ([]*packages.
 		packageFiles = append(packageFiles, path.Join(pkgPath, filename))
 	}
 
+	for _, filename := range basePackage.CgoFiles {
+		packageFiles = append(packageFiles, path.Join(pkgPath, filename))
+	}
+
 	if gosec.tests {
 		testsFiles := []string{}
 		testsFiles = append(testsFiles, basePackage.TestGoFiles...)


### PR DESCRIPTION
 - Add CGO files

The MR is for https://github.com/securego/gosec/issues/408

It works ... but ... CGO generates somes other files. and the name of the file is not the "original" one.
```
# gosec ./...
[gosec] 2019/10/31 15:47:26 Including rules: default
[gosec] 2019/10/31 15:47:26 Excluding rules: default
[gosec] 2019/10/31 15:47:26 Import directory: /go/src/github.com/delanne/gas-package-repro/repro
[gosec] 2019/10/31 15:47:26 Checking package: repro
[gosec] 2019/10/31 15:47:26 Checking file: /go/src/github.com/delanne/gas-package-repro/repro/target.go
[gosec] 2019/10/31 15:47:26 Checking file: /root/.cache/go-build/31/3112f732a456d0e79e39510022210b1457b53698229dd3a4a19837dd755be21d-d
[gosec] 2019/10/31 15:47:26 Checking file: /root/.cache/go-build/a8/a882d7b11a1d34905f55a938219cafeeed7f4e3658413af9c94e8d136d13bb67-d
[gosec] 2019/10/31 15:47:26 Checking file: /root/.cache/go-build/df/df62f620da4a7eda3c25c76534e9726ee0036e4b08aa0d2ba0c7d4cb3024232f-d
[gosec] 2019/10/31 15:47:26 Import directory: /go/src/github.com/delanne/gas-package-repro
Results:


Summary:
   Files: 4
   Lines: 63
   Nosec: 0
  Issues: 0
```

I don't know how the retreive the name of the CGO file (and not the generated one).
The code to fix is: 
```
	for _, file := range pkg.Syntax {
		gosec.logger.Println("Checking file:", pkg.Fset.File(file.Pos()).Name())
```

fixes #408 