### PR TITLE
Process the code snippet before adding it to the SARIF report

### DIFF
--- a/report/sarif/formatter.go
+++ b/report/sarif/formatter.go
@@ -188,7 +188,24 @@ func parseSarifRegion(issue *gosec.Issue) (*Region, error) {
 	if err != nil {
 		return nil, err
 	}
-	snippet := NewArtifactContent(issue.Code)
+	var code string
+	line := startLine
+	codeLines := strings.Split(issue.Code, "\n")
+	for _, codeLine := range codeLines {
+		lineStart := fmt.Sprintf("%d:", line)
+		if strings.HasPrefix(codeLine, lineStart) {
+			code += strings.TrimSpace(
+				strings.TrimPrefix(codeLine, lineStart))
+			if endLine > startLine {
+				code += "\n"
+			}
+			line++
+			if line > endLine {
+				break
+			}
+		}
+	}
+	snippet := NewArtifactContent(code)
 	return NewRegion(startLine, endLine, col, col, "go").WithSnippet(snippet), nil
 }
 

--- a/report/sarif/sarif_test.go
+++ b/report/sarif/sarif_test.go
@@ -56,5 +56,59 @@ var _ = Describe("Sarif Formatter", func() {
 			hasSuppressions, _ := regexp.MatchString(`"suppressions": \[(\s*){`, result)
 			Expect(hasSuppressions).To(BeTrue())
 		})
+		It("sarif formatted report should contain the formatted one line code snippet", func() {
+			ruleID := "G101"
+			cwe := gosec.GetCweByRule(ruleID)
+			code := "68: \t\t}\n69: \t\tvar data = template.HTML(v.TmplFile)\n70: \t\tisTmpl := true\n"
+			expectedCode := "var data = template.HTML(v.TmplFile)"
+			issue := gosec.Issue{
+				File:       "/home/src/project/test.go",
+				Line:       "69",
+				Col:        "14",
+				RuleID:     ruleID,
+				What:       "test",
+				Confidence: gosec.High,
+				Severity:   gosec.High,
+				Code:       code,
+				Cwe:        cwe,
+				Suppressions: []gosec.SuppressionInfo{
+					{
+						Kind:          "kind",
+						Justification: "justification",
+					},
+				},
+			}
+			reportInfo := gosec.NewReportInfo([]*gosec.Issue{&issue}, &gosec.Metrics{}, map[string][]gosec.Error{}).WithVersion("v2.7.0")
+			sarifReport, err := sarif.GenerateReport([]string{}, reportInfo)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(sarifReport.Runs[0].Results[0].Locations[0].PhysicalLocation.Region.Snippet.Text).Should(Equal(expectedCode))
+		})
+		It("sarif formatted report should contain the formatted multiple line code snippet", func() {
+			ruleID := "G101"
+			cwe := gosec.GetCweByRule(ruleID)
+			code := "68: }\n69: var data = template.HTML(v.TmplFile)\n70: isTmpl := true\n"
+			expectedCode := "var data = template.HTML(v.TmplFile)\nisTmpl := true\n"
+			issue := gosec.Issue{
+				File:       "/home/src/project/test.go",
+				Line:       "69-70",
+				Col:        "14",
+				RuleID:     ruleID,
+				What:       "test",
+				Confidence: gosec.High,
+				Severity:   gosec.High,
+				Code:       code,
+				Cwe:        cwe,
+				Suppressions: []gosec.SuppressionInfo{
+					{
+						Kind:          "kind",
+						Justification: "justification",
+					},
+				},
+			}
+			reportInfo := gosec.NewReportInfo([]*gosec.Issue{&issue}, &gosec.Metrics{}, map[string][]gosec.Error{}).WithVersion("v2.7.0")
+			sarifReport, err := sarif.GenerateReport([]string{}, reportInfo)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(sarifReport.Runs[0].Results[0].Locations[0].PhysicalLocation.Region.Snippet.Text).Should(Equal(expectedCode))
+		})
 	})
 })


### PR DESCRIPTION
Preprocess the code snippet from the issue in order to extract only the line(s)
of code where the issue is located.  In addition remove the line numbers and whitespaces
before writing the code snippet into the SARIF report.

fixes #773