### PR TITLE
Fix TLS min version resolution when is defined in the same package but in a different file

### DIFF
--- a/rules/tls.go
+++ b/rules/tls.go
@@ -87,7 +87,7 @@ func (t *insecureConfigTLS) processTLSConfVal(n *ast.KeyValueExpr, c *gosec.Cont
 			}
 
 		case "MinVersion":
-			if d, ok := n.Value.(*ast.Ident); ok {
+			if d, ok := n.Value.(*ast.Ident); ok && d.Obj != nil {
 				if vs, ok := d.Obj.Decl.(*ast.ValueSpec); ok && len(vs.Values) > 0 {
 					if s, ok := vs.Values[0].(*ast.SelectorExpr); ok {
 						x := s.X.(*ast.Ident).Name

--- a/rules/tls.go
+++ b/rules/tls.go
@@ -87,8 +87,17 @@ func (t *insecureConfigTLS) processTLSConfVal(n *ast.KeyValueExpr, c *gosec.Cont
 			}
 
 		case "MinVersion":
-			if d, ok := n.Value.(*ast.Ident); ok && d.Obj != nil {
-				if vs, ok := d.Obj.Decl.(*ast.ValueSpec); ok && len(vs.Values) > 0 {
+			if d, ok := n.Value.(*ast.Ident); ok {
+				obj := d.Obj
+				if obj == nil {
+					for _, f := range c.PkgFiles {
+						obj = f.Scope.Lookup(d.Name)
+						if obj != nil {
+							break
+						}
+					}
+				}
+				if vs, ok := obj.Decl.(*ast.ValueSpec); ok && len(vs.Values) > 0 {
 					if s, ok := vs.Values[0].(*ast.SelectorExpr); ok {
 						x := s.X.(*ast.Ident).Name
 						sel := s.Sel.Name

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -2838,6 +2838,27 @@ func TlsConfig1() *tls.Config {
    return &tls.Config{MinVersion: 0x0304}
 }
 `}, 1, gosec.NewConfig()},
+		{[]string{`
+package main
+
+import (
+	"crypto/tls"
+	"fmt"
+)
+
+func main() {
+	cfg := tls.Config{
+		MinVersion: MinVer,
+	}
+	fmt.Println("tls min version", cfg.MinVersion)
+}
+`, `
+package main
+
+import "crypto/tls"
+
+const MinVer = tls.VersionTLS13
+`}, 0, gosec.NewConfig()},
 	}
 
 	// SampleCodeG403 - weak key strength


### PR DESCRIPTION
- Add a test for tls min version defined in a different file
- Resolve the TLS min version when is declarted in the same package but in a different file

fixes #767 