### PR TITLE
Use version `^v0` instead of `latest` for cyclonedx-gomod

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           json: true
           output: bom.json
           resolve-licenses: true
-          version: latest
+          version: ^v0
       - name: Release Binaries
         uses: goreleaser/goreleaser-action@v2
         with:


### PR DESCRIPTION
To avoid breaking the build when cyclonedx-gomod introduces breaking changes in a new major version. See https://github.com/CycloneDX/gh-gomod-generate-sbom/releases/tag/v0.3.0