### PR TITLE
Fix #743

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -325,11 +325,18 @@ func (gosec *Analyzer) ignore(n ast.Node) map[string]SuppressionInfo {
 
 		for _, group := range groups {
 			comment := strings.TrimSpace(group.Text())
-			foundDefaultTag := strings.HasPrefix(comment, noSecDefaultTag)
-			foundAlternativeTag := strings.HasPrefix(comment, noSecAlternativeTag)
+			foundDefaultTag := strings.HasPrefix(comment, noSecDefaultTag) || regexp.MustCompile("\n *"+noSecDefaultTag).Match([]byte(comment))
+			foundAlternativeTag := strings.HasPrefix(comment, noSecAlternativeTag) || regexp.MustCompile("\n *"+noSecAlternativeTag).Match([]byte(comment))
 
 			if foundDefaultTag || foundAlternativeTag {
 				gosec.stats.NumNosec++
+
+				// Discard what's in front of the nosec tag.
+				if foundDefaultTag {
+					comment = strings.SplitN(comment, noSecDefaultTag, 2)[1]
+				} else {
+					comment = strings.SplitN(comment, noSecAlternativeTag, 2)[1]
+				}
 
 				// Extract the directive and the justification.
 				justification := ""

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -361,7 +361,7 @@ var _ = Describe("Analyzer", func() {
 
 			nosecPackage := testutils.NewTestPackage()
 			defer nosecPackage.Close()
-			nosecSource := strings.Replace(source, "h := md5.New()", "//#nosec //G301\n//#nosec\nh := md5.New()", 1)
+			nosecSource := strings.Replace(source, "h := md5.New()", "//#nosec\n//G301\n//#nosec\nh := md5.New()", 1)
 			nosecPackage.AddFile("md5.go", nosecSource)
 			err := nosecPackage.Build()
 			Expect(err).ShouldNot(HaveOccurred())

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -303,6 +303,74 @@ var _ = Describe("Analyzer", func() {
 			Expect(metrics.NumNosec).Should(Equal(1))
 		})
 
+		It("should not report errors when nosec tag is in front of a line", func() {
+			sample := testutils.SampleCodeG401[0]
+			source := sample.Code[0]
+			analyzer.LoadRules(rules.Generate(false, rules.NewRuleFilter(false, "G401")).RulesInfo())
+
+			nosecPackage := testutils.NewTestPackage()
+			defer nosecPackage.Close()
+			nosecSource := strings.Replace(source, "h := md5.New()", "//Some description\n//#nosec G401\nh := md5.New()", 1)
+			nosecPackage.AddFile("md5.go", nosecSource)
+			err := nosecPackage.Build()
+			Expect(err).ShouldNot(HaveOccurred())
+			err = analyzer.Process(buildTags, nosecPackage.Path)
+			Expect(err).ShouldNot(HaveOccurred())
+			nosecIssues, _, _ := analyzer.Report()
+			Expect(nosecIssues).Should(BeEmpty())
+		})
+
+		It("should report errors when nosec tag is not in front of a line", func() {
+			sample := testutils.SampleCodeG401[0]
+			source := sample.Code[0]
+			analyzer.LoadRules(rules.Generate(false, rules.NewRuleFilter(false, "G401")).RulesInfo())
+
+			nosecPackage := testutils.NewTestPackage()
+			defer nosecPackage.Close()
+			nosecSource := strings.Replace(source, "h := md5.New()", "//Some description\n//Another description #nosec G401\nh := md5.New()", 1)
+			nosecPackage.AddFile("md5.go", nosecSource)
+			err := nosecPackage.Build()
+			Expect(err).ShouldNot(HaveOccurred())
+			err = analyzer.Process(buildTags, nosecPackage.Path)
+			Expect(err).ShouldNot(HaveOccurred())
+			nosecIssues, _, _ := analyzer.Report()
+			Expect(nosecIssues).Should(HaveLen(sample.Errors))
+		})
+
+		It("should not report errors when rules are in front of nosec tag even rules are wrong", func() {
+			sample := testutils.SampleCodeG401[0]
+			source := sample.Code[0]
+			analyzer.LoadRules(rules.Generate(false, rules.NewRuleFilter(false, "G401")).RulesInfo())
+
+			nosecPackage := testutils.NewTestPackage()
+			defer nosecPackage.Close()
+			nosecSource := strings.Replace(source, "h := md5.New()", "//G301\n//#nosec\nh := md5.New()", 1)
+			nosecPackage.AddFile("md5.go", nosecSource)
+			err := nosecPackage.Build()
+			Expect(err).ShouldNot(HaveOccurred())
+			err = analyzer.Process(buildTags, nosecPackage.Path)
+			Expect(err).ShouldNot(HaveOccurred())
+			nosecIssues, _, _ := analyzer.Report()
+			Expect(nosecIssues).Should(BeEmpty())
+		})
+
+		It("should report errors when there are nosec tags after a #nosec WrongRuleList annotation", func() {
+			sample := testutils.SampleCodeG401[0]
+			source := sample.Code[0]
+			analyzer.LoadRules(rules.Generate(false, rules.NewRuleFilter(false, "G401")).RulesInfo())
+
+			nosecPackage := testutils.NewTestPackage()
+			defer nosecPackage.Close()
+			nosecSource := strings.Replace(source, "h := md5.New()", "//#nosec //G301\n//#nosec\nh := md5.New()", 1)
+			nosecPackage.AddFile("md5.go", nosecSource)
+			err := nosecPackage.Build()
+			Expect(err).ShouldNot(HaveOccurred())
+			err = analyzer.Process(buildTags, nosecPackage.Path)
+			Expect(err).ShouldNot(HaveOccurred())
+			nosecIssues, _, _ := analyzer.Report()
+			Expect(nosecIssues).Should(HaveLen(sample.Errors))
+		})
+
 		It("should be possible to use an alternative nosec tag", func() {
 			// Rule for MD5 weak crypto usage
 			sample := testutils.SampleCodeG401[0]


### PR DESCRIPTION
### Problem

fixes #743 

Details can be seen in #743.

### Solution

If a `nosec` tag is:
- the prefix of the comment (group)
- or the prefix of a line in the multi-line comment (group), where the whitespaces in this line before `nosec` are ignored.

then `nosec` will work.

For example:

```go
//#nosec
```
```go
// #nosec
```
```go
//#nosec G101
```
```go
// #nosec G101
```
```go
// Some description
// #nosec
```
```go
//#nosec -- justification
```
```go
//#nosec
//-- justification
```
```go
//#nosec
//G101 G102
```

Examples that `#nosec` will not work:

```go
//Some description #nosec
```
```go
// Some description #nosec
// Another description
```

Bad practices:

```go
// G101
//#nosec
ViolateG102() // This violation will not be reported since "G101" before "#nosec" is discarded.
```
```go
//#nosec G101
//#nosec
ViolateG102() // This violation will be reported since only G101 is suppressed here.
```
```go
//#nosec
//This description will not be tracked as a justification of this suppression.
Violate()
```