### PR TITLE
Fix wrong local installation info

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ jobs:
 ### Local Installation
 
 ```bash
-go get github.com/securego/gosec/v2/cmd/gosec
+go get github.com/securego/gosec/cmd/gosec
 ```
 
 ## Usage


### PR DESCRIPTION
There's no `v2` folder inside https://github.com/securego/gosec/tree/master/cmd.  
Local installation information was wrong, I fixed it.