### PR TITLE
errors.go: add Hash.Write() to the white list.

### DIFF
--- a/rules/errors.go
+++ b/rules/errors.go
@@ -86,6 +86,7 @@ func NewNoErrorCheck(id string, conf gosec.Config) (gosec.Rule, []ast.Node) {
 	whitelist.AddAll("fmt", "Print", "Printf", "Println", "Fprint", "Fprintf", "Fprintln")
 	whitelist.AddAll("strings.Builder", "Write", "WriteByte", "WriteRune", "WriteString")
 	whitelist.Add("io.PipeWriter", "CloseWithError")
+	whitelist.Add("hash.Hash", "Write")
 
 	if configured, ok := conf["G104"]; ok {
 		if whitelisted, ok := configured.(map[string]interface{}); ok {


### PR DESCRIPTION
go/src/hash/hash.go:

  ...
  type Hash interface {
	// Write (via the embedded io.Writer interface) adds more data to the running hash.
	// It never returns an error.
	io.Writer
 ...