### PR TITLE
ISSUE-600 | Adding -stdout -verbose Flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,12 @@ file. The output format is controlled by the `-fmt` flag, and the output file is
 $ gosec -fmt=json -out=results.json *.go
 ```
 
+Results will be reported to stdout as well as to the provided output file by `-stdout` flag.
+```bash
+# Write output in json format to results.json as well as stdout
+$ gosec -fmt=json -out=results.json -stdout *.go
+```
+
 **Note:** gosec generates the [generic issue import format](https://docs.sonarqube.org/latest/analysis/generic-issue/) for SonarQube, and a report has to be imported into SonarQube using `sonar.externalIssuesReportPaths=path/to/gosec-report.json`.
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -302,8 +302,8 @@ file. The output format is controlled by the `-fmt` flag, and the output file is
 $ gosec -fmt=json -out=results.json *.go
 ```
 
-Results will be reported to stdout as well as to the provided output file by `-stdout` flag. The `-verbose` flag overrides the
-overrides the output format when stdout the results while saving them in the output file
+Results will be reported to stdout as well as to the provided output file by `-stdout` flag. The `-verbose` flag overrides the 
+output format when stdout the results while saving them in the output file
 ```bash
 # Write output in json format to results.json as well as stdout
 $ gosec -fmt=json -out=results.json -stdout *.go

--- a/README.md
+++ b/README.md
@@ -302,10 +302,14 @@ file. The output format is controlled by the `-fmt` flag, and the output file is
 $ gosec -fmt=json -out=results.json *.go
 ```
 
-Results will be reported to stdout as well as to the provided output file by `-stdout` flag.
+Results will be reported to stdout as well as to the provided output file by `-stdout` flag. The `-verbose` flag overrides the
+overrides the output format when stdout the results while saving them in the output file
 ```bash
 # Write output in json format to results.json as well as stdout
 $ gosec -fmt=json -out=results.json -stdout *.go
+
+# Overrides the output format to 'text' when stdout the results, while writing it to results.json
+$ gosec -fmt=json -out=results.json -stdout -verbose=text *.go
 ```
 
 **Note:** gosec generates the [generic issue import format](https://docs.sonarqube.org/latest/analysis/generic-issue/) for SonarQube, and a report has to be imported into SonarQube using `sonar.externalIssuesReportPaths=path/to/gosec-report.json`.

--- a/cmd/gosec/main.go
+++ b/cmd/gosec/main.go
@@ -120,6 +120,9 @@ var (
 	// stdout the results as well as write it in the output file
 	flagStdOut = flag.Bool("stdout", false, "Stdout the results as well as write it in the output file")
 
+	// overrides the output format when stdout the results while saving them in the output file
+	flagVerbose = flag.String("verbose", "", "Overrides the output format when stdout the results while saving them in the output file")
+
 	// exlude the folders from scan
 	flagDirsExclude arrayFlags
 
@@ -190,38 +193,25 @@ func loadRules(include, exclude string) rules.RuleList {
 	return rules.Generate(filters...)
 }
 
-func saveOutput(filename, format string, color bool, stdout bool, paths []string, issues []*gosec.Issue, metrics *gosec.Metrics, errors map[string][]gosec.Error) error {
-	rootPaths := []string{}
-	for _, path := range paths {
-		rootPath, err := gosec.RootPath(path)
-		if err != nil {
-			return fmt.Errorf("failed to get the root path of the projects: %s", err)
-		}
-		rootPaths = append(rootPaths, rootPath)
+func printReport(format string, color bool, rootPaths []string, issues []*gosec.Issue, metrics *gosec.Metrics, errors map[string][]gosec.Error) error {
+
+	err := report.CreateReport(os.Stdout, format, color, rootPaths, issues, metrics, errors)
+	if err != nil {
+		return err
 	}
-	if filename != "" {
-		outfile, err := os.Create(filename)
-		if err != nil {
-			return err
-		}
-		defer outfile.Close() // #nosec G307
-		err = report.CreateReport(outfile, format, color, rootPaths, issues, metrics, errors)
-		if err != nil {
-			return err
-		}
-		if stdout {
-			format = "text"
-			color = true
-			err = report.CreateReport(os.Stdout, format, color, rootPaths, issues, metrics, errors)
-			if err != nil {
-				return err
-			}
-		}
-	} else {
-		err := report.CreateReport(os.Stdout, format, color, rootPaths, issues, metrics, errors)
-		if err != nil {
-			return err
-		}
+	return nil
+}
+
+func saveReport(filename, format string, color bool, rootPaths []string, issues []*gosec.Issue, metrics *gosec.Metrics, errors map[string][]gosec.Error) error {
+
+	outfile, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer outfile.Close() // #nosec G307
+	err = report.CreateReport(outfile, format, color, rootPaths, issues, metrics, errors)
+	if err != nil {
+		return err
 	}
 	return nil
 }
@@ -302,7 +292,7 @@ func main() {
 
 	// Color flag is allowed for text format
 	var color bool
-	if *flagFormat == "text" {
+	if *flagFormat == "text" || *flagVerbose == "text" {
 		color = true
 	}
 
@@ -374,8 +364,27 @@ func main() {
 	}
 
 	// Create output report
-	if err := saveOutput(*flagOutput, *flagFormat, color, *flagStdOut, flag.Args(), issues, metrics, errors); err != nil {
-		logger.Fatal(err)
+	rootPaths := []string{}
+	for _, path := range flag.Args() {
+		rootPath, err := gosec.RootPath(path)
+		if err != nil {
+			logger.Fatal(fmt.Errorf("failed to get the root path of the projects: %s", err))
+		}
+		rootPaths = append(rootPaths, rootPath)
+	}
+	if *flagOutput == "" || *flagStdOut {
+		var fileFormat = *flagFormat
+		if *flagOutput != "" && *flagVerbose != "" {
+			fileFormat = *flagVerbose
+		}
+		if err := printReport(fileFormat, color, rootPaths, issues, metrics, errors); err != nil {
+			logger.Fatal((err))
+		}
+	}
+	if *flagOutput != "" {
+		if err := saveReport(*flagOutput, *flagFormat, color, rootPaths, issues, metrics, errors); err != nil {
+			logger.Fatal(err)
+		}
 	}
 
 	// Finalize logging

--- a/cmd/gosec/main.go
+++ b/cmd/gosec/main.go
@@ -121,7 +121,7 @@ var (
 	flagStdOut = flag.Bool("stdout", false, "Stdout the results as well as write it in the output file")
 
 	// overrides the output format when stdout the results while saving them in the output file
-	flagVerbose = flag.String("verbose", "", "Overrides the output format when stdout the results while saving them in the output file")
+	flagVerbose = flag.String("verbose", "", "Overrides the output format when stdout the results while saving them in the output file.\nValid options are: json, yaml, csv, junit-xml, html, sonarqube, golint, sarif or text")
 
 	// exlude the folders from scan
 	flagDirsExclude arrayFlags

--- a/cmd/gosec/main.go
+++ b/cmd/gosec/main.go
@@ -230,6 +230,17 @@ func convertToScore(severity string) (gosec.Score, error) {
 	}
 }
 
+func getRootPaths(paths []string) []string {
+	rootPaths := []string{}
+	for _, path := range paths {
+		rootPath, err := gosec.RootPath(path)
+		if err != nil {
+			logger.Fatal(fmt.Errorf("failed to get the root path of the projects: %s", err))
+		}
+		rootPaths = append(rootPaths, rootPath)
+	}
+	return rootPaths
+}
 func filterIssues(issues []*gosec.Issue, severity gosec.Score, confidence gosec.Score) []*gosec.Issue {
 	result := []*gosec.Issue{}
 	for _, issue := range issues {
@@ -364,14 +375,8 @@ func main() {
 	}
 
 	// Create output report
-	rootPaths := []string{}
-	for _, path := range flag.Args() {
-		rootPath, err := gosec.RootPath(path)
-		if err != nil {
-			logger.Fatal(fmt.Errorf("failed to get the root path of the projects: %s", err))
-		}
-		rootPaths = append(rootPaths, rootPath)
-	}
+	rootPaths := getRootPaths(flag.Args())
+
 	if *flagOutput == "" || *flagStdOut {
 		var fileFormat = *flagFormat
 		if *flagOutput != "" && *flagVerbose != "" {


### PR DESCRIPTION
This PR adds up the `-stdout` flag to enable the results to be reported to stdout (console log) and at the same time it'll get stored inside the file provided by `-out` flag. 
It adds the `-verbose` flag to choose which format the stdout should follow while output format is present.
This helps in Devops CICD pipelines to store the generated report as an artifact and at the same time, makes it easily available in logs. 

fixes #600 