### PR TITLE
Track both #nosec and #nosec rulelist for one violation

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -394,10 +394,13 @@ func (gosec *Analyzer) Visit(n ast.Node) ast.Visitor {
 
 	for _, rule := range gosec.ruleset.RegisteredFor(n) {
 		// Check if all rules are ignored.
-		suppressions, ignored := ignores[aliasOfAllRules]
-		if !ignored {
-			suppressions, ignored = ignores[rule.ID()]
-		}
+		generalSuppressions, generalIgnored := ignores[aliasOfAllRules]
+		// Check if the specific rule is ignored
+		ruleSuppressions, ruleIgnored := ignores[rule.ID()]
+
+		ignored := generalIgnored || ruleIgnored
+		suppressions := append(generalSuppressions, ruleSuppressions...)
+
 		// Track external suppressions.
 		if gosec.ruleset.IsRuleSuppressed(rule.ID()) {
 			ignored = true


### PR DESCRIPTION
### Problem

For this piece of code

```go
package main

import "fmt"

// #nosec -- j1
func main() {
	username := "admin"
	/* #nosec G101 -- j2 */
	password := "f62e5bcda4fae4f82370da0c6f20697b8f8447ef"
	fmt.Println("Doing something with: ", username, password)
}
```

If we run `gosec -fmt=sarif -track-suppressions ./...` on it...

Expected:

```
"suppressions": [
  { "kind": "inSource", "justification": "j1" },
  { "kind": "inSource", "justification": "j2" }
]
```

Actual:

```
"suppressions": [
  { "kind": "inSource", "justification": "j1" }
]
```

### Root cause

If gosec ignores all rules, it will skip checking specific rules.

### Solution

Check both general suppressions and specific rule suppressions, then merge then together.