### PR TITLE
Fix for sarif output, the results are an empty array if nothing is reported

### DIFF
--- a/output/formatter.go
+++ b/output/formatter.go
@@ -182,7 +182,7 @@ func convertToSarifReport(rootPaths []string, data *reportInfo) (*sarifReport, e
 
 	var rules []*sarifRule
 	var locations []*sarifLocation
-	var results []*sarifResult
+	results := []*sarifResult{}
 
 	for index, issue := range data.Issues {
 		rules = append(rules, buildSarifRule(issue))


### PR DESCRIPTION
Currently master is returning a `null` result when there are none returned, this doesn't match the JSON schema.

```json
{
	"$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
	"version": "2.1.0",
	"runs": [
		{
			"tool": {
				"driver": {
					"name": "gosec",
					"informationUri": "https://github.com/securego/gosec/"
				}
			},
			"results": null
		}
	]
}
```
The schema specifies results must be empty not null as below.

```json
        "results": {
          "description": "An array of result objects that will be merged with a separate run.",
          "type": "array",
          "minItems": 0,
          "uniqueItems": false,
          "default": [],
          "items": {
            "$ref": "#/definitions/result"
          }
        },
```