### PR TITLE
Expand the arguments to a list of strings when they are provided as a single string

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN go mod download
 RUN make build-linux
 
 FROM golang:${GO_VERSION}-alpine 
-RUN apk add --update --no-cache ca-certificates git gcc libc-dev
+RUN apk add --update --no-cache ca-certificates bash git gcc libc-dev
 ENV GO111MODULE on
 COPY --from=builder /build/gosec /bin/gosec
-ENTRYPOINT ["/bin/gosec"]
+COPY entrypoint.sh /bin/entrypoint.sh
+ENTRYPOINT ["/bin/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Expand the arguments into an array of strings. This is requires because the GitHub action
+# provides all arguments concatenated as a single string.
+ARGS=("$@")
+
+/bin/gosec ${ARGS[*]}


### PR DESCRIPTION
The GitHub action provide the arguments as a single string to the docker container,
so we need to expand them in order for gosec to properly interpret them.


This allows us to run a scan in a container and provide the arguments either:
```
docker run -it --rm -v <path-out>:<path-in> -w <path-in> securego/gosec -fmt=json ./...
```

or (which it happens in the case of GitHub action execution)

```
docker run -it --rm -v <path-out>:<path-in> -w <path-in> securego/gosec "-fmt=json ./..."
```

fixes #502