### PR TITLE
feat: add concurrency option to parallelize package loading

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -166,7 +166,6 @@ func (gosec *Analyzer) Process(buildTags []string, packagePaths ...string) error
 	jobs := make(chan string)
 
 	var wg sync.WaitGroup
-	wg.Add(gosec.concurrency)
 
 	worker := func(j chan string, r chan result) {
 		for s := range j {
@@ -177,6 +176,7 @@ func (gosec *Analyzer) Process(buildTags []string, packagePaths ...string) error
 	}
 
 	for i := 0; i < gosec.concurrency; i++ {
+		wg.Add(1)
 		go worker(jobs, results)
 	}
 

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Analyzer", func() {
 	)
 	BeforeEach(func() {
 		logger, _ = testutils.NewLogger()
-		analyzer = gosec.NewAnalyzer(nil, tests, false, false, logger)
+		analyzer = gosec.NewAnalyzer(nil, tests, false, false, 1, logger)
 	})
 
 	Context("when processing a package", func() {
@@ -262,7 +262,7 @@ var _ = Describe("Analyzer", func() {
 			// overwrite nosec option
 			nosecIgnoreConfig := gosec.NewConfig()
 			nosecIgnoreConfig.SetGlobal(gosec.Nosec, "true")
-			customAnalyzer := gosec.NewAnalyzer(nosecIgnoreConfig, tests, false, false, logger)
+			customAnalyzer := gosec.NewAnalyzer(nosecIgnoreConfig, tests, false, false, 1, logger)
 			customAnalyzer.LoadRules(rules.Generate(false, rules.NewRuleFilter(false, "G401")).RulesInfo())
 
 			nosecPackage := testutils.NewTestPackage()
@@ -286,7 +286,7 @@ var _ = Describe("Analyzer", func() {
 			nosecIgnoreConfig := gosec.NewConfig()
 			nosecIgnoreConfig.SetGlobal(gosec.Nosec, "true")
 			nosecIgnoreConfig.SetGlobal(gosec.ShowIgnored, "true")
-			customAnalyzer := gosec.NewAnalyzer(nosecIgnoreConfig, tests, false, false, logger)
+			customAnalyzer := gosec.NewAnalyzer(nosecIgnoreConfig, tests, false, false, 1, logger)
 			customAnalyzer.LoadRules(rules.Generate(false, rules.NewRuleFilter(false, "G401")).RulesInfo())
 
 			nosecPackage := testutils.NewTestPackage()
@@ -379,7 +379,7 @@ var _ = Describe("Analyzer", func() {
 			// overwrite nosec option
 			nosecIgnoreConfig := gosec.NewConfig()
 			nosecIgnoreConfig.SetGlobal(gosec.NoSecAlternative, "#falsePositive")
-			customAnalyzer := gosec.NewAnalyzer(nosecIgnoreConfig, tests, false, false, logger)
+			customAnalyzer := gosec.NewAnalyzer(nosecIgnoreConfig, tests, false, false, 1, logger)
 			customAnalyzer.LoadRules(rules.Generate(false, rules.NewRuleFilter(false, "G401")).RulesInfo())
 
 			nosecPackage := testutils.NewTestPackage()
@@ -402,7 +402,7 @@ var _ = Describe("Analyzer", func() {
 			// overwrite nosec option
 			nosecIgnoreConfig := gosec.NewConfig()
 			nosecIgnoreConfig.SetGlobal(gosec.NoSecAlternative, "#falsePositive")
-			customAnalyzer := gosec.NewAnalyzer(nosecIgnoreConfig, tests, false, false, logger)
+			customAnalyzer := gosec.NewAnalyzer(nosecIgnoreConfig, tests, false, false, 1, logger)
 			customAnalyzer.LoadRules(rules.Generate(false, rules.NewRuleFilter(false, "G401")).RulesInfo())
 
 			nosecPackage := testutils.NewTestPackage()
@@ -418,7 +418,7 @@ var _ = Describe("Analyzer", func() {
 		})
 
 		It("should be able to analyze Go test package", func() {
-			customAnalyzer := gosec.NewAnalyzer(nil, true, false, false, logger)
+			customAnalyzer := gosec.NewAnalyzer(nil, true, false, false, 1, logger)
 			customAnalyzer.LoadRules(rules.Generate(false).RulesInfo())
 			pkg := testutils.NewTestPackage()
 			defer pkg.Close()
@@ -443,7 +443,7 @@ var _ = Describe("Analyzer", func() {
 			Expect(issues).Should(HaveLen(1))
 		})
 		It("should be able to scan generated files if NOT excluded", func() {
-			customAnalyzer := gosec.NewAnalyzer(nil, true, false, false, logger)
+			customAnalyzer := gosec.NewAnalyzer(nil, true, false, false, 1, logger)
 			customAnalyzer.LoadRules(rules.Generate(false).RulesInfo())
 			pkg := testutils.NewTestPackage()
 			defer pkg.Close()
@@ -464,7 +464,7 @@ var _ = Describe("Analyzer", func() {
 			Expect(issues).Should(HaveLen(1))
 		})
 		It("should be able to skip generated files if excluded", func() {
-			customAnalyzer := gosec.NewAnalyzer(nil, true, true, false, logger)
+			customAnalyzer := gosec.NewAnalyzer(nil, true, true, false, 1, logger)
 			customAnalyzer.LoadRules(rules.Generate(false).RulesInfo())
 			pkg := testutils.NewTestPackage()
 			defer pkg.Close()
@@ -671,7 +671,7 @@ var _ = Describe("Analyzer", func() {
 
 	Context("when tracking suppressions", func() {
 		BeforeEach(func() {
-			analyzer = gosec.NewAnalyzer(nil, tests, false, true, logger)
+			analyzer = gosec.NewAnalyzer(nil, tests, false, true, 1, logger)
 		})
 
 		It("should not report an error if the violation is suppressed", func() {

--- a/cmd/gosec/main.go
+++ b/cmd/gosec/main.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"runtime"
 	"sort"
 	"strings"
 
@@ -113,6 +114,9 @@ var (
 
 	// fail by confidence
 	flagConfidence = flag.String("confidence", "low", "Filter out the issues with a lower confidence than the given value. Valid options are: low, medium, high")
+
+	// concurrency value
+	flagConcurrency = flag.Int("concurrency", runtime.NumCPU(), "Concurrency value")
 
 	// do not fail
 	flagNoFail = flag.Bool("no-fail", false, "Do not fail the scanning, even if issues were found")
@@ -371,7 +375,7 @@ func main() {
 	}
 
 	// Create the analyzer
-	analyzer := gosec.NewAnalyzer(config, *flagScanTests, *flagExcludeGenerated, *flagTrackSuppressions, logger)
+	analyzer := gosec.NewAnalyzer(config, *flagScanTests, *flagExcludeGenerated, *flagTrackSuppressions, *flagConcurrency, logger)
 	analyzer.LoadRules(ruleList.RulesInfo())
 
 	excludedDirs := gosec.ExcludedDirsRegExp(flagDirsExclude)

--- a/rules/rules_test.go
+++ b/rules/rules_test.go
@@ -24,7 +24,7 @@ var _ = Describe("gosec rules", func() {
 	BeforeEach(func() {
 		logger, _ = testutils.NewLogger()
 		config = gosec.NewConfig()
-		analyzer = gosec.NewAnalyzer(config, tests, false, false, logger)
+		analyzer = gosec.NewAnalyzer(config, tests, false, false, 1, logger)
 		runner = func(rule string, samples []testutils.CodeSample) {
 			for n, sample := range samples {
 				analyzer.Reset()


### PR DESCRIPTION
This PR adds support for running package loading in parallel due to `gosec.load` being a major bottleneck for big projects. 

The concurrency option defaults to the number of available CPUs and tests are using a concurrency value of 1.

## Benchmarks:

Benchmarks of a couple of GitLab projects using [hyperfine](https://github.com/sharkdp/hyperfine/):
___

### [Gitlab Pages](https://gitlab.com/gitlab-org/gitlab-pages):

#### before:

```
Benchmark 1: /path/to/gosec -exclude-generated ./...
Time (mean ± σ):     11.384 s ±  0.227 s    [User: 28.443 s, System: 8.731 s]
Range (min … max):   10.974 s … 11.793 s    10 runs

Warning: Ignoring non-zero exit code.
```

#### after:

```
Benchmark 1: /path/to/gosec -exclude-generated ./...
Time (mean ± σ):      2.292 s ±  0.078 s    [User: 23.965 s, System: 8.732 s]
Range (min … max):    2.230 s …  2.469 s    10 runs

Warning: Ignoring non-zero exit code.
```

### [Gitaly](https://gitlab.com/gitlab-org/gitaly/)

#### before:

```
Benchmark 1: /path/to/gosec -exclude-generated ./...
Time (mean ± σ):     27.442 s ±  0.710 s    [User: 75.289 s, System: 20.270 s]
Range (min … max):   26.601 s … 28.497 s    10 runs

Warning: Ignoring non-zero exit code.
```

#### after:

```
Benchmark 1: /path/to/gosec -exclude-generated ./...
Time (mean ± σ):      5.953 s ±  1.047 s    [User: 67.921 s, System: 20.703 s]
Range (min … max):    5.237 s …  8.658 s    10 runs

Warning: Ignoring non-zero exit code.
```
