### PR TITLE
Display a sponsor button in the repository

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: [ccojocar, gcmurphy]


### PR DESCRIPTION
Enable the funding button in the project following https://help.github.com/en/github/administering-a-repository/displaying-a-sponsor-button-in-your-repository