### PR TITLE
Phase out support for go version 1.15 because current ginko is not backward compatible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
     strategy:
       matrix:
         go_version:
-          - '1.15'
           - '1.16'
           - '1.17'
     runs-on: ubuntu-latest


### PR DESCRIPTION
We are going to support only the stable versions provided by the Go team.
