### PR TITLE
Add the Cgo files to the analysed files and ignore all non-Go files

### DIFF
--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -339,6 +339,21 @@ var _ = Describe("Analyzer", func() {
 			Expect(issues).Should(HaveLen(1))
 		})
 	})
+	It("should be able to analyze Cgo files", func() {
+		analyzer.LoadRules(rules.Generate().Builders())
+		sample := testutils.SampleCodeCgo[0]
+		source := sample.Code[0]
+
+		testPackage := testutils.NewTestPackage()
+		defer testPackage.Close()
+		testPackage.AddFile("main.go", source)
+		err := testPackage.Build()
+		Expect(err).ShouldNot(HaveOccurred())
+		err = analyzer.Process(buildTags, testPackage.Path)
+		Expect(err).ShouldNot(HaveOccurred())
+		issues, _, _ := analyzer.Report()
+		Expect(issues).Should(HaveLen(0))
+	})
 
 	Context("when parsing errors from a package", func() {
 

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -1541,4 +1541,49 @@ package main
 func main() {
   fmt.Println("no package imported error")
 }`}, 1, gosec.NewConfig()}}
+
+	// SampleCodeCgo - Cgo file sample
+	SampleCodeCgo = []CodeSample{{[]string{`
+package main
+
+import (
+        "fmt"
+        "unsafe"
+)
+
+/*
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+int printData(unsigned char *data) {
+    return printf("cData: %lu \"%s\"\n", (long unsigned int)strlen(data), data);
+}
+*/
+import "C"
+
+func main() {
+        // Allocate C data buffer.
+        width, height := 8, 2
+        lenData := width * height
+        // add string terminating null byte
+        cData := (*C.uchar)(C.calloc(C.size_t(lenData+1), C.sizeof_uchar))
+
+        // When no longer in use, free C allocations.
+        defer C.free(unsafe.Pointer(cData))
+
+        // Go slice reference to C data buffer,
+        // minus string terminating null byte
+        gData := (*[1 << 30]byte)(unsafe.Pointer(cData))[:lenData:lenData]
+
+        // Write and read cData via gData.
+        for i := range gData {
+                gData[i] = '.'
+        }
+        copy(gData[0:], "Data")
+        gData[len(gData)-1] = 'X'
+        fmt.Printf("gData: %d %q\n", len(gData), gData)
+        C.printData(cData)
+}
+`}, 0, gosec.NewConfig()}}
 )


### PR DESCRIPTION
A Cgo file seems to be expanded into 3 different files by the package loader 
which doesn't map to the original Cgo file. This files are only stored in the 
cached without a go extension. For now is safe bet to just ignore them to 
avoid false warnings which doesn't related directly to the original Cgo file. 

I haven't managed to find a way to get the AST of a Cgo file such that it can 
be reliably analysed.

related #408