### PR TITLE
Remove space between `//` and `#nosec` in examples and internal use

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ AST so can apply to a whole block or more granularly to a single expression.
 
 ```go
 
-import "md5" // #nosec
+import "md5" //#nosec
 
 
 func main(){
@@ -293,11 +293,11 @@ func main(){
 
 When a specific false positive has been identified and verified as safe, you may wish to suppress only that single rule (or a specific set of rules)
 within a section of code, while continuing to scan for other problems. To do this, you can list the rule(s) to be suppressed within
-the `#nosec` annotation, e.g: `/* #nosec G401 */` or `// #nosec G201 G202 G203`
+the `#nosec` annotation, e.g: `/* #nosec G401 */` or `//#nosec G201 G202 G203`
 
 You could put the description or justification text for the annotation. The
 justification should be after the rule(s) to suppress and start with two or
-more dashes, e.g: `// #nosec G101 G102 -- This is a false positive`
+more dashes, e.g: `//#nosec G101 G102 -- This is a false positive`
 
 In some cases you may also want to revisit places where `#nosec` annotations
 have been used. To run the scanner and ignore any `#nosec` annotations you

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -146,7 +146,7 @@ var _ = Describe("Analyzer", func() {
 
 			nosecPackage := testutils.NewTestPackage()
 			defer nosecPackage.Close()
-			nosecSource := strings.Replace(source, "h := md5.New()", "h := md5.New() // #nosec", 1)
+			nosecSource := strings.Replace(source, "h := md5.New()", "h := md5.New() //#nosec", 1)
 			nosecPackage.AddFile("md5.go", nosecSource)
 			err := nosecPackage.Build()
 			Expect(err).ShouldNot(HaveOccurred())
@@ -181,7 +181,7 @@ var _ = Describe("Analyzer", func() {
 
 			nosecPackage := testutils.NewTestPackage()
 			defer nosecPackage.Close()
-			nosecSource := strings.Replace(source, "h := md5.New()", "h := md5.New() // #nosec G401", 1)
+			nosecSource := strings.Replace(source, "h := md5.New()", "h := md5.New() //#nosec G401", 1)
 			nosecPackage.AddFile("md5.go", nosecSource)
 			err := nosecPackage.Build()
 			Expect(err).ShouldNot(HaveOccurred())
@@ -198,7 +198,7 @@ var _ = Describe("Analyzer", func() {
 
 			nosecPackage := testutils.NewTestPackage()
 			defer nosecPackage.Close()
-			nosecSource := strings.Replace(source, "h := md5.New()", "h := md5.New() // #nosec G301", 1)
+			nosecSource := strings.Replace(source, "h := md5.New()", "h := md5.New() //#nosec G301", 1)
 			nosecPackage.AddFile("md5.go", nosecSource)
 			err := nosecPackage.Build()
 			Expect(err).ShouldNot(HaveOccurred())
@@ -215,7 +215,7 @@ var _ = Describe("Analyzer", func() {
 
 			nosecPackage := testutils.NewTestPackage()
 			defer nosecPackage.Close()
-			nosecSource := strings.Replace(source, "h := md5.New()", "h := md5.New() // #nosec G301 G401", 1)
+			nosecSource := strings.Replace(source, "h := md5.New()", "h := md5.New() //#nosec G301 G401", 1)
 			nosecPackage.AddFile("md5.go", nosecSource)
 			err := nosecPackage.Build()
 			Expect(err).ShouldNot(HaveOccurred())
@@ -267,7 +267,7 @@ var _ = Describe("Analyzer", func() {
 
 			nosecPackage := testutils.NewTestPackage()
 			defer nosecPackage.Close()
-			nosecSource := strings.Replace(source, "h := md5.New()", "h := md5.New() // #nosec", 1)
+			nosecSource := strings.Replace(source, "h := md5.New()", "h := md5.New() //#nosec", 1)
 			nosecPackage.AddFile("md5.go", nosecSource)
 			err := nosecPackage.Build()
 			Expect(err).ShouldNot(HaveOccurred())
@@ -291,7 +291,7 @@ var _ = Describe("Analyzer", func() {
 
 			nosecPackage := testutils.NewTestPackage()
 			defer nosecPackage.Close()
-			nosecSource := strings.Replace(source, "h := md5.New()", "h := md5.New() // #nosec", 1)
+			nosecSource := strings.Replace(source, "h := md5.New()", "h := md5.New() //#nosec", 1)
 			nosecPackage.AddFile("md5.go", nosecSource)
 			err := nosecPackage.Build()
 			Expect(err).ShouldNot(HaveOccurred())
@@ -339,7 +339,7 @@ var _ = Describe("Analyzer", func() {
 
 			nosecPackage := testutils.NewTestPackage()
 			defer nosecPackage.Close()
-			nosecSource := strings.Replace(source, "h := md5.New()", "h := md5.New() // #nosec", 1)
+			nosecSource := strings.Replace(source, "h := md5.New()", "h := md5.New() //#nosec", 1)
 			nosecPackage.AddFile("md5.go", nosecSource)
 			err := nosecPackage.Build()
 			Expect(err).ShouldNot(HaveOccurred())
@@ -613,7 +613,7 @@ var _ = Describe("Analyzer", func() {
 
 			nosecPackage := testutils.NewTestPackage()
 			defer nosecPackage.Close()
-			nosecSource := strings.Replace(source, "h := md5.New()", "h := md5.New() // #nosec G401 -- Justification", 1)
+			nosecSource := strings.Replace(source, "h := md5.New()", "h := md5.New() //#nosec G401 -- Justification", 1)
 			nosecPackage.AddFile("md5.go", nosecSource)
 			err := nosecPackage.Build()
 			Expect(err).ShouldNot(HaveOccurred())
@@ -633,7 +633,7 @@ var _ = Describe("Analyzer", func() {
 
 			nosecPackage := testutils.NewTestPackage()
 			defer nosecPackage.Close()
-			nosecSource := strings.Replace(source, "h := md5.New()", "h := md5.New() // #nosec", 1)
+			nosecSource := strings.Replace(source, "h := md5.New()", "h := md5.New() //#nosec", 1)
 			nosecPackage.AddFile("md5.go", nosecSource)
 			err := nosecPackage.Build()
 			Expect(err).ShouldNot(HaveOccurred())
@@ -691,7 +691,7 @@ var _ = Describe("Analyzer", func() {
 
 			nosecPackage := testutils.NewTestPackage()
 			defer nosecPackage.Close()
-			nosecSource := strings.Replace(source, "}", "} // #nosec G101 -- Justification", 1)
+			nosecSource := strings.Replace(source, "}", "} //#nosec G101 -- Justification", 1)
 			nosecPackage.AddFile("pwd.go", nosecSource)
 			err := nosecPackage.Build()
 			Expect(err).ShouldNot(HaveOccurred())

--- a/cmd/gosec/main.go
+++ b/cmd/gosec/main.go
@@ -70,7 +70,7 @@ func (a *arrayFlags) Set(value string) error {
 }
 
 var (
-	// #nosec flag
+	//#nosec flag
 	flagIgnoreNoSec = flag.Bool("nosec", false, "Ignores #nosec comments when set")
 
 	// show ignored
@@ -79,7 +79,7 @@ var (
 	// format output
 	flagFormat = flag.String("fmt", "text", "Set output format. Valid options are: json, yaml, csv, junit-xml, html, sonarqube, golint, sarif or text")
 
-	// #nosec alternative tag
+	//#nosec alternative tag
 	flagAlternativeNoSec = flag.String("nosec-tag", "", "Set an alternative string for #nosec. Some examples: #dontanalyze, #falsepositive")
 
 	// output file
@@ -141,7 +141,7 @@ var (
 	logger *log.Logger
 )
 
-// #nosec
+//#nosec
 func usage() {
 	usageText := fmt.Sprintf(usageText, Version, GitTag, BuildDate)
 	fmt.Fprintln(os.Stderr, usageText)
@@ -166,12 +166,12 @@ func usage() {
 func loadConfig(configFile string) (gosec.Config, error) {
 	config := gosec.NewConfig()
 	if configFile != "" {
-		// #nosec
+		//#nosec
 		file, err := os.Open(configFile)
 		if err != nil {
 			return nil, err
 		}
-		defer file.Close() // #nosec G307
+		defer file.Close() //#nosec G307
 		if _, err := config.ReadFrom(file); err != nil {
 			return nil, err
 		}
@@ -242,7 +242,7 @@ func saveReport(filename, format string, rootPaths []string, reportInfo *gosec.R
 	if err != nil {
 		return err
 	}
-	defer outfile.Close() // #nosec G307
+	defer outfile.Close() //#nosec G307
 	err = report.CreateReport(outfile, format, false, rootPaths, reportInfo)
 	if err != nil {
 		return err
@@ -309,7 +309,7 @@ func main() {
 
 	// Ensure at least one file was specified
 	if flag.NArg() == 0 {
-		fmt.Fprintf(os.Stderr, "\nError: FILE [FILE...] or './...' expected\n") // #nosec
+		fmt.Fprintf(os.Stderr, "\nError: FILE [FILE...] or './...' expected\n") //#nosec
 		flag.Usage()
 		os.Exit(1)
 	}
@@ -417,7 +417,7 @@ func main() {
 	}
 
 	// Finalize logging
-	logWriter.Close() // #nosec
+	logWriter.Close() //#nosec
 
 	// Do we have an issue? If so exit 1 unless NoFail is set
 	if (len(issues) > 0 || len(errors) > 0) && !*flagNoFail {

--- a/cmd/gosecutil/tools.go
+++ b/cmd/gosecutil/tools.go
@@ -76,12 +76,12 @@ func (u *utilities) run(args ...string) {
 func shouldSkip(path string) bool {
 	st, e := os.Stat(path)
 	if e != nil {
-		// #nosec
+		//#nosec
 		fmt.Fprintf(os.Stderr, "Skipping: %s - %s\n", path, e)
 		return true
 	}
 	if st.IsDir() {
-		// #nosec
+		//#nosec
 		fmt.Fprintf(os.Stderr, "Skipping: %s - directory\n", path)
 		return true
 	}
@@ -99,12 +99,12 @@ func dumpAst(files ...string) {
 		fset := token.NewFileSet() // positions are relative to fset
 		f, err := parser.ParseFile(fset, arg, nil, 0)
 		if err != nil {
-			// #nosec
+			//#nosec
 			fmt.Fprintf(os.Stderr, "Unable to parse file %s\n", err)
 			continue
 		}
 
-		// #nosec -- Print the AST.
+		//#nosec -- Print the AST.
 		ast.Print(fset, f)
 	}
 }
@@ -122,7 +122,7 @@ func createContext(filename string) *context {
 	fileset := token.NewFileSet()
 	root, e := parser.ParseFile(fileset, filename, nil, parser.ParseComments)
 	if e != nil {
-		// #nosec
+		//#nosec
 		fmt.Fprintf(os.Stderr, "Unable to parse file: %s. Reason: %s\n", filename, e)
 		return nil
 	}
@@ -138,7 +138,7 @@ func createContext(filename string) *context {
 	config := types.Config{Importer: importer.Default()}
 	pkg, e := config.Check("main.go", fileset, []*ast.File{root}, info)
 	if e != nil {
-		// #nosec
+		//#nosec
 		fmt.Fprintf(os.Stderr, "Type check failed for file: %s. Reason: %s\n", filename, e)
 		return nil
 	}
@@ -163,7 +163,7 @@ func printObject(obj types.Object) {
 }
 
 func checkContext(ctx *context, file string) bool {
-	// #nosec
+	//#nosec
 	if ctx == nil {
 		fmt.Fprintln(os.Stderr, "Failed to create context for file: ", file)
 		return false

--- a/cmd/tlsconfig/tlsconfig.go
+++ b/cmd/tlsconfig/tlsconfig.go
@@ -66,7 +66,7 @@ type goTLSConfiguration struct {
 
 // getTLSConfFromURL retrieves the json containing the TLS configurations from the specified URL.
 func getTLSConfFromURL(url string) (*ServerSideTLSJson, error) {
-	r, err := http.Get(url) // #nosec G107
+	r, err := http.Get(url) //#nosec G107
 	if err != nil {
 		return nil, err
 	}
@@ -190,5 +190,5 @@ func main() {
 	outputPath := filepath.Join(dir, *outputFile)
 	if err := ioutil.WriteFile(outputPath, src, 0o644); err != nil {
 		log.Fatalf("Writing output: %s", err)
-	} // #nosec G306
+	} //#nosec G306
 }

--- a/issue.go
+++ b/issue.go
@@ -180,7 +180,7 @@ func NewIssue(ctx *Context, node ast.Node, ruleID, desc string, severity Score, 
 
 	var code string
 	if file, err := os.Open(fobj.Name()); err == nil {
-		defer file.Close() // #nosec
+		defer file.Close() //#nosec
 		s := codeSnippetStartLine(node, fobj)
 		e := codeSnippetEndLine(node, fobj)
 		code, err = codeSnippet(file, s, e, node)

--- a/testutils/pkg.go
+++ b/testutils/pkg.go
@@ -55,7 +55,7 @@ func (p *TestPackage) write() error {
 	for filename, content := range p.Files {
 		if e := ioutil.WriteFile(filename, []byte(content), 0o644); e != nil {
 			return e
-		} // #nosec G306
+		} //#nosec G306
 	}
 	p.onDisk = true
 	return nil

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -1999,7 +1999,7 @@ func unzip(archive, target string) error {
 	for _, file := range reader.File {
 		path := filepath.Join(target, file.Name)
 		if file.FileInfo().IsDir() {
-			os.MkdirAll(path, file.Mode()) // #nosec
+			os.MkdirAll(path, file.Mode()) //#nosec
 			continue
 		}
 
@@ -2045,7 +2045,7 @@ func unzip(archive, target string) error {
                 archiveFile := file.Name
 		path := filepath.Join(target, archiveFile)
 		if file.FileInfo().IsDir() {
-			os.MkdirAll(path, file.Mode()) // #nosec
+			os.MkdirAll(path, file.Mode()) //#nosec
 			continue
 		}
 


### PR DESCRIPTION
Comments intended for machines to read do not have the space by convention.

I'm unable to find an "authoritative" reference at the moment, but it is mentioned here and there, and is in my experience the convention indeed. Anyway one example mention is at end of https://golangci-lint.run/usage/false-positives/#nolint