### PR TITLE
feature(formatter/text): Add color option on text format

### DIFF
--- a/cmd/gosec/main.go
+++ b/cmd/gosec/main.go
@@ -190,7 +190,7 @@ func loadRules(include, exclude string) rules.RuleList {
 	return rules.Generate(filters...)
 }
 
-func saveOutput(filename, format string, paths []string, issues []*gosec.Issue, metrics *gosec.Metrics, errors map[string][]gosec.Error) error {
+func saveOutput(filename, format string, color bool, paths []string, issues []*gosec.Issue, metrics *gosec.Metrics, errors map[string][]gosec.Error) error {
 	rootPaths := []string{}
 	for _, path := range paths {
 		rootPath, err := gosec.RootPath(path)
@@ -205,12 +205,12 @@ func saveOutput(filename, format string, paths []string, issues []*gosec.Issue, 
 			return err
 		}
 		defer outfile.Close() // #nosec G307
-		err = output.CreateReport(outfile, format, rootPaths, issues, metrics, errors)
+		err = output.CreateReport(outfile, format, color, rootPaths, issues, metrics, errors)
 		if err != nil {
 			return err
 		}
 	} else {
-		err := output.CreateReport(os.Stdout, format, rootPaths, issues, metrics, errors)
+		err := output.CreateReport(os.Stdout, format, color, rootPaths, issues, metrics, errors)
 		if err != nil {
 			return err
 		}
@@ -358,7 +358,7 @@ func main() {
 	}
 
 	// Create output report
-	if err := saveOutput(*flagOutput, *flagFormat, flag.Args(), issues, metrics, errors); err != nil {
+	if err := saveOutput(*flagOutput, *flagFormat, *flagColor, flag.Args(), issues, metrics, errors); err != nil {
 		logger.Fatal(err)
 	}
 

--- a/cmd/gosec/main.go
+++ b/cmd/gosec/main.go
@@ -120,6 +120,9 @@ var (
 	// exlude the folders from scan
 	flagDirsExclude arrayFlags
 
+	// set color on text format output
+	flagColor = flag.Bool("color", false, "Enable colored output. Valid for text format")
+
 	logger *log.Logger
 )
 
@@ -280,6 +283,11 @@ func main() {
 		logger = log.New(ioutil.Discard, "", 0)
 	} else {
 		logger = log.New(logWriter, "[gosec] ", log.LstdFlags)
+	}
+
+	// Color flag is allowed for text format
+	if *flagColor && *flagFormat != "text" {
+		logger.Fatalf("cannot set color with %s format. Only text format is accepted", *flagFormat)
 	}
 
 	failSeverity, err := convertToScore(*flagSeverity)

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	golang.org/x/text v0.3.2 // indirect
 	golang.org/x/tools v0.0.0-20200331202046-9d5940d49312
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
+	gopkg.in/gookit/color.v1 v1.1.6
 	gopkg.in/yaml.v2 v2.2.8
 )
 

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogR
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
+gopkg.in/gookit/color.v1 v1.1.6 h1:5fB10p6AUFjhd2ayq9JgmJWr9WlTrguFdw3qlYtKNHk=
+gopkg.in/gookit/color.v1 v1.1.6/go.mod h1:IcEkFGaveVShJ+j8ew+jwe9epHyGpJ9IrptHmW3laVY=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=

--- a/issue.go
+++ b/issue.go
@@ -88,6 +88,11 @@ type Issue struct {
 	Col        string `json:"column"`     // Column number in line
 }
 
+// FileLocation point out the file path and line number in file
+func (i Issue) FileLocation() string {
+	return fmt.Sprintf("%s:%s", i.File, i.Line)
+}
+
 // MetaData is embedded in all gosec rules. The Severity, Confidence and What message
 // will be passed through to reported issues.
 type MetaData struct {

--- a/output/formatter.go
+++ b/output/formatter.go
@@ -26,6 +26,7 @@ import (
 	plainTemplate "text/template"
 
 	"github.com/securego/gosec/v2"
+	color "gopkg.in/gookit/color.v1"
 	"gopkg.in/yaml.v2"
 )
 
@@ -61,11 +62,15 @@ Golang errors in file: [{{ $filePath }}]:
   > {{ $issue.Code }}
 
 {{ end }}
-Summary:
+{{ notice "Summary:" }}
    Files: {{.Stats.NumFiles}}
    Lines: {{.Stats.NumLines}}
    Nosec: {{.Stats.NumNosec}}
-  Issues: {{.Stats.NumFound}}
+  Issues: {{ if eq .Stats.NumFound 0 }}
+	{{- success .Stats.NumFound }}
+	{{- else }}
+	{{- danger .Stats.NumFound }}
+	{{- end }}
 
 `
 
@@ -96,13 +101,15 @@ func CreateReport(w io.Writer, format string, rootPaths []string, issues []*gose
 	case "html":
 		err = reportFromHTMLTemplate(w, html, data)
 	case "text":
-		err = reportFromPlaintextTemplate(w, text, data)
+		enableColor := true
+		err = reportFromPlaintextTemplate(w, text, enableColor, data)
 	case "sonarqube":
 		err = reportSonarqube(rootPaths, w, data)
 	case "golint":
 		err = reportGolint(w, data)
 	default:
-		err = reportFromPlaintextTemplate(w, text, data)
+		enableColor := true
+		err = reportFromPlaintextTemplate(w, text, enableColor, data)
 	}
 	return err
 }
@@ -253,8 +260,11 @@ func reportJUnitXML(w io.Writer, data *reportInfo) error {
 	return nil
 }
 
-func reportFromPlaintextTemplate(w io.Writer, reportTemplate string, data *reportInfo) error {
-	t, e := plainTemplate.New("gosec").Parse(reportTemplate)
+func reportFromPlaintextTemplate(w io.Writer, reportTemplate string, enableColor bool, data *reportInfo) error {
+	t, e := plainTemplate.
+		New("gosec").
+		Funcs(plainTextFuncMap(enableColor)).
+		Parse(reportTemplate)
 	if e != nil {
 		return e
 	}
@@ -269,4 +279,21 @@ func reportFromHTMLTemplate(w io.Writer, reportTemplate string, data *reportInfo
 	}
 
 	return t.Execute(w, data)
+}
+
+func plainTextFuncMap(enableColor bool) plainTemplate.FuncMap {
+	if enableColor {
+		return plainTemplate.FuncMap{
+			"danger":  color.Danger.Render,
+			"notice":  color.Notice.Render,
+			"success": color.Success.Render,
+		}
+	}
+
+	// by default those functions return the given content untouched
+	return plainTemplate.FuncMap{
+		"danger":  fmt.Sprint,
+		"notice":  fmt.Sprint,
+		"success": fmt.Sprint,
+	}
 }

--- a/output/formatter.go
+++ b/output/formatter.go
@@ -82,7 +82,7 @@ type reportInfo struct {
 
 // CreateReport generates a report based for the supplied issues and metrics given
 // the specified format. The formats currently accepted are: json, yaml, csv, junit-xml, html, sonarqube, golint and text.
-func CreateReport(w io.Writer, format string, rootPaths []string, issues []*gosec.Issue, metrics *gosec.Metrics, errors map[string][]gosec.Error) error {
+func CreateReport(w io.Writer, format string, enableColor bool, rootPaths []string, issues []*gosec.Issue, metrics *gosec.Metrics, errors map[string][]gosec.Error) error {
 	data := &reportInfo{
 		Errors: errors,
 		Issues: issues,
@@ -101,14 +101,12 @@ func CreateReport(w io.Writer, format string, rootPaths []string, issues []*gose
 	case "html":
 		err = reportFromHTMLTemplate(w, html, data)
 	case "text":
-		enableColor := true
 		err = reportFromPlaintextTemplate(w, text, enableColor, data)
 	case "sonarqube":
 		err = reportSonarqube(rootPaths, w, data)
 	case "golint":
 		err = reportGolint(w, data)
 	default:
-		enableColor := true
 		err = reportFromPlaintextTemplate(w, text, enableColor, data)
 	}
 	return err

--- a/output/formatter.go
+++ b/output/formatter.go
@@ -76,7 +76,7 @@ type reportInfo struct {
 }
 
 // CreateReport generates a report based for the supplied issues and metrics given
-// the specified format. The formats currently accepted are: json, csv, html and text.
+// the specified format. The formats currently accepted are: json, yaml, csv, junit-xml, html, sonarqube, golint and text.
 func CreateReport(w io.Writer, format string, rootPaths []string, issues []*gosec.Issue, metrics *gosec.Metrics, errors map[string][]gosec.Error) error {
 	data := &reportInfo{
 		Errors: errors,

--- a/output/formatter_test.go
+++ b/output/formatter_test.go
@@ -262,7 +262,7 @@ var _ = Describe("Formatter", func() {
 				error := map[string][]gosec.Error{}
 
 				buf := new(bytes.Buffer)
-				err := CreateReport(buf, "csv", []string{}, []*gosec.Issue{&issue}, &gosec.Metrics{}, error)
+				err := CreateReport(buf, "csv", false, []string{}, []*gosec.Issue{&issue}, &gosec.Metrics{}, error)
 				Expect(err).ShouldNot(HaveOccurred())
 				pattern := "/home/src/project/test.go,1,test,HIGH,HIGH,testcode,CWE-%s\n"
 				expect := fmt.Sprintf(pattern, cwe.ID)
@@ -276,7 +276,7 @@ var _ = Describe("Formatter", func() {
 				error := map[string][]gosec.Error{}
 
 				buf := new(bytes.Buffer)
-				err := CreateReport(buf, "xml", []string{}, []*gosec.Issue{&issue}, &gosec.Metrics{NumFiles: 0, NumLines: 0, NumNosec: 0, NumFound: 0}, error)
+				err := CreateReport(buf, "xml", false, []string{}, []*gosec.Issue{&issue}, &gosec.Metrics{NumFiles: 0, NumLines: 0, NumNosec: 0, NumFound: 0}, error)
 				Expect(err).ShouldNot(HaveOccurred())
 				pattern := "Results:\n\n\n[/home/src/project/test.go:1] - %s (CWE-%s): test (Confidence: HIGH, Severity: HIGH)\n  > testcode\n\n\nSummary:\n   Files: 0\n   Lines: 0\n   Nosec: 0\n  Issues: 0\n\n"
 				expect := fmt.Sprintf(pattern, rule, cwe.ID)
@@ -296,7 +296,7 @@ var _ = Describe("Formatter", func() {
 				err := enc.Encode(data)
 				Expect(err).ShouldNot(HaveOccurred())
 				buf := new(bytes.Buffer)
-				err = CreateReport(buf, "json", []string{}, []*gosec.Issue{&issue}, &gosec.Metrics{}, error)
+				err = CreateReport(buf, "json", false, []string{}, []*gosec.Issue{&issue}, &gosec.Metrics{}, error)
 				Expect(err).ShouldNot(HaveOccurred())
 				result := stripString(buf.String())
 				expectation := stripString(expect.String())
@@ -316,7 +316,7 @@ var _ = Describe("Formatter", func() {
 				err := enc.Encode(data)
 				Expect(err).ShouldNot(HaveOccurred())
 				buf := new(bytes.Buffer)
-				err = CreateReport(buf, "html", []string{}, []*gosec.Issue{&issue}, &gosec.Metrics{}, error)
+				err = CreateReport(buf, "html", false, []string{}, []*gosec.Issue{&issue}, &gosec.Metrics{}, error)
 				Expect(err).ShouldNot(HaveOccurred())
 				result := stripString(buf.String())
 				expectation := stripString(expect.String())
@@ -336,7 +336,7 @@ var _ = Describe("Formatter", func() {
 				err := enc.Encode(data)
 				Expect(err).ShouldNot(HaveOccurred())
 				buf := new(bytes.Buffer)
-				err = CreateReport(buf, "yaml", []string{}, []*gosec.Issue{&issue}, &gosec.Metrics{}, error)
+				err = CreateReport(buf, "yaml", false, []string{}, []*gosec.Issue{&issue}, &gosec.Metrics{}, error)
 				Expect(err).ShouldNot(HaveOccurred())
 				result := stripString(buf.String())
 				expectation := stripString(expect.String())
@@ -356,7 +356,7 @@ var _ = Describe("Formatter", func() {
 				err := enc.Encode(data)
 				Expect(err).ShouldNot(HaveOccurred())
 				buf := new(bytes.Buffer)
-				err = CreateReport(buf, "junit-xml", []string{}, []*gosec.Issue{&issue}, &gosec.Metrics{}, error)
+				err = CreateReport(buf, "junit-xml", false, []string{}, []*gosec.Issue{&issue}, &gosec.Metrics{}, error)
 				Expect(err).ShouldNot(HaveOccurred())
 				expectation := stripString(fmt.Sprintf("[/home/src/project/test.go:1] - test (Confidence: 2, Severity: 2, CWE: %s)", cwe.ID))
 				result := stripString(buf.String())
@@ -376,7 +376,7 @@ var _ = Describe("Formatter", func() {
 				err := enc.Encode(data)
 				Expect(err).ShouldNot(HaveOccurred())
 				buf := new(bytes.Buffer)
-				err = CreateReport(buf, "text", []string{}, []*gosec.Issue{&issue}, &gosec.Metrics{}, error)
+				err = CreateReport(buf, "text", false, []string{}, []*gosec.Issue{&issue}, &gosec.Metrics{}, error)
 				Expect(err).ShouldNot(HaveOccurred())
 				expectation := stripString(fmt.Sprintf("[/home/src/project/test.go:1] - %s (CWE-%s): test (Confidence: HIGH, Severity: HIGH)", rule, cwe.ID))
 				result := stripString(buf.String())
@@ -389,7 +389,7 @@ var _ = Describe("Formatter", func() {
 				issue := createIssue(rule, cwe)
 				error := map[string][]gosec.Error{}
 				buf := new(bytes.Buffer)
-				err := CreateReport(buf, "sonarqube", []string{"/home/src/project"}, []*gosec.Issue{&issue}, &gosec.Metrics{}, error)
+				err := CreateReport(buf, "sonarqube", false, []string{"/home/src/project"}, []*gosec.Issue{&issue}, &gosec.Metrics{}, error)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				result := stripString(buf.String())
@@ -410,7 +410,7 @@ var _ = Describe("Formatter", func() {
 				error := map[string][]gosec.Error{}
 
 				buf := new(bytes.Buffer)
-				err := CreateReport(buf, "golint", []string{}, []*gosec.Issue{&issue}, &gosec.Metrics{}, error)
+				err := CreateReport(buf, "golint", false, []string{}, []*gosec.Issue{&issue}, &gosec.Metrics{}, error)
 				Expect(err).ShouldNot(HaveOccurred())
 				pattern := "/home/src/project/test.go:1:1: [CWE-%s] test (Rule:%s, Severity:HIGH, Confidence:HIGH)\n"
 				expect := fmt.Sprintf(pattern, cwe.ID, rule)


### PR DESCRIPTION
## Description

Add a flag `-color` to support colored output. This is only available for text output format.
Using the [gookit/color](https://github.com/gookit/color) to have support for a range of OS.

## Basic Examples

### Text format without color flag on
<img width="1200" alt="format-text-without-color" src="https://user-images.githubusercontent.com/355174/79030567-fc239c80-7b6f-11ea-98e2-451d5571ee60.png">

### Using other format than _-fmt=text_
It's not allowed to use that flag with other format types

<img width="750" alt="format-html-with-color" src="https://user-images.githubusercontent.com/355174/79030333-e82b6b00-7b6e-11ea-9122-0460f59bd32f.png">

### No Issues
The `Summary` and `Issues` sections are presented colored

<img width="740" alt="no-issues" src="https://user-images.githubusercontent.com/355174/79030313-d0ec7d80-7b6e-11ea-9111-ea514da6c125.png">

## With Issues

The file path is presented colored and also the `Issues` number is red when it's more than zero

### `High` severity
<img width="1160" alt="example-high" src="https://user-images.githubusercontent.com/355174/79030536-d3030c00-7b6f-11ea-90d9-5bc2a6b06d8b.png">

### `Medium` severity
<img width="1160" alt="example-medium" src="https://user-images.githubusercontent.com/355174/79030668-853ad380-7b70-11ea-9cea-7524caac54e4.png">

### `Low` severity
<img width="1160" alt="example-low" src="https://user-images.githubusercontent.com/355174/79030679-91bf2c00-7b70-11ea-9c04-bb271fd5fc61.png">

## Other examples

Running full example using different apps

### Terminal App (Mac)
<img width="1154" alt="full-terminal" src="https://user-images.githubusercontent.com/355174/79030227-69363280-7b6e-11ea-953b-9fa90a2b6b35.png">

###  iTerm (Mac)
<img width="1154" alt="full-iterm" src="https://user-images.githubusercontent.com/355174/79030232-6fc4aa00-7b6e-11ea-9e15-b71824f4e68f.png">

closes #456 