### PR TITLE
fix: create a separate type for flag that has validation

### DIFF
--- a/cmd/gosec/main.go
+++ b/cmd/gosec/main.go
@@ -96,14 +96,13 @@ var (
 	flagRulesInclude = flag.String("include", "", "Comma separated list of rules IDs to include. (see rule list)")
 
 	// rules to explicitly exclude
-	flagRulesExclude = new(vflag.ValidateFlag)
+	flagRulesExclude = vflag.ValidatedFlag{}
 
 	// rules to explicitly exclude
 	flagExcludeGenerated = flag.Bool("exclude-generated", false, "Exclude generated files")
 
 	// log to file or stderr
 	flagLogfile = flag.String("log", "", "Log messages to file rather than stderr")
-
 	// sort the issues by severity
 	flagSortIssues = flag.Bool("sort", true, "Sort issues by severity")
 
@@ -296,7 +295,7 @@ func main() {
 	}
 
 	// set for exclude
-	flag.Var(flagRulesExclude, "exclude", "Comma separated list of rules IDs to exclude. (see rule list)")
+	flag.Var(&flagRulesExclude, "exclude", "Comma separated list of rules IDs to exclude. (see rule list)")
 
 	// Parse command line arguments
 	flag.Parse()

--- a/cmd/gosec/main.go
+++ b/cmd/gosec/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"github.com/securego/gosec/v2/cmd/validate"
 	"io/ioutil"
 	"log"
 	"os"
@@ -94,7 +95,7 @@ var (
 	flagRulesInclude = flag.String("include", "", "Comma separated list of rules IDs to include. (see rule list)")
 
 	// rules to explicitly exclude
-	flagRulesExclude = flag.String("exclude", "", "Comma separated list of rules IDs to exclude. (see rule list)")
+	flagRulesExclude = new (validate.ValidatedFlag)
 
 	// rules to explicitly exclude
 	flagExcludeGenerated = flag.Bool("exclude-generated", false, "Exclude generated files")
@@ -293,6 +294,9 @@ func main() {
 		fmt.Fprintf(os.Stderr, "\nError: failed to exclude the %q directory from scan", ".git")
 	}
 
+	// set for exclude
+	flag.Var(flagRulesExclude, "exclude", "Comma separated list of rules IDs to exclude. (see rule list)")
+
 	// Parse command line arguments
 	flag.Parse()
 
@@ -342,7 +346,7 @@ func main() {
 	}
 
 	// Load enabled rule definitions
-	ruleDefinitions := loadRules(*flagRulesInclude, *flagRulesExclude)
+	ruleDefinitions := loadRules(*flagRulesInclude, flagRulesExclude.String())
 	if len(ruleDefinitions) == 0 {
 		logger.Fatal("No rules are configured")
 	}

--- a/cmd/gosec/main.go
+++ b/cmd/gosec/main.go
@@ -17,7 +17,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/securego/gosec/v2/cmd/validate"
+	"github.com/securego/gosec/v2/cmd/vflag"
 	"io/ioutil"
 	"log"
 	"os"
@@ -95,7 +95,7 @@ var (
 	flagRulesInclude = flag.String("include", "", "Comma separated list of rules IDs to include. (see rule list)")
 
 	// rules to explicitly exclude
-	flagRulesExclude = new (validate.ValidatedFlag)
+	flagRulesExclude = new(vflag.ValidateFlag)
 
 	// rules to explicitly exclude
 	flagExcludeGenerated = flag.Bool("exclude-generated", false, "Exclude generated files")

--- a/cmd/gosec/main.go
+++ b/cmd/gosec/main.go
@@ -17,12 +17,13 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/securego/gosec/v2/cmd/vflag"
 	"io/ioutil"
 	"log"
 	"os"
 	"sort"
 	"strings"
+
+	"github.com/securego/gosec/v2/cmd/vflag"
 
 	"github.com/securego/gosec/v2"
 	"github.com/securego/gosec/v2/report"

--- a/cmd/validate/flag.go
+++ b/cmd/validate/flag.go
@@ -1,0 +1,22 @@
+package validate
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+type ValidatedFlag string
+
+func (f *ValidatedFlag) String() string {
+	return fmt.Sprint(*f)
+}
+
+// Set will be called for flag that is of validateFlag type
+func (f *ValidatedFlag) Set(value string) error {
+	if strings.Contains(value, "-") {
+		return errors.New("")
+	}
+	return nil
+}
+

--- a/cmd/validate/flag.go
+++ b/cmd/validate/flag.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 )
 
+// ValidateFlag used for flag cli string type
 type ValidatedFlag string
 
 func (f *ValidatedFlag) String() string {

--- a/cmd/vflag/flag.go
+++ b/cmd/vflag/flag.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-//ValidateFlag cli string type
+// ValidateFlag cli string type
 type ValidateFlag string
 
 func (f *ValidateFlag) String() string {
@@ -20,4 +20,3 @@ func (f *ValidateFlag) Set(value string) error {
 	}
 	return nil
 }
-

--- a/cmd/vflag/flag.go
+++ b/cmd/vflag/flag.go
@@ -2,21 +2,24 @@ package vflag
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 )
 
-// ValidateFlag cli string type
-type ValidateFlag string
+// ValidatedFlag cli string type
+type ValidatedFlag struct {
+	Value string
+}
 
-func (f *ValidateFlag) String() string {
-	return fmt.Sprint(*f)
+func (f *ValidatedFlag) String() string {
+	return f.Value
 }
 
 // Set will be called for flag that is of validateFlag type
-func (f *ValidateFlag) Set(value string) error {
+func (f *ValidatedFlag) Set(value string) error {
 	if strings.Contains(value, "-") {
-		return errors.New("")
+		return errors.New("flag value cannot start with -")
 	}
+
+	f.Value = value
 	return nil
 }

--- a/cmd/vflag/flag.go
+++ b/cmd/vflag/flag.go
@@ -1,4 +1,4 @@
-package validate
+package vflag
 
 import (
 	"errors"
@@ -6,15 +6,15 @@ import (
 	"strings"
 )
 
-// ValidateFlag used for flag cli string type
-type ValidatedFlag string
+//ValidateFlag cli string type
+type ValidateFlag string
 
-func (f *ValidatedFlag) String() string {
+func (f *ValidateFlag) String() string {
 	return fmt.Sprint(*f)
 }
 
 // Set will be called for flag that is of validateFlag type
-func (f *ValidatedFlag) Set(value string) error {
+func (f *ValidateFlag) Set(value string) error {
 	if strings.Contains(value, "-") {
 		return errors.New("")
 	}

--- a/flag_test.go
+++ b/flag_test.go
@@ -1,0 +1,42 @@
+package gosec_test
+
+import (
+	"flag"
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/securego/gosec/v2/cmd/vflag"
+)
+
+var _ = Describe("Cli", func() {
+	Context("vflag test", func() {
+		It("value must be empty as parameter value contains invalid character", func() {
+			os.Args = []string{"gosec", "-test1=-incorrect"}
+			f := vflag.ValidatedFlag{}
+			flag.Var(&f, "test1", "")
+			flag.CommandLine.Init("test1", flag.ContinueOnError)
+			flag.Parse()
+			Expect(flag.Parsed()).Should(Equal(true))
+			Expect(f.Value).Should(Equal(``))
+		})
+		It("value must be empty as parameter value contains invalid character without equal sign", func() {
+			os.Args = []string{"gosec", "-test2= -incorrect"}
+			f := vflag.ValidatedFlag{}
+			flag.Var(&f, "test2", "")
+			flag.CommandLine.Init("test2", flag.ContinueOnError)
+			flag.Parse()
+			Expect(flag.Parsed()).Should(Equal(true))
+			Expect(f.Value).Should(Equal(``))
+		})
+		It("value must not be empty as parameter value contains valid character", func() {
+			os.Args = []string{"gosec", "-test3=correct"}
+			f := vflag.ValidatedFlag{}
+			flag.Var(&f, "test3", "")
+			flag.CommandLine.Init("test3", flag.ContinueOnError)
+			flag.Parse()
+			Expect(flag.Parsed()).Should(Equal(true))
+			Expect(f.Value).Should(Equal(`correct`))
+		})
+	})
+})


### PR DESCRIPTION
Fix: #535 

Create a separate type to allow CLI validation using the `flag` package from the go library.