### PR TITLE
Add possibility to list waived (nosec) marked issues but not count them as such

### DIFF
--- a/config.go
+++ b/config.go
@@ -20,6 +20,8 @@ type GlobalOption string
 const (
 	// Nosec global option for #nosec directive
 	Nosec GlobalOption = "nosec"
+	// ShowIgnored defines whether nosec issues are counted as finding or not
+	ShowIgnored GlobalOption = "show-ignored"
 	// Audit global option which indicates that gosec runs in audit mode
 	Audit GlobalOption = "audit"
 	// NoSecAlternative global option alternative for #nosec directive

--- a/issue.go
+++ b/issue.go
@@ -97,6 +97,7 @@ type Issue struct {
 	Code       string        `json:"code"`       // Impacted code line
 	Line       string        `json:"line"`       // Line number in file
 	Col        string        `json:"column"`     // Column number in line
+	NoSec      bool          `json:"nosec"`      // true if the issue is nosec
 }
 
 // FileLocation point out the file path and line number in file

--- a/report/html/template.go
+++ b/report/html/template.go
@@ -62,6 +62,8 @@ const templateContent = `
           level += " is-warning";
         } else if (this.props.level === "LOW") {
           level += " is-info";
+        } else if (this.props.level === "WAIVED") {
+          level += " is-success";
         }
         level +=" is-rounded";
         return (
@@ -96,6 +98,7 @@ const templateContent = `
               </div>
               <div className="column is-one-quarter">
                 <div className="field is-grouped is-grouped-multiline">
+                  {this.props.data.nosec && <IssueTag label="NoSec" level="WAIVED"/>}
                   <IssueTag label="Severity" level={ this.props.data.severity }/>
                   <IssueTag label="Confidence" level={ this.props.data.confidence }/>
                 </div>

--- a/report/text/template.go
+++ b/report/text/template.go
@@ -8,7 +8,7 @@ Golang errors in file: [{{ $filePath }}]:
 {{end}}
 {{end}}
 {{ range $index, $issue := .Issues }}
-[{{ highlight $issue.FileLocation $issue.Severity }}] - {{ $issue.RuleID }} ({{ $issue.Cwe.SprintID }}): {{ $issue.What }} (Confidence: {{ $issue.Confidence}}, Severity: {{ $issue.Severity }})
+[{{ highlight $issue.FileLocation $issue.Severity $issue.NoSec }}] - {{ $issue.RuleID }}{{ if $issue.NoSec }} ({{- success "NoSec" -}}){{ end }} ({{ $issue.Cwe.SprintID }}): {{ $issue.What }} (Confidence: {{ $issue.Confidence}}, Severity: {{ $issue.Severity }})
 {{ printCode $issue }}
 
 {{ end }}

--- a/report/text/writer.go
+++ b/report/text/writer.go
@@ -45,7 +45,7 @@ func plainTextFuncMap(enableColor bool) template.FuncMap {
 
 	// by default those functions return the given content untouched
 	return template.FuncMap{
-		"highlight": func(t string, s gosec.Score) string {
+		"highlight": func(t string, s gosec.Score, ignored bool) string {
 			return t
 		},
 		"danger":    fmt.Sprint,
@@ -56,7 +56,10 @@ func plainTextFuncMap(enableColor bool) template.FuncMap {
 }
 
 // highlight returns content t colored based on Score
-func highlight(t string, s gosec.Score) string {
+func highlight(t string, s gosec.Score, ignored bool) string {
+	if ignored {
+		return defaultTheme.Sprint(t)
+	}
 	switch s {
 	case gosec.High:
 		return errorTheme.Sprint(t)


### PR DESCRIPTION
Our Security regulations demand evidence reports that our source code follows secure coding guidelines.
We are using gosec for this purpose.
The regulations demand, that waived issues are also listed. Hence it would be great, if gosec optionally could generate reports, where waived issues are reported, but not counted as such and marked as waived.

This PR implements a possible solution but fails to get valid unittests. 
As suggested by @ccojocar in https://github.com/securego/gosec/issues/675 I open it as a PR.

fixes #675 