### PR TITLE
Add golint format to output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ gosec -tag debug,ignore ./...
 
 ### Output formats
 
-gosec currently supports text, json, yaml, csv, sonarqube and JUnit XML output formats. By default
+gosec currently supports text, json, yaml, csv, sonarqube, JUnit XML and golint output formats. By default
 results will be reported to stdout, but can also be written to an output
 file. The output format is controlled by the '-fmt' flag, and the output file is controlled by the '-out' flag as follows:
 

--- a/cmd/gosec/main.go
+++ b/cmd/gosec/main.go
@@ -73,7 +73,7 @@ var (
 	flagIgnoreNoSec = flag.Bool("nosec", false, "Ignores #nosec comments when set")
 
 	// format output
-	flagFormat = flag.String("fmt", "text", "Set output format. Valid options are: json, yaml, csv, junit-xml, html, sonarqube, or text")
+	flagFormat = flag.String("fmt", "text", "Set output format. Valid options are: json, yaml, csv, junit-xml, html, sonarqube, golint or text")
 
 	// #nosec alternative tag
 	flagAlternativeNoSec = flag.String("nosec-tag", "", "Set an alternative string for #nosec. Some examples: #dontanalyze, #falsepositive")

--- a/issue.go
+++ b/issue.go
@@ -83,6 +83,7 @@ type Issue struct {
 	File       string `json:"file"`       // File name we found it in
 	Code       string `json:"code"`       // Impacted code line
 	Line       string `json:"line"`       // Line number in file
+	Col        string `json:"column"`     // Column number in line
 }
 
 // MetaData is embedded in all gosec rules. The Severity, Confidence and What message
@@ -142,6 +143,8 @@ func NewIssue(ctx *Context, node ast.Node, ruleID, desc string, severity Score, 
 		line = fmt.Sprintf("%d-%d", start, end)
 	}
 
+	col := strconv.Itoa(fobj.Position(node.Pos()).Column)
+
 	// #nosec
 	if file, err := os.Open(fobj.Name()); err == nil {
 		defer file.Close()
@@ -156,6 +159,7 @@ func NewIssue(ctx *Context, node ast.Node, ruleID, desc string, severity Score, 
 	return &Issue{
 		File:       name,
 		Line:       line,
+		Col:        col,
 		RuleID:     ruleID,
 		What:       desc,
 		Confidence: confidence,

--- a/issue_test.go
+++ b/issue_test.go
@@ -41,6 +41,7 @@ var _ = Describe("Issue", func() {
 			Expect(issue).ShouldNot(BeNil())
 			Expect(issue.Code).Should(MatchRegexp(`"bar"`))
 			Expect(issue.Line).Should(Equal("2"))
+			Expect(issue.Col).Should(Equal("16"))
 			Expect(issue.Cwe.ID).Should(Equal(""))
 		})
 
@@ -84,6 +85,7 @@ var _ = Describe("Issue", func() {
 			Expect(issue).ShouldNot(BeNil())
 			Expect(issue.File).Should(MatchRegexp("foo.go"))
 			Expect(issue.Line).Should(MatchRegexp("3-4"))
+			Expect(issue.Col).Should(Equal("21"))
 		})
 
 		It("should maintain the provided severity score", func() {

--- a/output/formatter_test.go
+++ b/output/formatter_test.go
@@ -15,6 +15,7 @@ func createIssue(ruleID string, cwe gosec.Cwe) gosec.Issue {
 	return gosec.Issue{
 		File:       "/home/src/project/test.go",
 		Line:       "1",
+		Col:        "1",
 		RuleID:     ruleID,
 		What:       "test",
 		Confidence: gosec.High,
@@ -389,6 +390,19 @@ var _ = Describe("Formatter", func() {
 
 				expectation := stripString(expect.String())
 				Expect(result).To(ContainSubstring(expectation))
+			}
+		})
+		It("golint formatted report should contain the CWE mapping", func() {
+			for _, rule := range grules {
+				cwe := gosec.IssueToCWE[rule]
+				issue := createIssue(rule, cwe)
+				error := map[string][]gosec.Error{}
+
+				buf := new(bytes.Buffer)
+				CreateReport(buf, "golint", []string{}, []*gosec.Issue{&issue}, &gosec.Metrics{}, error)
+				pattern := "/home/src/project/test.go:1:1: [CWE-%s] test (Rule:%s, Severity:HIGH, Confidence:HIGH)\n"
+				expect := fmt.Sprintf(pattern, cwe.ID, rule)
+				Expect(string(buf.Bytes())).To(Equal(expect))
 			}
 		})
 	})


### PR DESCRIPTION
### What
- Add new output format (same format as golint)

### Why
- As written in issues below, golint is a very common lint tool for Go, So it's easy to integrate with other tools if gosec has this format.
Fixes https://github.com/securego/gosec/issues/423 https://github.com/securego/gosec/issues/424

