### PR TITLE
Extend the code snippet included in the issue and refactored how the code snippet is printed

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -15,9 +15,12 @@
 package gosec
 
 import (
+	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"go/ast"
+	"go/token"
 	"os"
 	"strconv"
 )
@@ -33,6 +36,10 @@ const (
 	// High severity or confidence
 	High
 )
+
+// SnippetOffset defines the number of lines captured before
+// the beginning and after the end of a code snippet
+const SnippetOffset = 1
 
 // Cwe id and url
 type Cwe struct {
@@ -126,41 +133,53 @@ func (c Score) String() string {
 
 func codeSnippet(file *os.File, start int64, end int64, n ast.Node) (string, error) {
 	if n == nil {
-		return "", fmt.Errorf("Invalid AST node provided")
+		return "", fmt.Errorf("invalid AST node provided")
 	}
+	var pos int64
+	var buf bytes.Buffer
+	scanner := bufio.NewScanner(file)
+	scanner.Split(bufio.ScanLines)
+	for scanner.Scan() {
+		pos++
+		if pos > end {
+			break
+		} else if pos >= start && pos <= end {
+			code := fmt.Sprintf("%d: %s\n", pos, scanner.Text())
+			buf.WriteString(code)
+		}
+	}
+	return buf.String(), nil
+}
 
-	size := (int)(end - start)    // Go bug, os.File.Read should return int64 ...
-	_, err := file.Seek(start, 0) // #nosec
-	if err != nil {
-		return "", fmt.Errorf("move to the beginning of file: %v", err)
+func codeSnippetStartLine(node ast.Node, fobj *token.File) int64 {
+	s := (int64)(fobj.Line(node.Pos()))
+	if s-SnippetOffset > 0 {
+		return s - SnippetOffset
 	}
+	return s
+}
 
-	buf := make([]byte, size)
-	if nread, err := file.Read(buf); err != nil || nread != size {
-		return "", fmt.Errorf("Unable to read code")
-	}
-	return string(buf), nil
+func codeSnippetEndLine(node ast.Node, fobj *token.File) int64 {
+	e := (int64)(fobj.Line(node.End()))
+	return e + SnippetOffset
 }
 
 // NewIssue creates a new Issue
 func NewIssue(ctx *Context, node ast.Node, ruleID, desc string, severity Score, confidence Score) *Issue {
-	var code string
 	fobj := ctx.FileSet.File(node.Pos())
 	name := fobj.Name()
-
 	start, end := fobj.Line(node.Pos()), fobj.Line(node.End())
 	line := strconv.Itoa(start)
 	if start != end {
 		line = fmt.Sprintf("%d-%d", start, end)
 	}
-
 	col := strconv.Itoa(fobj.Position(node.Pos()).Column)
 
-	// #nosec
+	var code string
 	if file, err := os.Open(fobj.Name()); err == nil {
-		defer file.Close()
-		s := (int64)(fobj.Position(node.Pos()).Offset) // Go bug, should be int64
-		e := (int64)(fobj.Position(node.End()).Offset) // Go bug, should be int64
+		defer file.Close() // #nosec
+		s := codeSnippetStartLine(node, fobj)
+		e := codeSnippetEndLine(node, fobj)
 		code, err = codeSnippet(file, s, e, node)
 		if err != nil {
 			code = err.Error()

--- a/issue.go
+++ b/issue.go
@@ -131,6 +131,7 @@ func (c Score) String() string {
 	return "UNDEFINED"
 }
 
+// codeSnippet extracts a code snippet based on the ast reference
 func codeSnippet(file *os.File, start int64, end int64, n ast.Node) (string, error) {
 	if n == nil {
 		return "", fmt.Errorf("invalid AST node provided")

--- a/output/formatter.go
+++ b/output/formatter.go
@@ -322,6 +322,7 @@ func highlight(t string, s gosec.Score) string {
 	}
 }
 
+// printCodeSnippet prints the code snippet from the issue by adding a marker to the affected line
 func printCodeSnippet(issue *gosec.Issue) string {
 	scanner := bufio.NewScanner(strings.NewReader(issue.Code))
 	var buf bytes.Buffer

--- a/output/formatter.go
+++ b/output/formatter.go
@@ -324,16 +324,38 @@ func highlight(t string, s gosec.Score) string {
 
 // printCodeSnippet prints the code snippet from the issue by adding a marker to the affected line
 func printCodeSnippet(issue *gosec.Issue) string {
+	start, end := parseLine(issue.Line)
 	scanner := bufio.NewScanner(strings.NewReader(issue.Code))
 	var buf bytes.Buffer
+	line := start
 	for scanner.Scan() {
 		codeLine := scanner.Text()
-		if strings.HasPrefix(codeLine, issue.Line) {
+		if strings.HasPrefix(codeLine, strconv.Itoa(line)) && line <= end {
 			codeLine = "  > " + codeLine + "\n"
+			line++
 		} else {
 			codeLine = "    " + codeLine + "\n"
 		}
 		buf.WriteString(codeLine)
 	}
 	return buf.String()
+}
+
+// parseLine extract the start and the end line numbers from a issue line
+func parseLine(line string) (int, int) {
+	parts := strings.Split(line, "-")
+	start := parts[0]
+	end := start
+	if len(parts) > 1 {
+		end = parts[1]
+	}
+	s, err := strconv.Atoi(start)
+	if err != nil {
+		return -1, -1
+	}
+	e, err := strconv.Atoi(end)
+	if err != nil {
+		return -1, -1
+	}
+	return s, e
 }

--- a/output/formatter_test.go
+++ b/output/formatter_test.go
@@ -21,7 +21,7 @@ func createIssue(ruleID string, cwe gosec.Cwe) gosec.Issue {
 		What:       "test",
 		Confidence: gosec.High,
 		Severity:   gosec.High,
-		Code:       "testcode",
+		Code:       "1: testcode",
 		Cwe:        cwe,
 	}
 }
@@ -264,7 +264,7 @@ var _ = Describe("Formatter", func() {
 				buf := new(bytes.Buffer)
 				err := CreateReport(buf, "csv", false, []string{}, []*gosec.Issue{&issue}, &gosec.Metrics{}, error)
 				Expect(err).ShouldNot(HaveOccurred())
-				pattern := "/home/src/project/test.go,1,test,HIGH,HIGH,testcode,CWE-%s\n"
+				pattern := "/home/src/project/test.go,1,test,HIGH,HIGH,1: testcode,CWE-%s\n"
 				expect := fmt.Sprintf(pattern, cwe.ID)
 				Expect(string(buf.String())).To(Equal(expect))
 			}
@@ -278,7 +278,7 @@ var _ = Describe("Formatter", func() {
 				buf := new(bytes.Buffer)
 				err := CreateReport(buf, "xml", false, []string{}, []*gosec.Issue{&issue}, &gosec.Metrics{NumFiles: 0, NumLines: 0, NumNosec: 0, NumFound: 0}, error)
 				Expect(err).ShouldNot(HaveOccurred())
-				pattern := "Results:\n\n\n[/home/src/project/test.go:1] - %s (CWE-%s): test (Confidence: HIGH, Severity: HIGH)\n  > testcode\n\n\nSummary:\n   Files: 0\n   Lines: 0\n   Nosec: 0\n  Issues: 0\n\n"
+				pattern := "Results:\n\n\n[/home/src/project/test.go:1] - %s (CWE-%s): test (Confidence: HIGH, Severity: HIGH)\n  > 1: testcode\n\n\n\nSummary:\n   Files: 0\n   Lines: 0\n   Nosec: 0\n  Issues: 0\n\n"
 				expect := fmt.Sprintf(pattern, rule, cwe.ID)
 				Expect(string(buf.String())).To(Equal(expect))
 			}


### PR DESCRIPTION
fixes #268

This will capture 3 lines around the place where the issue occurs. The output looks something like:
```
[/Users/cosmin/go/src/github.com/securego/gosec/issue.go:180] - G307 (CWE-703): Deferring unsafe method "Close" on type "*os.File" (Confidence: HIGH, Severity: MEDIUM)
    179:        if file, err := os.Open(fobj.Name()); err == nil {
  > 180:                defer file.Close()
    181:                s := codeSnippetStartLine(node, fobj)



Summary:
   Files: 50
   Lines: 8069
   Nosec: 21
  Issues: 1
```

Also it marks properly a multiline finding:
```
[/Users/cosmin/go/src/github.com/securego/gosec/issue.go:170-171] - G102 (CWE-200): Binds to all network interfaces (Confidence: HIGH, Severity: MEDIUM)
    169: func multiline() {
  > 170:        _, _ = net.Listen("tcp",
  > 171:                "0.0.0.0:2000")
    172: }
```

In this way, it seems easier to figure out the place where the security issue is detected.