### PR TITLE
Change naming rule from blacklist to blocklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ wget -O - -q https://raw.githubusercontent.com/securego/gosec/master/install.sh 
 # then you will have to download a tar.gz file for your operating system instead of a binary file
 wget https://github.com/securego/gosec/releases/download/vX.Y.Z/gosec_vX.Y.Z_OS.tar.gz
 
-# The file will be in the current folder where you run the command 
+# The file will be in the current folder where you run the command
 # and you can check the checksum like this
 echo "<check sum from the check sum file>  gosec_vX.Y.Z_OS.tar.gz" | sha256sum -c -
 
@@ -66,7 +66,7 @@ jobs:
     env:
       GO111MODULE: on
     steps:
-      - name: Checkout Source 
+      - name: Checkout Source
         uses: actions/checkout@v2
       - name: Run Gosec Security Scanner
         uses: securego/gosec@master
@@ -114,11 +114,11 @@ directory you can supply `./...` as the input argument.
 - G402: Look for bad TLS connection settings
 - G403: Ensure minimum RSA key length of 2048 bits
 - G404: Insecure random number source (rand)
-- G501: Import blacklist: crypto/md5
-- G502: Import blacklist: crypto/des
-- G503: Import blacklist: crypto/rc4
-- G504: Import blacklist: net/http/cgi
-- G505: Import blacklist: crypto/sha1
+- G501: Import blocklist: crypto/md5
+- G502: Import blocklist: crypto/des
+- G503: Import blocklist: crypto/rc4
+- G504: Import blocklist: net/http/cgi
+- G505: Import blocklist: crypto/sha1
 - G601: Implicit memory aliasing of items from a range statement
 
 ### Retired rules
@@ -161,7 +161,7 @@ A number of global settings can be provided in a configuration file as follows:
 # Run with a global configuration file
 $ gosec -conf config.json .
 ```
-Also some rules accept configuration. For instance on rule `G104`, it is possible to define packages along with a list 
+Also some rules accept configuration. For instance on rule `G104`, it is possible to define packages along with a list
 of functions which will be skipped when auditing the not checked errors:
 
 ```JSON
@@ -186,14 +186,14 @@ You can also configure the hard-coded credentials rule `G101` with additional pa
 }
 ```
 
-### Dependencies 
+### Dependencies
 
 gosec will fetch automatically the dependencies of the code which is being analyzed when go module is turned on (e.g.` GO111MODULE=on`). If this is not the case,
 the dependencies need to be explicitly downloaded by running the `go get -d` command before the scan.
 
 ### Excluding test files and folders
 
-gosec will ignore test files across all packages and any dependencies in your vendor directory. 
+gosec will ignore test files across all packages and any dependencies in your vendor directory.
 
 The scanning of test files can be enabled with the following flag:
 
@@ -233,7 +233,7 @@ func main(){
 ```
 
 When a specific false positive has been identified and verified as safe, you may wish to suppress only that single rule (or a specific set of rules)
-within a section of code, while continuing to scan for other problems. To do this, you can list the rule(s) to be suppressed within 
+within a section of code, while continuing to scan for other problems. To do this, you can list the rule(s) to be suppressed within
 the `#nosec` annotation, e.g: `/* #nosec G401 */` or `// #nosec G201 G202 G203`
 
 In some cases you may also want to revisit places where `#nosec` annotations
@@ -300,7 +300,7 @@ You can also build locally the docker image by using the command:
 make image
 ```
 
-You can run the `gosec` tool in a container against your local Go project. You only have to mount the project 
+You can run the `gosec` tool in a container against your local Go project. You only have to mount the project
 into a volume as follows:
 
 ```bash
@@ -327,4 +327,4 @@ This will generate the `rules/tls_config.go` file which will contain the current
 
 ## Who is using gosec?
 
-This is a [list](USERS.md) with some of the gosec's users. 
+This is a [list](USERS.md) with some of the gosec's users.

--- a/rules/blacklist.go
+++ b/rules/blacklist.go
@@ -21,9 +21,9 @@ import (
 	"github.com/securego/gosec/v2"
 )
 
-type blacklistedImport struct {
+type blocklistedImport struct {
 	gosec.MetaData
-	Blacklisted map[string]string
+	Blocklisted map[string]string
 }
 
 func unquote(original string) string {
@@ -32,63 +32,63 @@ func unquote(original string) string {
 	return strings.TrimRight(copy, `"`)
 }
 
-func (r *blacklistedImport) ID() string {
+func (r *blocklistedImport) ID() string {
 	return r.MetaData.ID
 }
 
-func (r *blacklistedImport) Match(n ast.Node, c *gosec.Context) (*gosec.Issue, error) {
+func (r *blocklistedImport) Match(n ast.Node, c *gosec.Context) (*gosec.Issue, error) {
 	if node, ok := n.(*ast.ImportSpec); ok {
-		if description, ok := r.Blacklisted[unquote(node.Path.Value)]; ok {
+		if description, ok := r.Blocklisted[unquote(node.Path.Value)]; ok {
 			return gosec.NewIssue(c, node, r.ID(), description, r.Severity, r.Confidence), nil
 		}
 	}
 	return nil, nil
 }
 
-// NewBlacklistedImports reports when a blacklisted import is being used.
+// NewBlocklistedImports reports when a blocklisted import is being used.
 // Typically when a deprecated technology is being used.
-func NewBlacklistedImports(id string, conf gosec.Config, blacklist map[string]string) (gosec.Rule, []ast.Node) {
-	return &blacklistedImport{
+func NewBlocklistedImports(id string, conf gosec.Config, blocklist map[string]string) (gosec.Rule, []ast.Node) {
+	return &blocklistedImport{
 		MetaData: gosec.MetaData{
 			ID:         id,
 			Severity:   gosec.Medium,
 			Confidence: gosec.High,
 		},
-		Blacklisted: blacklist,
+		Blocklisted: blocklist,
 	}, []ast.Node{(*ast.ImportSpec)(nil)}
 }
 
-// NewBlacklistedImportMD5 fails if MD5 is imported
-func NewBlacklistedImportMD5(id string, conf gosec.Config) (gosec.Rule, []ast.Node) {
-	return NewBlacklistedImports(id, conf, map[string]string{
-		"crypto/md5": "Blacklisted import crypto/md5: weak cryptographic primitive",
+// NewBlocklistedImportMD5 fails if MD5 is imported
+func NewBlocklistedImportMD5(id string, conf gosec.Config) (gosec.Rule, []ast.Node) {
+	return NewBlocklistedImports(id, conf, map[string]string{
+		"crypto/md5": "Blocklisted import crypto/md5: weak cryptographic primitive",
 	})
 }
 
-// NewBlacklistedImportDES fails if DES is imported
-func NewBlacklistedImportDES(id string, conf gosec.Config) (gosec.Rule, []ast.Node) {
-	return NewBlacklistedImports(id, conf, map[string]string{
-		"crypto/des": "Blacklisted import crypto/des: weak cryptographic primitive",
+// NewBlocklistedImportDES fails if DES is imported
+func NewBlocklistedImportDES(id string, conf gosec.Config) (gosec.Rule, []ast.Node) {
+	return NewBlocklistedImports(id, conf, map[string]string{
+		"crypto/des": "Blocklisted import crypto/des: weak cryptographic primitive",
 	})
 }
 
-// NewBlacklistedImportRC4 fails if DES is imported
-func NewBlacklistedImportRC4(id string, conf gosec.Config) (gosec.Rule, []ast.Node) {
-	return NewBlacklistedImports(id, conf, map[string]string{
-		"crypto/rc4": "Blacklisted import crypto/rc4: weak cryptographic primitive",
+// NewBlocklistedImportRC4 fails if DES is imported
+func NewBlocklistedImportRC4(id string, conf gosec.Config) (gosec.Rule, []ast.Node) {
+	return NewBlocklistedImports(id, conf, map[string]string{
+		"crypto/rc4": "Blocklisted import crypto/rc4: weak cryptographic primitive",
 	})
 }
 
-// NewBlacklistedImportCGI fails if CGI is imported
-func NewBlacklistedImportCGI(id string, conf gosec.Config) (gosec.Rule, []ast.Node) {
-	return NewBlacklistedImports(id, conf, map[string]string{
-		"net/http/cgi": "Blacklisted import net/http/cgi: Go versions < 1.6.3 are vulnerable to Httpoxy attack: (CVE-2016-5386)",
+// NewBlocklistedImportCGI fails if CGI is imported
+func NewBlocklistedImportCGI(id string, conf gosec.Config) (gosec.Rule, []ast.Node) {
+	return NewBlocklistedImports(id, conf, map[string]string{
+		"net/http/cgi": "Blocklisted import net/http/cgi: Go versions < 1.6.3 are vulnerable to Httpoxy attack: (CVE-2016-5386)",
 	})
 }
 
-// NewBlacklistedImportSHA1 fails if SHA1 is imported
-func NewBlacklistedImportSHA1(id string, conf gosec.Config) (gosec.Rule, []ast.Node) {
-	return NewBlacklistedImports(id, conf, map[string]string{
-		"crypto/sha1": "Blacklisted import crypto/sha1: weak cryptographic primitive",
+// NewBlocklistedImportSHA1 fails if SHA1 is imported
+func NewBlocklistedImportSHA1(id string, conf gosec.Config) (gosec.Rule, []ast.Node) {
+	return NewBlocklistedImports(id, conf, map[string]string{
+		"crypto/sha1": "Blocklisted import crypto/sha1: weak cryptographic primitive",
 	})
 }

--- a/rules/rulelist.go
+++ b/rules/rulelist.go
@@ -90,12 +90,12 @@ func Generate(filters ...RuleFilter) RuleList {
 		{"G403", "Ensure minimum RSA key length of 2048 bits", NewWeakKeyStrength},
 		{"G404", "Insecure random number source (rand)", NewWeakRandCheck},
 
-		// blacklist
-		{"G501", "Import blacklist: crypto/md5", NewBlacklistedImportMD5},
-		{"G502", "Import blacklist: crypto/des", NewBlacklistedImportDES},
-		{"G503", "Import blacklist: crypto/rc4", NewBlacklistedImportRC4},
-		{"G504", "Import blacklist: net/http/cgi", NewBlacklistedImportCGI},
-		{"G505", "Import blacklist: crypto/sha1", NewBlacklistedImportSHA1},
+		// blocklist
+		{"G501", "Import blocklist: crypto/md5", NewBlocklistedImportMD5},
+		{"G502", "Import blocklist: crypto/des", NewBlocklistedImportDES},
+		{"G503", "Import blocklist: crypto/rc4", NewBlocklistedImportRC4},
+		{"G504", "Import blocklist: net/http/cgi", NewBlocklistedImportCGI},
+		{"G505", "Import blocklist: crypto/sha1", NewBlocklistedImportSHA1},
 
 		// memory safety
 		{"G601", "Implicit memory aliasing in RangeStmt", NewImplicitAliasing},

--- a/rules/rules_test.go
+++ b/rules/rules_test.go
@@ -155,23 +155,23 @@ var _ = Describe("gosec rules", func() {
 			runner("G404", testutils.SampleCodeG404)
 		})
 
-		It("should detect blacklisted imports - MD5", func() {
+		It("should detect blocklisted imports - MD5", func() {
 			runner("G501", testutils.SampleCodeG501)
 		})
 
-		It("should detect blacklisted imports - DES", func() {
+		It("should detect blocklisted imports - DES", func() {
 			runner("G502", testutils.SampleCodeG502)
 		})
 
-		It("should detect blacklisted imports - RC4", func() {
+		It("should detect blocklisted imports - RC4", func() {
 			runner("G503", testutils.SampleCodeG503)
 		})
 
-		It("should detect blacklisted imports - CGI (httpoxy)", func() {
+		It("should detect blocklisted imports - CGI (httpoxy)", func() {
 			runner("G504", testutils.SampleCodeG504)
 		})
 
-		It("should detect blacklisted imports - SHA1", func() {
+		It("should detect blocklisted imports - SHA1", func() {
 			runner("G505", testutils.SampleCodeG505)
 		})
 

--- a/rules/weakcrypto.go
+++ b/rules/weakcrypto.go
@@ -22,7 +22,7 @@ import (
 
 type usesWeakCryptography struct {
 	gosec.MetaData
-	blacklist map[string][]string
+	blocklist map[string][]string
 }
 
 func (r *usesWeakCryptography) ID() string {
@@ -30,7 +30,7 @@ func (r *usesWeakCryptography) ID() string {
 }
 
 func (r *usesWeakCryptography) Match(n ast.Node, c *gosec.Context) (*gosec.Issue, error) {
-	for pkg, funcs := range r.blacklist {
+	for pkg, funcs := range r.blocklist {
 		if _, matched := gosec.MatchCallByPackage(n, c, pkg, funcs...); matched {
 			return gosec.NewIssue(c, n, r.ID(), r.What, r.Severity, r.Confidence), nil
 		}
@@ -46,7 +46,7 @@ func NewUsesWeakCryptography(id string, conf gosec.Config) (gosec.Rule, []ast.No
 	calls["crypto/sha1"] = []string{"New", "Sum"}
 	calls["crypto/rc4"] = []string{"NewCipher"}
 	rule := &usesWeakCryptography{
-		blacklist: calls,
+		blocklist: calls,
 		MetaData: gosec.MetaData{
 			ID:         id,
 			Severity:   gosec.Medium,

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -76,7 +76,7 @@ import "fmt"
 func main() {
 	var password string
 	if password == "f62e5bcda4fae4f82370da0c6f20697b8f8447ef" {
-		fmt.Println("password equality") 
+		fmt.Println("password equality")
 	}
 }`}, 1, gosec.NewConfig()},
 		{[]string{`
@@ -85,7 +85,7 @@ import "fmt"
 func main() {
 	var password string
 	if password != "f62e5bcda4fae4f82370da0c6f20697b8f8447ef" {
-		fmt.Println("password equality") 
+		fmt.Println("password equality")
 	}
 }`}, 1, gosec.NewConfig()},
 		{[]string{`
@@ -94,7 +94,7 @@ import "fmt"
 func main() {
 	var p string
 	if p != "f62e5bcda4fae4f82370da0c6f20697b8f8447ef" {
-		fmt.Println("password equality") 
+		fmt.Println("password equality")
 	}
 }`}, 0, gosec.NewConfig()}}
 
@@ -522,7 +522,7 @@ func main() {
     }
     fmt.Println(resp.Status)
 }`}, 0, gosec.NewConfig()}, {[]string{`
-// An exported variable declared a packaged scope is not secure 
+// An exported variable declared a packaged scope is not secure
 // because it can changed at any time
 package main
 
@@ -1672,34 +1672,34 @@ func check(e error) {
 }
 
 func main() {
-	
+
 	d1 := []byte("hello\ngo\n")
 	err := ioutil.WriteFile("/tmp/dat1", d1, 0744)
 	check(err)
 
 	allowed := ioutil.WriteFile("/tmp/dat1", d1, 0600)
 	check(allowed)
-	
+
 	f, err := os.Create("/tmp/dat2")
 	check(err)
-	
+
 	defer f.Close()
-	
+
 	d2 := []byte{115, 111, 109, 101, 10}
 	n2, err := f.Write(d2)
 
 	defer check(err)
 	fmt.Printf("wrote %d bytes\n", n2)
-	
+
 	n3, err := f.WriteString("writes\n")
 	fmt.Printf("wrote %d bytes\n", n3)
-	
+
 	f.Sync()
-	
+
 	w := bufio.NewWriter(f)
 	n4, err := w.WriteString("buffered\n")
 	fmt.Printf("wrote %d bytes\n", n4)
-	
+
 	w.Flush()
 
 }`}, 1, gosec.NewConfig()}}
@@ -1739,16 +1739,16 @@ func main() {
 
 	defer check(err)
 	fmt.Printf("wrote %d bytes\n", n2)
-	
+
 	n3, err := f.WriteString("writes\n")
 	fmt.Printf("wrote %d bytes\n", n3)
-	
+
 	f.Sync()
-	
+
 	w := bufio.NewWriter(f)
 	n4, err := w.WriteString("buffered\n")
 	fmt.Printf("wrote %d bytes\n", n4)
-	
+
 	w.Flush()
 
 }`}, 1, gosec.NewConfig()}}
@@ -1973,7 +1973,7 @@ func main() {
 	println(bad)
 }`}, 1, gosec.NewConfig()}}
 
-	// SampleCodeG501 - Blacklisted import MD5
+	// SampleCodeG501 - Blocklisted import MD5
 	SampleCodeG501 = []CodeSample{
 		{[]string{`
 package main
@@ -1988,7 +1988,7 @@ func main() {
 	}
 }`}, 1, gosec.NewConfig()}}
 
-	// SampleCodeG502 - Blacklisted import DES
+	// SampleCodeG502 - Blocklisted import DES
 	SampleCodeG502 = []CodeSample{
 		{[]string{`
 package main
@@ -2016,7 +2016,7 @@ func main() {
 	fmt.Println("Secret message is: %s", hex.EncodeToString(ciphertext))
 }`}, 1, gosec.NewConfig()}}
 
-	// SampleCodeG503 - Blacklisted import RC4
+	// SampleCodeG503 - Blocklisted import RC4
 	SampleCodeG503 = []CodeSample{{[]string{`
 package main
 import (
@@ -2035,7 +2035,7 @@ func main() {
 	fmt.Println("Secret message is: %s", hex.EncodeToString(ciphertext))
 }`}, 1, gosec.NewConfig()}}
 
-	// SampleCodeG504 - Blacklisted import CGI
+	// SampleCodeG504 - Blocklisted import CGI
 	SampleCodeG504 = []CodeSample{{[]string{`
 package main
 import (
@@ -2045,7 +2045,7 @@ import (
 func main() {
 	cgi.Serve(http.FileServer(http.Dir("/usr/share/doc")))
 }`}, 1, gosec.NewConfig()}}
-	// SampleCodeG505 - Blacklisted import SHA1
+	// SampleCodeG505 - Blocklisted import SHA1
 	SampleCodeG505 = []CodeSample{
 		{[]string{`
 package main


### PR DESCRIPTION
This PR changes naming from `blacklist` to `blocklist`.
some codes are changed by formatter. (e.g. trailing spaces)