### PR TITLE
feat: adds support for path.Join usage and tar archives in G305

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ directory you can supply `./...` as the input argument.
 - G302: Poor file permissions used with chmod
 - G303: Creating tempfile using a predictable path
 - G304: File path provided as taint input
-- G305: File traversal when extracting zip archive
+- G305: File traversal when extracting zip/tar archive
 - G306: Poor file permissions used when writing to a new file
 - G307: Deferring a method which returns an error
 - G401: Detect the usage of DES, RC4, MD5 or SHA1


### PR DESCRIPTION
Hey `gosec` folks! great work with this tool :) 

I've tested rule G305 against packages with known vulnerabilities, and some of them were not detected. Contributing the following to rule G305:
1. `path.Join` could be used instead of `filepath.Join`. Making sure these occurrences get detected
2. `tar` files are susceptible to path traversals, including them

PS: I didn't create a new rule for .tar files since it will be just a replica of G305 with one line differing. Happy to move it to a different rule if this makes more sense to you.