### PR TITLE
Bug fix 393 - BuildTags are propagated

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -158,7 +158,7 @@ func (gosec *Analyzer) load(pkgPath string, conf *packages.Config) ([]*packages.
 	}
 
 	gosec.logger.Println("Import directory:", abspath)
-	// step 1/3 create build context
+	// step 1/3 create build context.
 	buildD := build.Default
 	// step 2/3: add build tags to get env dependent files into basePackage.
 	buildD.BuildTags = conf.BuildFlags

--- a/analyzer.go
+++ b/analyzer.go
@@ -146,14 +146,9 @@ func (gosec *Analyzer) Process(buildTags []string, packagePaths ...string) error
 }
 
 func (gosec *Analyzer) pkgConfig(buildTags []string) *packages.Config {
-	flags := []string{}
-	if len(buildTags) > 0 {
-		tagsFlag := "-tags=" + strings.Join(buildTags, " ")
-		flags = append(flags, tagsFlag)
-	}
 	return &packages.Config{
 		Mode:       LoadMode,
-		BuildFlags: flags,
+		BuildFlags: buildTags,
 		Tests:      gosec.tests,
 	}
 }
@@ -166,7 +161,9 @@ func (gosec *Analyzer) load(pkgPath string, conf *packages.Config) ([]*packages.
 	}
 
 	gosec.logger.Println("Import directory:", abspath)
-	basePackage, err := build.Default.ImportDir(pkgPath, build.ImportComment)
+	d := build.Default
+	d.BuildTags = conf.BuildFlags
+	basePackage, err := d.ImportDir(pkgPath, build.IgnoreVendor)
 	if err != nil {
 		return []*packages.Package{}, fmt.Errorf("importing dir %q: %v", pkgPath, err)
 	}

--- a/analyzer.go
+++ b/analyzer.go
@@ -159,6 +159,7 @@ func (gosec *Analyzer) load(pkgPath string, conf *packages.Config) ([]*packages.
 
 	gosec.logger.Println("Import directory:", abspath)
 	buildD := build.Default
+	// step 1/2: add build tags to get env dependent files into basePackage.
 	buildD.BuildTags = conf.BuildFlags
 	basePackage, err := buildD.ImportDir(pkgPath, build.ImportComment)
 	if err != nil {
@@ -182,6 +183,8 @@ func (gosec *Analyzer) load(pkgPath string, conf *packages.Config) ([]*packages.
 		}
 	}
 
+	// step/2/ remove build tags from conf to proceed build correctly.
+	conf.BuildFlags = nil
 	pkgs, err := packages.Load(conf, packageFiles...)
 	if err != nil {
 		return []*packages.Package{}, fmt.Errorf("loading files from package %q: %v", pkgPath, err)

--- a/analyzer.go
+++ b/analyzer.go
@@ -158,8 +158,9 @@ func (gosec *Analyzer) load(pkgPath string, conf *packages.Config) ([]*packages.
 	}
 
 	gosec.logger.Println("Import directory:", abspath)
+	// step 1/3 create build context
 	buildD := build.Default
-	// step 1/2: add build tags to get env dependent files into basePackage.
+	// step 2/3: add build tags to get env dependent files into basePackage.
 	buildD.BuildTags = conf.BuildFlags
 	basePackage, err := buildD.ImportDir(pkgPath, build.ImportComment)
 	if err != nil {
@@ -183,7 +184,7 @@ func (gosec *Analyzer) load(pkgPath string, conf *packages.Config) ([]*packages.
 		}
 	}
 
-	// step/2/ remove build tags from conf to proceed build correctly.
+	// step 3/3 remove build tags from conf to proceed build correctly.
 	conf.BuildFlags = nil
 	pkgs, err := packages.Load(conf, packageFiles...)
 	if err != nil {


### PR DESCRIPTION
Based on this issue: #393 (comment)

BuildTags are propagated as BuildFlags. Tested with the provided code examples (#393).

fixes #393 
