### PR TITLE
build(fmt): use `[` instead of `[[`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ test: install-test-deps build fmt lint sec
 fmt:
 	@echo "FORMATTING"
 	@FORMATTED=`$(GO) fmt ./...`
-	@([[ ! -z "$(FORMATTED)" ]] && printf "Fixed unformatted files:\n$(FORMATTED)") || true
+	@([ ! -z "$(FORMATTED)" ] && printf "Fixed unformatted files:\n$(FORMATTED)") || true
 
 lint:
 	@echo "LINTING"


### PR DESCRIPTION
When `/bin/sh` is not a shell having `[[`, `make fmt` fails:

```
FORMATTING
/bin/sh: 1: [[: not found
```