### PR TITLE
fix(docker) gcc and libc-dev needed for bindings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG GO_VERSION=1.13
 FROM golang:${GO_VERSION}-alpine AS builder
-RUN apk add --update --no-cache ca-certificates make git curl
+RUN apk add --update --no-cache ca-certificates make git curl gcc libc-dev
 RUN mkdir -p /build
 WORKDIR /build
 COPY . /build/
@@ -8,7 +8,7 @@ RUN go mod download
 RUN make build-linux
 
 FROM golang:${GO_VERSION}-alpine 
-RUN apk add --update --no-cache ca-certificates git 
+RUN apk add --update --no-cache ca-certificates git gcc libc-dev
 ENV GO111MODULE on
 COPY --from=builder /build/gosec /bin/gosec
 ENTRYPOINT ["/bin/gosec"]


### PR DESCRIPTION
The docker image doesn't include the necessary packages to build / analyze
some packages. Adding gcc and libc-dev to address this.

Fixes #420 