### PR TITLE
Adds sast-scan to self scan with gosec

### DIFF
--- a/.github/workflows/sastscan.yml
+++ b/.github/workflows/sastscan.yml
@@ -1,0 +1,23 @@
+name: SAST scan
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Perform sast-scan
+      uses: AppThreat/sast-scan-action@v1.0.2
+      env:
+        WORKSPACE: https://github.com/securego/gosec/blob/master
+      with:
+        output: reports
+      continue-on-error: true
+    - name: Upload scan reports
+      uses: actions/upload-artifact@v1.0.0
+      with:
+        name: sast-scan-reports
+        path: reports

--- a/.github/workflows/sastscan.yml
+++ b/.github/workflows/sastscan.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Perform sast-scan
-      uses: AppThreat/sast-scan-action@v1.0.2
+      uses: AppThreat/sast-scan-action@1.0.2
       env:
         WORKSPACE: https://github.com/securego/gosec/blob/master
       with:


### PR DESCRIPTION
This PR adds [sast-scan](https://github.com/AppThreat/sast-scan/) action which includes gosec and a number of other oss sast tools.

gosec has identified 2 medium issue against this repo as per the last run. (I am aware that there are #nosec comment against them and in the process of correcting the args) 

https://github.com/prabhu/gosec/commit/1411d03d03904ebea5b6b5ce53bff22e6d3911e2/checks?check_suite_id=399740953#step:4:92

To view the report, download the sast-scan-reports from artifacts and use any sarif viewer such as http://sarifviewer.azurewebsites.net/

Thank you for this project without which projects such as sast-scan would not be possible at all.