### PR TITLE
show nosec in html summary

### DIFF
--- a/report/html/template.go
+++ b/report/html/template.go
@@ -40,6 +40,10 @@ const templateContent = `
     .break-word {
       word-wrap: break-word;
     }
+
+    .help {
+      white-space: pre-wrap;
+    }
   </style>
 </head>
 <body>
@@ -102,6 +106,7 @@ const templateContent = `
           <p className="help">
             Scanned { this.props.data.Stats.files.toLocaleString() } files
             with { this.props.data.Stats.lines.toLocaleString() } lines of code.
+            { this.props.data.Stats.nosec ? '\n' + this.props.data.Stats.nosec.toLocaleString() + ' false positives (nosec) have been waived.' : ''}
           </p>
         );
       }


### PR DESCRIPTION
This PR adds the number of waived nosec false positives to the stats section of the html report.

If I have waived findings in the code I'd like to see how many of them I have in the stats.