### PR TITLE
use go embed for templates

### DIFF
--- a/report/html/template.html
+++ b/report/html/template.html
@@ -1,20 +1,3 @@
-// (c) Copyright 2016 Hewlett Packard Enterprise Development LP
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-package html
-
-const templateContent = `
 <!doctype html>
 <html lang="en">
 <head>
@@ -454,4 +437,4 @@ const templateContent = `
     );
   </script>
 </body>
-</html>`
+</html>

--- a/report/html/writer.go
+++ b/report/html/writer.go
@@ -1,11 +1,17 @@
 package html
 
 import (
+
+	// use go embed to import template
+	_ "embed"
 	"html/template"
 	"io"
 
 	"github.com/securego/gosec/v2"
 )
+
+//go:embed template.html
+var templateContent string
 
 // WriteReport write a report in html format to the output writer
 func WriteReport(w io.Writer, data *gosec.ReportInfo) error {

--- a/report/text/template.txt
+++ b/report/text/template.txt
@@ -1,6 +1,4 @@
-package text
-
-const templateContent = `Results:
+Results:
 {{range $filePath,$fileErrors := .Errors}}
 Golang errors in file: [{{ $filePath }}]:
 {{range $index, $error := $fileErrors}}
@@ -23,4 +21,3 @@ Golang errors in file: [{{ $filePath }}]:
 	{{- danger .Stats.NumFound }}
 	{{- end }}
 
-`

--- a/report/text/writer.go
+++ b/report/text/writer.go
@@ -3,6 +3,9 @@ package text
 import (
 	"bufio"
 	"bytes"
+
+	// use go embed to import template
+	_ "embed"
 	"fmt"
 	"io"
 	"strconv"
@@ -17,6 +20,9 @@ var (
 	errorTheme   = color.New(color.FgLightWhite, color.BgRed)
 	warningTheme = color.New(color.FgBlack, color.BgYellow)
 	defaultTheme = color.New(color.FgWhite, color.BgBlack)
+
+	//go:embed template.txt
+	templateContent string
 )
 
 // WriteReport write a (colorized) report in text format


### PR DESCRIPTION
Since go 1.15 is now phased out we could reactivate the changes from https://github.com/securego/gosec/pull/625

Use go embed feature to make template maintenance easier.
