### PR TITLE
Add option to specify multiple nodes for Issue

### DIFF
--- a/issue_test.go
+++ b/issue_test.go
@@ -126,6 +126,10 @@ func main() {
 			Expect(issue.Col).Should(Equal("10"))
 		})
 
+		It("should support multiple nodes", func() {
+			Skip("Not implemented")
+		})
+
 		It("should maintain the provided severity score", func() {
 			Skip("Not implemented")
 		})

--- a/rules/sql.go
+++ b/rules/sql.go
@@ -95,7 +95,7 @@ func (s *sqlStrConcat) checkQuery(call *ast.CallExpr, ctx *gosec.Context) (*gose
 				if op, ok := op.(*ast.Ident); ok && s.checkObject(op, ctx) {
 					continue
 				}
-				return gosec.NewIssue(ctx, be, s.ID(), s.What, s.Severity, s.Confidence), nil
+				return gosec.NewIssue(ctx, query, s.ID(), s.What, s.Severity, s.Confidence), nil
 			}
 		}
 	}
@@ -186,7 +186,7 @@ func (s *sqlStrFormat) checkQuery(call *ast.CallExpr, ctx *gosec.Context) (*gose
 		decl := ident.Obj.Decl
 		if assign, ok := decl.(*ast.AssignStmt); ok {
 			for _, expr := range assign.Rhs {
-				issue := s.checkFormatting(expr, ctx)
+				issue := s.checkFormatting(expr, ctx, query)
 				if issue != nil {
 					return issue, err
 				}
@@ -197,7 +197,7 @@ func (s *sqlStrFormat) checkQuery(call *ast.CallExpr, ctx *gosec.Context) (*gose
 	return nil, nil
 }
 
-func (s *sqlStrFormat) checkFormatting(n ast.Node, ctx *gosec.Context) *gosec.Issue {
+func (s *sqlStrFormat) checkFormatting(n ast.Node, ctx *gosec.Context, query ast.Node) *gosec.Issue {
 	// argIndex changes the function argument which gets matched to the regex
 	argIndex := 0
 	if node := s.fmtCalls.ContainsPkgCallExpr(n, ctx, false); node != nil {
@@ -250,7 +250,7 @@ func (s *sqlStrFormat) checkFormatting(n ast.Node, ctx *gosec.Context) *gosec.Is
 			}
 		}
 		if s.MatchPatterns(formatter) {
-			return gosec.NewIssue(ctx, n, s.ID(), s.What, s.Severity, s.Confidence)
+			return gosec.NewIssue(ctx, query, s.ID(), s.What, s.Severity, s.Confidence)
 		}
 	}
 	return nil

--- a/rules/sql.go
+++ b/rules/sql.go
@@ -95,7 +95,7 @@ func (s *sqlStrConcat) checkQuery(call *ast.CallExpr, ctx *gosec.Context) (*gose
 				if op, ok := op.(*ast.Ident); ok && s.checkObject(op, ctx) {
 					continue
 				}
-				return gosec.NewIssue(ctx, query, s.ID(), s.What, s.Severity, s.Confidence), nil
+				return gosec.NewIssueMultipleNodes(ctx, []ast.Node{query, call}, s.ID(), s.What, s.Severity, s.Confidence), nil
 			}
 		}
 	}
@@ -250,7 +250,7 @@ func (s *sqlStrFormat) checkFormatting(n ast.Node, ctx *gosec.Context, query ast
 			}
 		}
 		if s.MatchPatterns(formatter) {
-			return gosec.NewIssue(ctx, query, s.ID(), s.What, s.Severity, s.Confidence)
+			return gosec.NewIssueMultipleNodes(ctx, []ast.Node{query, n}, s.ID(), s.What, s.Severity, s.Confidence)
 		}
 	}
 	return nil


### PR DESCRIPTION
builds on top of https://github.com/securego/gosec/pull/798 because that's where the need for specifying multiple nodes comes from.

If the maintainers like this change then I'll add some tests, but considering I have to figure out how to use the test utils I'd like a :+1: before investing that time.

I don't like the `NewIssueMultipleNodes` naming, but can't think of something better, except maybe:
```
func NewIssue(ctx *Context, node ast.Node, ruleID, desc string, severity Score, confidence Score, extraNodes ...ast.Node) *Issue {
```

but I think it varies heavily per person if you like that approach or not ;)
