### PR TITLE
feat: add os.ReadFile to G304

### DIFF
--- a/rules/readfile.go
+++ b/rules/readfile.go
@@ -122,6 +122,7 @@ func NewReadFile(id string, conf gosec.Config) (gosec.Rule, []ast.Node) {
 	rule.clean.Add("path/filepath", "Clean")
 	rule.clean.Add("path/filepath", "Rel")
 	rule.Add("io/ioutil", "ReadFile")
+	rule.Add("os", "ReadFile")
 	rule.Add("os", "Open")
 	rule.Add("os", "OpenFile")
 	return rule, []ast.Node{(*ast.CallExpr)(nil)}

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -1788,6 +1788,22 @@ func main() {
 package main
 
 import (
+"os"
+"log"
+)
+
+func main() {
+	f := os.Getenv("tainted_file")
+	body, err := os.ReadFile(f)
+	if err != nil {
+	log.Printf("Error: %v\n", err)
+	}
+	log.Print(body)
+
+}`}, 1, gosec.NewConfig()}, {[]string{`
+package main
+
+import (
 	"fmt"
 	"log"
 	"net/http"


### PR DESCRIPTION
In Go 1.16 or higher, the `io/ioutil` has been deprecated and the `ioutil.ReadFile` function now calls `os.ReadFile`.

This PR adds the `os.ReadFile` function into the **G304: Potential file inclusion via variable** rule.