### PR TITLE
Fix sarif formatting issues

### DIFF
--- a/output/formatter.go
+++ b/output/formatter.go
@@ -209,6 +209,7 @@ func convertToSarifReport(rootPaths []string, data *reportInfo) (*sarifReport, e
 	tool := &sarifTool{
 		Driver: &sarifDriver{
 			Name:           "gosec",
+			Version:        "2.1.0",
 			InformationURI: "https://github.com/securego/gosec/",
 			Rules:          rules,
 		},

--- a/output/sarif_format.go
+++ b/output/sarif_format.go
@@ -93,7 +93,7 @@ type sarifReport struct {
 func buildSarifReport() *sarifReport {
 	return &sarifReport{
 		Version: "2.1.0",
-		Schema:  "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+		Schema:  "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
 		Runs:    []*sarifRun{},
 	}
 }

--- a/output/sarif_format.go
+++ b/output/sarif_format.go
@@ -2,9 +2,10 @@ package output
 
 import (
 	"fmt"
-	"github.com/securego/gosec/v2"
 	"strconv"
 	"strings"
+
+	"github.com/securego/gosec/v2"
 )
 
 type sarifLevel string
@@ -68,6 +69,7 @@ type sarifResult struct {
 
 type sarifDriver struct {
 	Name           string       `json:"name"`
+	Version        string       `json:"version"`
 	InformationURI string       `json:"informationUri"`
 	Rules          []*sarifRule `json:"rules,omitempty"`
 }


### PR DESCRIPTION
closes #563 

PR attempts to fix issues formatting issues with produced SARIF report.
Covered changes:
1. Use running tip version of the SARIF `$schema`
2. `tool` declares it's version. Used the same version as the `$schema`, might not be ideal but that fixes the immediate problem of invalid SARIF schema. The other option could be passing through commit SHA or gosec module version.
3. `tool`'s `rules` couldn't be duplicated
4. `results`' `locations` array should have only a single entry (https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#_Toc34317650). 