### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ You can also configure the hard-coded credentials rule `G101` with additional pa
          "ignore_entropy": false,
          "entropy_threshold": "80.0",
          "per_char_threshold": "3.0",
-         "trucate": "32"
+         "truncate": "32"
     }
 }
 ```


### PR DESCRIPTION
Fixes minor typo for G101 configuration example: s/trucate/truncate