### PR TITLE
Update README file with some more details required to run successfully a scan with the docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ GOBIN ?= $(GOPATH)/bin
 GOLINT ?= $(GOBIN)/golint
 GOSEC ?= $(GOBIN)/gosec
 GINKGO ?= $(GOBIN)/ginkgo
-GO_VERSION = 1.14
+GO_VERSION = 1.15
 
 default:
 	$(MAKE) build

--- a/README.md
+++ b/README.md
@@ -304,8 +304,9 @@ You can run the `gosec` tool in a container against your local Go project. You o
 into a volume as follows:
 
 ```bash
-docker run -it -v <YOUR PROJECT PATH>/<PROJECT>:/<PROJECT> securego/gosec /<PROJECT>/...
+docker run --rm -it -w /<PROJECT>/ -v <YOUR PROJECT PATH>/<PROJECT>:/<PROJECT> securego/gosec /<PROJECT>/...
 ```
+**Note:** the current working directory needs to be set with `-w` option in order to get successfully resolved the dependencies from go module file 
 
 ### Generate TLS rule
 


### PR DESCRIPTION
The current working directory needs to be specified in the docker run
options in order for gosec to download the dependencies defined in the go
module file.

fixes #517