### PR TITLE
Fix #704

### DIFF
--- a/cmd/gosec/main.go
+++ b/cmd/gosec/main.go
@@ -185,7 +185,12 @@ func loadConfig(configFile string) (gosec.Config, error) {
 	if *flagAlternativeNoSec != "" {
 		config.SetGlobal(gosec.NoSecAlternative, *flagAlternativeNoSec)
 	}
-	if flagRulesExclude.String() != "" {
+	// set global option IncludeRules ,when flag set or global option IncludeRules  is nil
+	if v, _ := config.GetGlobal(gosec.IncludeRules); *flagRulesInclude != "" || v == "" {
+		config.SetGlobal(gosec.IncludeRules, *flagRulesInclude)
+	}
+	// set global option ExcludeRules ,when flag set or global option IncludeRules  is nil
+	if v, _ := config.GetGlobal(gosec.ExcludeRules); flagRulesExclude.String() != "" || v == "" {
 		config.SetGlobal(gosec.ExcludeRules, flagRulesExclude.String())
 	}
 	return config, nil
@@ -351,11 +356,16 @@ func main() {
 	}
 
 	// Load enabled rule definitions
-	eRules, err := config.GetGlobal(gosec.ExcludeRules)
+	excludeRules, err := config.GetGlobal(gosec.ExcludeRules)
 	if err != nil {
 		logger.Fatal(err)
 	}
-	ruleList := loadRules(*flagRulesInclude, eRules)
+	includeRules, err := config.GetGlobal(gosec.IncludeRules)
+	if err != nil {
+		logger.Fatal(err)
+	}
+	// get a bug
+	ruleList := loadRules(includeRules, excludeRules)
 	if len(ruleList.Rules) == 0 {
 		logger.Fatal("No rules are configured")
 	}

--- a/cmd/gosec/main.go
+++ b/cmd/gosec/main.go
@@ -185,6 +185,9 @@ func loadConfig(configFile string) (gosec.Config, error) {
 	if *flagAlternativeNoSec != "" {
 		config.SetGlobal(gosec.NoSecAlternative, *flagAlternativeNoSec)
 	}
+	if flagRulesExclude.String() != "" {
+		config.SetGlobal(gosec.ExcludeRules, flagRulesExclude.String())
+	}
 	return config, nil
 }
 
@@ -348,7 +351,11 @@ func main() {
 	}
 
 	// Load enabled rule definitions
-	ruleList := loadRules(*flagRulesInclude, flagRulesExclude.String())
+	eRules, err := config.GetGlobal(gosec.ExcludeRules)
+	if err != nil {
+		logger.Fatal(err)
+	}
+	ruleList := loadRules(*flagRulesInclude, eRules)
 	if len(ruleList.Rules) == 0 {
 		logger.Fatal("No rules are configured")
 	}

--- a/config.go
+++ b/config.go
@@ -26,6 +26,8 @@ const (
 	Audit GlobalOption = "audit"
 	// NoSecAlternative global option alternative for #nosec directive
 	NoSecAlternative GlobalOption = "#nosec"
+	// ExcludeRules global option for some rules  should not be load
+	ExcludeRules GlobalOption = "exclude"
 )
 
 // Config is used to provide configuration and customization to each of the rules.

--- a/config.go
+++ b/config.go
@@ -28,6 +28,8 @@ const (
 	NoSecAlternative GlobalOption = "#nosec"
 	// ExcludeRules global option for some rules  should not be load
 	ExcludeRules GlobalOption = "exclude"
+	// ExcludeRules global option for  should be load
+	IncludeRules GlobalOption = "include"
 )
 
 // Config is used to provide configuration and customization to each of the rules.

--- a/config.go
+++ b/config.go
@@ -28,7 +28,7 @@ const (
 	NoSecAlternative GlobalOption = "#nosec"
 	// ExcludeRules global option for some rules  should not be load
 	ExcludeRules GlobalOption = "exclude"
-	// ExcludeRules global option for  should be load
+	// IncludeRules global option for  should be load
 	IncludeRules GlobalOption = "include"
 )
 


### PR DESCRIPTION
fixes [#704](https://github.com/securego/gosec/issues/704)
### Root cause
config.json not suport exclude/include option 
### Solution in this PR
1, loadConfig set global config
2, use global config loadRules 




