### PR TITLE
fix: add variable assignment checking as part of MinVersion

### DIFF
--- a/rules/tls.go
+++ b/rules/tls.go
@@ -19,10 +19,11 @@ package rules
 import (
 	"crypto/tls"
 	"fmt"
-	"github.com/securego/gosec/v2"
 	"go/ast"
 	"go/types"
 	"strconv"
+
+	"github.com/securego/gosec/v2"
 )
 
 type insecureConfigTLS struct {

--- a/rules/tls.go
+++ b/rules/tls.go
@@ -85,7 +85,12 @@ func (t *insecureConfigTLS) processTLSConfVal(n *ast.KeyValueExpr, c *gosec.Cont
 			}
 
 		case "MinVersion":
-			if ival, ierr := gosec.GetInt(n.Value); ierr == nil {
+			if ident, ok := n.Value.(*ast.Ident); ok {
+				valueSpec, _ := ident.Obj.Decl.(*ast.ValueSpec)
+				if ival, ierr := gosec.GetInt(valueSpec.Values[0]); ierr == nil {
+					t.actualMinVersion = ival
+				}
+			} else if ival, ierr := gosec.GetInt(n.Value); ierr == nil {
 				t.actualMinVersion = ival
 			} else {
 				if se, ok := n.Value.(*ast.SelectorExpr); ok {

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -2091,7 +2091,8 @@ func main() {
 	}
 
 	// SampleCodeG402 - TLS settings
-	SampleCodeG402 = []CodeSample{{[]string{`
+	SampleCodeG402 = []CodeSample{
+		{[]string{`
 // InsecureSkipVerify
 package main
 import (
@@ -2109,8 +2110,9 @@ func main() {
 	if err != nil {
 		fmt.Println(err)
 	}
-}`}, 1, gosec.NewConfig()}, {[]string{
-		`
+}`}, 1, gosec.NewConfig()},
+		{[]string{
+			`
 // Insecure minimum version
 package main
 import (
@@ -2127,8 +2129,10 @@ func main() {
 	if err != nil {
 		fmt.Println(err)
 	}
-}`}, 1, gosec.NewConfig()}, {[]string{
-		`
+}`,
+		}, 1, gosec.NewConfig()},
+		{[]string{
+			`
 // Insecure minimum version
 package main
 import (
@@ -2147,7 +2151,8 @@ func CaseNotError() *tls.Config {
 func main() {
     a := CaseNotError()
 	fmt.Printf("Debug: %v\n", a.MinVersion)
-}`}, 0, gosec.NewConfig()},
+}`,
+		}, 0, gosec.NewConfig()},
 		{[]string{
 			`
 // Insecure minimum version
@@ -2166,7 +2171,8 @@ func CaseNotError() *tls.Config {
 func main() {
     a := CaseNotError()
 	fmt.Printf("Debug: %v\n", a.MinVersion)
-}`}, 0, gosec.NewConfig()},
+}`,
+		}, 0, gosec.NewConfig()},
 		{[]string{
 			`
 // Insecure minimum version
@@ -2186,7 +2192,8 @@ func CaseError() *tls.Config {
 func main() {
     a := CaseError()
 	fmt.Printf("Debug: %v\n", a.MinVersion)
-}`}, 1, gosec.NewConfig()},
+}`,
+		}, 1, gosec.NewConfig()},
 		{[]string{
 			`
 // Insecure minimum version
@@ -2210,7 +2217,8 @@ func getVersion() uint16 {
 func main() {
     a := CaseError()
 	fmt.Printf("Debug: %v\n", a.MinVersion)
-}`}, 1, gosec.NewConfig()},
+}`,
+		}, 1, gosec.NewConfig()},
 		{[]string{
 			`
 // Insecure minimum version
@@ -2254,7 +2262,8 @@ func main() {
 		fmt.Println(err)
 	}
 }
-`}, 1, gosec.NewConfig()}, {
+`}, 1, gosec.NewConfig()},
+		{
 			[]string{`
 // Insecure ciphersuite selection
 package main
@@ -2276,7 +2285,8 @@ func main() {
 		fmt.Println(err)
 	}
 }`}, 1, gosec.NewConfig(),
-		}, {[]string{`
+		},
+		{[]string{`
 // secure max version when min version is specified
 package main
 import (
@@ -2293,7 +2303,8 @@ func main() {
 	if err != nil {
 		fmt.Println(err)
 	}
-}`}, 0, gosec.NewConfig()}, {[]string{`
+}`}, 0, gosec.NewConfig()},
+		{[]string{`
 package p0
 
 import "crypto/tls"
@@ -2310,7 +2321,8 @@ import "crypto/tls"
 func TlsConfig1() *tls.Config {
    return &tls.Config{MinVersion: 0x0304}
 }
-`}, 1, gosec.NewConfig()}}
+`}, 1, gosec.NewConfig()},
+	}
 
 	// SampleCodeG403 - weak key strength
 	SampleCodeG403 = []CodeSample{

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -2127,8 +2127,90 @@ func main() {
 	if err != nil {
 		fmt.Println(err)
 	}
-}`,
-	}, 1, gosec.NewConfig()},
+}`}, 1, gosec.NewConfig()}, {[]string{
+		`
+// Insecure minimum version
+package main
+import (
+	"crypto/tls"
+	"fmt"
+)
+
+func CaseNotError() *tls.Config {
+	var v uint16 = tls.VersionTLS13
+
+	return &tls.Config{
+		MinVersion: v,
+	}
+}
+
+func main() {
+    a := CaseNotError()
+	fmt.Printf("Debug: %v\n", a.MinVersion)
+}`}, 0, gosec.NewConfig()},
+		{[]string{
+			`
+// Insecure minimum version
+package main
+import (
+	"crypto/tls"
+	"fmt"
+)
+
+func CaseNotError() *tls.Config {
+	return &tls.Config{
+		MinVersion: tls.VersionTLS13,
+	}
+}
+
+func main() {
+    a := CaseNotError()
+	fmt.Printf("Debug: %v\n", a.MinVersion)
+}`}, 0, gosec.NewConfig()},
+		{[]string{
+			`
+// Insecure minimum version
+package main
+import (
+	"crypto/tls"
+	"fmt"
+)
+
+func CaseError() *tls.Config {
+	var v = &tls.Config{
+		MinVersion: 0,
+	}
+	return v
+}
+
+func main() {
+    a := CaseError()
+	fmt.Printf("Debug: %v\n", a.MinVersion)
+}`}, 1, gosec.NewConfig()},
+		{[]string{
+			`
+// Insecure minimum version
+package main
+import (
+	"crypto/tls"
+	"fmt"
+)
+
+func CaseError() *tls.Config {
+	var v = &tls.Config{
+		MinVersion: getVersion(),
+	}
+	return v
+}
+
+func getVersion() uint16 {
+	return tls.VersionTLS12
+}
+
+func main() {
+    a := CaseError()
+	fmt.Printf("Debug: %v\n", a.MinVersion)
+}`}, 1, gosec.NewConfig()},
 		{[]string{
 			`
 // Insecure minimum version
@@ -2154,7 +2236,7 @@ func main() {
 }
 `,
 		}, 0, gosec.NewConfig()},
-	{[]string{`
+		{[]string{`
 // Insecure max version
 package main
 import (
@@ -2173,7 +2255,7 @@ func main() {
 	}
 }
 `}, 1, gosec.NewConfig()}, {
-		[]string{`
+			[]string{`
 // Insecure ciphersuite selection
 package main
 import (
@@ -2194,7 +2276,7 @@ func main() {
 		fmt.Println(err)
 	}
 }`}, 1, gosec.NewConfig(),
-	}, {[]string{`
+		}, {[]string{`
 // secure max version when min version is specified
 package main
 import (

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -2128,7 +2128,33 @@ func main() {
 		fmt.Println(err)
 	}
 }`,
-	}, 1, gosec.NewConfig()}, {[]string{`
+	}, 1, gosec.NewConfig()},
+		{[]string{
+			`
+// Insecure minimum version
+package main
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+)
+
+var theValue uint16 = 0x0304
+
+func main() {
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{MinVersion: theValue},
+	}
+	client := &http.Client{Transport: tr}
+	_, err := client.Get("https://golang.org/")
+	if err != nil {
+		fmt.Println(err)
+	}
+}
+`,
+		}, 0, gosec.NewConfig()},
+	{[]string{`
 // Insecure max version
 package main
 import (


### PR DESCRIPTION
Fix for #528

This PR update the assignment checking for `MinVersion` of TLS