### PR TITLE
add key to Highlight component

### DIFF
--- a/report/html/template.go
+++ b/report/html/template.go
@@ -105,7 +105,7 @@ const templateContent = `
               </div>
             </div>
             <div className="highlight">
-              <Highlight code={ this.props.data.code }/>
+              <Highlight key={ this.props.data.file + this.props.data.line } code={ this.props.data.code }/>
             </div>
           </div>
         );


### PR DESCRIPTION
The code segment in the issues list was not updated due to a missing component key.
This PR fixes this.