### PR TITLE
Assert that sample code compiles

### DIFF
--- a/rules/rules_test.go
+++ b/rules/rules_test.go
@@ -39,6 +39,7 @@ var _ = Describe("gosec rules", func() {
 				}
 				err := pkg.Build()
 				Expect(err).ShouldNot(HaveOccurred())
+				Expect(pkg.PrintErrors()).Should(BeZero())
 				err = analyzer.Process(buildTags, pkg.Path)
 				Expect(err).ShouldNot(HaveOccurred())
 				issues, _, _ := analyzer.Report()

--- a/testutils/pkg.go
+++ b/testutils/pkg.go
@@ -142,3 +142,8 @@ func (p *TestPackage) Pkgs() []*packages.Package {
 	}
 	return []*packages.Package{}
 }
+
+// PrintErrors prints to os.Stderr the accumulated errors of built packages
+func (p *TestPackage) PrintErrors() int {
+	return packages.PrintErrors(p.Pkgs())
+}

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -699,7 +699,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	_, err := io.Copy(os.Stdout, r)
+	_, err = io.Copy(os.Stdout, r)
 	if err != nil {
 		panic(err)
 	}
@@ -725,7 +725,7 @@ func main() {
 		panic(err)
 	}
 	buf := make([]byte, 8)
-	_, err := io.CopyBuffer(os.Stdout, r, buf)
+	_, err = io.CopyBuffer(os.Stdout, r, buf)
 	if err != nil {
 		panic(err)
 	}
@@ -1217,6 +1217,7 @@ func main() {
 // command line arguments as it's arguments is considered dangerous
 package main
 import (
+	"context"
 	"log"
 	"os"
 	"os/exec"
@@ -1311,7 +1312,7 @@ import (
 )
 
 func RunCmd(command string) {
-	_, err := syscall.StartProcess(command, []string{}, nil)
+	_, _, err := syscall.StartProcess(command, []string{}, nil)
 	if err != nil {
 	    fmt.Printf("Error: %v\n", err)
 	}
@@ -1597,7 +1598,7 @@ import (
 func main() {
     repoFile := "path_of_file"
     cleanRepoFile := filepath.Clean(repoFile)
-    byContext, err := os.OpenFile(cleanRepoFile, os.O_RDONLY, 0600)
+    _, err := os.OpenFile(cleanRepoFile, os.O_RDONLY, 0600)
     if err != nil {
         panic(err)
     }
@@ -1611,7 +1612,7 @@ import (
 )
 
 func openFile(filePath string) {
-	byContext, err := os.OpenFile(filepath.Clean(filePath), os.O_RDONLY, 0600)
+	_, err := os.OpenFile(filepath.Clean(filePath), os.O_RDONLY, 0600)
 	if err != nil {
 		panic(err)
 	}
@@ -1632,7 +1633,7 @@ import (
 func main() {
     repoFile := "path_of_file"
     relFile := filepath.Rel(repoFile)
-    byContext, err := os.OpenFile(relFile, os.O_RDONLY, 0600)
+    _, err := os.OpenFile(relFile, os.O_RDONLY, 0600)
     if err != nil {
         panic(err)
     }
@@ -2054,7 +2055,6 @@ func main() {
 	if err != nil {
 		fmt.Println(err)
 	}
-}
 }`}, 0, gosec.NewConfig()}}
 
 	// SampleCodeG403 - weak key strength
@@ -2109,7 +2109,7 @@ import (
 	"math/rand"
 )
 func main() {
-	gen := rand.New(rand.NewSource(10.4))
+	gen := rand.New(rand.NewSource(10))
 	bad := gen.Int()
 	println(bad)
 }`}, 1, gosec.NewConfig()},
@@ -2243,7 +2243,7 @@ func main() {
 	printVector()
 
 	zero, c_star, c := foo()
-	fmt.Printf("%d %v %s", zero, c_start, c)
+	fmt.Printf("%d %v %s", zero, c_star, c)
 }`,
 		}, 1, gosec.NewConfig()},
 		{[]string{`

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -582,7 +582,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"net/http/pprof"
 )
 
 func main() {
@@ -1632,8 +1631,11 @@ import (
 
 func main() {
     repoFile := "path_of_file"
-    relFile := filepath.Rel(repoFile)
-    _, err := os.OpenFile(relFile, os.O_RDONLY, 0600)
+	relFile, err := filepath.Rel("./", repoFile)
+	if err != nil {
+		panic(err)
+	}
+    _, err = os.OpenFile(relFile, os.O_RDONLY, 0600)
     if err != nil {
         panic(err)
     }
@@ -2229,10 +2231,11 @@ func printVector() {
 	fmt.Println()
 }
 
-func foo() (int, *string, string) {
+func foo() (int, **string, *string) {
 	for _, item := range vector {
 		return 0, &item, item
 	}
+	return 0, nil, nil
 }
 
 func main() {


### PR DESCRIPTION
This partially addresses #549. I fixed what seemed like typos to me, but there are still three failing specs that I'm not equipped to address:

1. `[Fail] gosec rules report correct errors for all samples [It] should detect pprof endpoint`

   The failing sample was introduced in 29341f6e. It seems to assert that importing `net/http/pprof` without an alias disables rule G108 when using `http.DefaultServeMux`. Is that the correct behavior?

   ```
   sample_1_0.go:8:2: "net/http/pprof" imported but not used
   ```

2. `[Fail] gosec rules report correct errors for all samples [It] should detect file path provided as taint input`

   The failing sample was introduced in f13b8bc6. It seems to assert that using `filepath.Rel` sanitizes path input, but that function returns an error. How should that error affect this sample?

   ```
   sample_8_0.go:11:37: too few arguments in call to filepath.Rel
   sample_8_0.go:11:16: cannot initialize 1 variables with 2 values
   ```

3. `[Fail] gosec rules report correct errors for all samples [It] should detect implicit aliasing in ForRange`

   The failing sample was introduced in ee3146e6. The `foo` function seems to be implemented for a `var vector []string`, while the rest of the sample is for a `var vector []*string`. What in this sample should change?

   ```
   sample_0_0.go:20:13: cannot use &item (value of type **string) as *string value in return statement
   sample_0_0.go:20:20: cannot use item (variable of type *string) as string value in return statement
   sample_0_0.go:22:1: missing return
   ```