### PR TITLE
Fix #736

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -319,16 +319,16 @@ func (gosec *Analyzer) ignore(n ast.Node) map[string]SuppressionInfo {
 		}
 
 		for _, group := range groups {
-
-			foundDefaultTag := strings.HasPrefix(group.Text(), noSecDefaultTag)
-			foundAlternativeTag := strings.HasPrefix(group.Text(), noSecAlternativeTag)
+			comment := strings.TrimSpace(group.Text())
+			foundDefaultTag := strings.HasPrefix(comment, noSecDefaultTag)
+			foundAlternativeTag := strings.HasPrefix(comment, noSecAlternativeTag)
 
 			if foundDefaultTag || foundAlternativeTag {
 				gosec.stats.NumNosec++
 
 				// Extract the directive and the justification.
 				justification := ""
-				commentParts := regexp.MustCompile(`-{2,}`).Split(group.Text(), 2)
+				commentParts := regexp.MustCompile(`-{2,}`).Split(comment, 2)
 				directive := commentParts[0]
 				if len(commentParts) > 1 {
 					justification = strings.TrimSpace(strings.TrimRight(commentParts[1], "\n"))


### PR DESCRIPTION
This PR is to fix #736.

### Root cause

Block comments will have an extra whitespace before the comment content that gotten from `group.Text()`. In the following table, `▯` indicates to a whitespace.

|comment|`group.Text()`|
|---|---|
|`// #nosec`|`/* #nosec */`|
|`#nosec`|`▯#nosec`|

In PR #735, `#nosec` or other `noSecAlternativeTag` is treated as a prefix of the annotation. There were not a test case that covered block comments and resulted in #736.

### Solution in this PR

Remove the whitespaces before comments with `strings.Trim()`.