### PR TITLE
add openssh to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN go mod download
 RUN make build-linux
 
 FROM golang:${GO_VERSION}-alpine 
-RUN apk add --update --no-cache ca-certificates bash git gcc libc-dev
+RUN apk add --update --no-cache ca-certificates bash git gcc libc-dev openssh
 ENV GO111MODULE on
 COPY --from=builder /build/gosec /bin/gosec
 COPY entrypoint.sh /bin/entrypoint.sh


### PR DESCRIPTION
I'm trying to scan a project which has dependencies which are private projects. When Go tries to fetch the dependencies it normally uses HTTPS, but that doesn't work if they're private (terminal prompts disabled, can't enter username/password). So you do this little trick with git configuration to get Go to fetch dependencies over ssh: `GIT_CONFIG_PARAMETERS=url.ssh://git@github.com/.insteadOf=https://github.com/`
unfortunately the docker image doesn't have ssh installed so this doesn't work :)