### PR TITLE
fix sarif add default configuration set to correct level

### DIFF
--- a/output/sarif_format.go
+++ b/output/sarif_format.go
@@ -21,12 +21,17 @@ type sarifProperties struct {
 }
 
 type sarifRule struct {
-	ID               string           `json:"id"`
-	Name             string           `json:"name"`
-	ShortDescription *sarifMessage    `json:"shortDescription"`
-	FullDescription  *sarifMessage    `json:"fullDescription"`
-	Help             *sarifMessage    `json:"help"`
-	Properties       *sarifProperties `json:"properties"`
+	ID                   string              `json:"id"`
+	Name                 string              `json:"name"`
+	ShortDescription     *sarifMessage       `json:"shortDescription"`
+	FullDescription      *sarifMessage       `json:"fullDescription"`
+	Help                 *sarifMessage       `json:"help"`
+	Properties           *sarifProperties    `json:"properties"`
+	DefaultConfiguration *sarifConfiguration `json:"defaultConfiguration"`
+}
+
+type sarifConfiguration struct {
+	Level sarifLevel `json:"level"`
 }
 
 type sarifArtifactLocation struct {
@@ -107,6 +112,9 @@ func buildSarifRule(issue *gosec.Issue) *sarifRule {
 		},
 		Properties: &sarifProperties{
 			Tags: []string{fmt.Sprintf("CWE-%s", issue.Cwe.ID), issue.Severity.String()},
+		},
+		DefaultConfiguration: &sarifConfiguration{
+			Level: getSarifLevel(issue.Severity.String()),
 		},
 	}
 }


### PR DESCRIPTION
i have been working on getting a good example of integration with the GitHub security scanning, which required a bit of research into how SARIF is processed by this service. One of the issues I have had is the checks seemed to default to warning so it wouldn't mark the PR as failed, this was resolved with the addition of a level on the rule.

For reference I got a hint about this information from https://github.com/hunt3rkillerz/Snyk-To-Sarif-JS/blob/main/snyk-to-sarif.js#L161-L163

![Screenshot from 2021-01-22 20-18-24](https://user-images.githubusercontent.com/50636/105471622-0bcf3480-5cef-11eb-8cd3-6a5fb45159cc.png)
