### PR TITLE
Fix false negative for SQL injection when using DB.QueryRow.Scan()

### DIFF
--- a/rules/sql.go
+++ b/rules/sql.go
@@ -261,14 +261,12 @@ func (s *sqlStrFormat) Match(n ast.Node, ctx *gosec.Context) (*gosec.Issue, erro
 	switch stmt := n.(type) {
 	case *ast.AssignStmt:
 		for _, expr := range stmt.Rhs {
-			// when expr is CallExpr and Call.Fun.X is CallExpr ,check Call.Fun.X
-			if Call, ok := expr.(*ast.CallExpr); ok {
-				Selector, ok := Call.Fun.(*ast.SelectorExpr)
+			if call, ok := expr.(*ast.CallExpr); ok {
+				selector, ok := call.Fun.(*ast.SelectorExpr)
 				if !ok {
 					continue
 				}
-				sqlQueryCall, ok := Selector.X.(*ast.CallExpr)
-				// checkQuery when success get sqlQuery CallExpr and Selector contains Callexpr
+				sqlQueryCall, ok := selector.X.(*ast.CallExpr)
 				if ok && s.ContainsCallExpr(sqlQueryCall, ctx) != nil {
 					issue, err := s.checkQuery(sqlQueryCall, ctx)
 					if err == nil && issue != nil {

--- a/rules/sql.go
+++ b/rules/sql.go
@@ -261,6 +261,21 @@ func (s *sqlStrFormat) Match(n ast.Node, ctx *gosec.Context) (*gosec.Issue, erro
 	switch stmt := n.(type) {
 	case *ast.AssignStmt:
 		for _, expr := range stmt.Rhs {
+			// when expr is CallExpr and Call.Fun.X is CallExpr ,check Call.Fun.X
+			if Call, ok := expr.(*ast.CallExpr); ok {
+				Selector, ok := Call.Fun.(*ast.SelectorExpr)
+				if !ok {
+					continue
+				}
+				sqlQueryCall, ok := Selector.X.(*ast.CallExpr)
+				// checkQuery when success get sqlQuery CallExpr and Selector contains Callexpr
+				if ok && s.ContainsCallExpr(sqlQueryCall, ctx) != nil {
+					issue, err := s.checkQuery(sqlQueryCall, ctx)
+					if err == nil && issue != nil {
+						return issue, err
+					}
+				}
+			}
 			if sqlQueryCall, ok := expr.(*ast.CallExpr); ok && s.ContainsCallExpr(expr, ctx) != nil {
 				return s.checkQuery(sqlQueryCall, ctx)
 			}

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -1189,6 +1189,75 @@ func main(){
 		panic(err)
 	}
 	defer rows.Close()
+<<<<<<< HEAD
+}`}, 1, gosec.NewConfig()}, {[]string{`
+// Format string with \n\r
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+)
+
+func main(){
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		panic(err)
+	}
+	q := fmt.Sprintf("SELECT * FROM foo where\nname = '%s'", os.Args[1])
+	rows, err := db.Query(q)
+	if err != nil {
+		panic(err)
+	}
+	defer rows.Close()
+}`}, 1, gosec.NewConfig()}, {[]string{`
+// SQLI by db.Query(some).Scan(&other)
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+)
+
+func main() {
+	var name string
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		panic(err)
+	}
+	q := fmt.Sprintf("SELECT name FROM users where id = '%s'", os.Args[1])
+	row := db.QueryRow(q)
+	err = row.Scan(&name)
+	if err != nil {
+		panic(err)
+	}
+	defer db.Close()
+}`}, 1, gosec.NewConfig()}, {[]string{`
+// SQLI by db.Query(some).Scan(&other)
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+)
+
+func main() {
+	var name string
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		panic(err)
+	}
+	q := fmt.Sprintf("SELECT name FROM users where id = '%s'", os.Args[1])
+	err = db.QueryRow(q).Scan(&name)
+	if err != nil {
+		panic(err)
+	}
+	defer db.Close()
+=======
+>>>>>>> 58058af0c8275f11249a71f18fc548bbd7b97ccc
 }`}, 1, gosec.NewConfig()},
 	}
 

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -1189,7 +1189,6 @@ func main(){
 		panic(err)
 	}
 	defer rows.Close()
-<<<<<<< HEAD
 }`}, 1, gosec.NewConfig()}, {[]string{`
 // Format string with \n\r
 package main
@@ -1256,8 +1255,6 @@ func main() {
 		panic(err)
 	}
 	defer db.Close()
-=======
->>>>>>> 58058af0c8275f11249a71f18fc548bbd7b97ccc
 }`}, 1, gosec.NewConfig()},
 	}
 


### PR DESCRIPTION
Problem
fixes #713

Details :
can be seen in #713.
G201 regexp only match callexpr once.
If there is a sqlquery like the following, there will be problems with matching.

func main() {
	var name string
	db, err := sql.Open("sqlite3", ":memory:")
	if err != nil {
		panic(err)
	}
	q := fmt.Sprintf("SELECT name FROM users where id = '%s'", os.Args[1])
	err = db.QueryRow(q).Scan(&name)
	if err != nil {
		panic(err)
	}
	defer db.Close()
}

Solution
Add an extra check befor checkQuery.