### PR TITLE
Add check for usage of Rat.SetString in math/big with an overflow error

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ directory you can supply `./...` as the input argument.
 - G504: Import blocklist: net/http/cgi
 - G505: Import blocklist: crypto/sha1
 - G601: Implicit memory aliasing of items from a range statement
+- G602: Usage of Rat.SetString in math/big with an overflow (CVE-2022-23772)
 
 ### Retired rules
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ directory you can supply `./...` as the input argument.
 - G110: Potential DoS vulnerability via decompression bomb
 - G111: Potential directory traversal
 - G112: Potential slowloris attack
+- G113: Usage of Rat.SetString in math/big with an overflow (CVE-2022-23772)
 - G201: SQL query construction using format string
 - G202: SQL query construction using string concatenation
 - G203: Use of unescaped data in HTML templates
@@ -166,7 +167,6 @@ directory you can supply `./...` as the input argument.
 - G504: Import blocklist: net/http/cgi
 - G505: Import blocklist: crypto/sha1
 - G601: Implicit memory aliasing of items from a range statement
-- G602: Usage of Rat.SetString in math/big with an overflow (CVE-2022-23772)
 
 ### Retired rules
 

--- a/issue.go
+++ b/issue.go
@@ -86,6 +86,7 @@ var ruleToCWE = map[string]string{
 	"G504": "327",
 	"G505": "327",
 	"G601": "118",
+	"G602": "190",
 }
 
 // Issue is returned by a gosec rule if it discovers an issue with the scanned code.
@@ -182,7 +183,7 @@ func NewIssue(ctx *Context, node ast.Node, ruleID, desc string, severity Score, 
 
 	var code string
 	if file, err := os.Open(fobj.Name()); err == nil {
-		defer file.Close() //#nosec
+		defer file.Close() // #nosec
 		s := codeSnippetStartLine(node, fobj)
 		e := codeSnippetEndLine(node, fobj)
 		code, err = codeSnippet(file, s, e, node)

--- a/issue.go
+++ b/issue.go
@@ -65,6 +65,7 @@ var ruleToCWE = map[string]string{
 	"G110": "409",
 	"G111": "22",
 	"G112": "400",
+	"G113": "190",
 	"G201": "89",
 	"G202": "89",
 	"G203": "79",
@@ -86,7 +87,6 @@ var ruleToCWE = map[string]string{
 	"G504": "327",
 	"G505": "327",
 	"G601": "118",
-	"G602": "190",
 }
 
 // Issue is returned by a gosec rule if it discovers an issue with the scanned code.

--- a/report/formatter_test.go
+++ b/report/formatter_test.go
@@ -277,10 +277,10 @@ var _ = Describe("Formatter", func() {
 	Context("When using different report formats", func() {
 		grules := []string{
 			"G101", "G102", "G103", "G104", "G106", "G107", "G109",
-			"G110", "G111", "G112", "G201", "G202", "G203", "G204", "G301",
-			"G302", "G303", "G304", "G305", "G401", "G402", "G403",
-			"G404", "G501", "G502", "G503", "G504", "G505", "G601",
-			"G602",
+			"G110", "G111", "G112", "G113", "G201", "G202", "G203",
+			"G204", "G301", "G302", "G303", "G304", "G305", "G401",
+			"G402", "G403", "G404", "G501", "G502", "G503", "G504",
+			"G505", "G601",
 		}
 
 		It("csv formatted report should contain the CWE mapping", func() {

--- a/report/formatter_test.go
+++ b/report/formatter_test.go
@@ -279,7 +279,8 @@ var _ = Describe("Formatter", func() {
 			"G101", "G102", "G103", "G104", "G106", "G107", "G109",
 			"G110", "G111", "G112", "G201", "G202", "G203", "G204", "G301",
 			"G302", "G303", "G304", "G305", "G401", "G402", "G403",
-			"G404", "G501", "G502", "G503", "G504", "G505",
+			"G404", "G501", "G502", "G503", "G504", "G505", "G601",
+			"G602",
 		}
 
 		It("csv formatted report should contain the CWE mapping", func() {

--- a/rules/math_big_rat.go
+++ b/rules/math_big_rat.go
@@ -1,0 +1,98 @@
+package rules
+
+import (
+	"fmt"
+	"go/ast"
+
+	"github.com/securego/gosec/v2"
+)
+
+type usingOldMathBig struct {
+	gosec.MetaData
+}
+
+func (r *usingOldMathBig) ID() string {
+	return r.MetaData.ID
+}
+
+func getXName(elem ast.Stmt) (*ast.IfStmt, string, error) {
+	ifStmt, ok := elem.(*ast.IfStmt)
+	if !ok {
+		return nil, "", fmt.Errorf("not an if")
+	}
+	ifCond, ok := ifStmt.Cond.(*ast.BinaryExpr)
+	if !ok {
+		return nil, "", fmt.Errorf("not a BinaryExpr")
+	}
+	ifCondX, ok := ifCond.X.(*ast.Ident)
+	if !ok {
+		return nil, "", fmt.Errorf("X not an Ident")
+	}
+	return ifStmt, ifCondX.Name, nil
+}
+
+func (r *usingOldMathBig) Match(node ast.Node, ctx *gosec.Context) (gi *gosec.Issue, err error) {
+	callExpr, callExprOk := node.(*ast.CallExpr)
+	if !callExprOk {
+		return nil, nil
+	}
+
+	packageName, callName, callInfoOk := gosec.GetCallInfo(callExpr, ctx)
+	if callInfoOk != nil {
+		return nil, nil
+	}
+
+	if packageName != "math/big.Rat" || callName != "SetString" {
+		return nil, nil
+	}
+
+	funcDecl, funcDeclErr := gosec.FindFuncDecl(callExpr, ctx)
+	if funcDeclErr != nil {
+		return nil, nil
+	}
+
+	for _, elem := range funcDecl.Body.List {
+		firstIf, firstName, err := getXName(elem)
+		if err != nil {
+			continue
+		}
+		if firstName != "exp5" {
+			continue
+		}
+		for _, secondElem := range firstIf.Body.List {
+			secondIf, secondName, err := getXName(secondElem)
+			if err != nil {
+				continue
+			}
+			if secondName != "n" {
+				continue
+			}
+			hasIf := false
+			for _, thirdElem := range secondIf.Body.List {
+				_, _, err := getXName(thirdElem)
+				if err != nil {
+					continue
+				}
+				hasIf = true
+			}
+			if hasIf {
+				return nil, nil
+			}
+			return gosec.NewIssue(ctx, node, r.ID(), r.What, r.Severity, r.Confidence), nil
+		}
+	}
+
+	return nil, nil
+}
+
+// NewUsingOldMathBig rule detects the use of Rat.SetString from math/big.
+func NewUsingOldMathBig(id string, conf gosec.Config) (gosec.Rule, []ast.Node) {
+	return &usingOldMathBig{
+		MetaData: gosec.MetaData{
+			ID:         id,
+			What:       "Rat.SetString in math/big in has an overflow that can lead to Uncontrolled Memory Consumption (CVE-2022-23772)",
+			Severity:   gosec.High,
+			Confidence: gosec.High,
+		},
+	}, []ast.Node{(*ast.CallExpr)(nil)}
+}

--- a/rules/rulelist.go
+++ b/rules/rulelist.go
@@ -75,6 +75,7 @@ func Generate(trackSuppressions bool, filters ...RuleFilter) RuleList {
 		{"G110", "Detect io.Copy instead of io.CopyN when decompression", NewDecompressionBombCheck},
 		{"G111", "Detect http.Dir('/') as a potential risk", NewDirectoryTraversal},
 		{"G112", "Detect ReadHeaderTimeout not configured as a potential risk", NewSlowloris},
+		{"G113", "Usage of Rat.SetString in math/big with an overflow", NewUsingOldMathBig},
 
 		// injection
 		{"G201", "SQL query construction using format string", NewSQLStrFormat},
@@ -106,7 +107,6 @@ func Generate(trackSuppressions bool, filters ...RuleFilter) RuleList {
 
 		// memory safety
 		{"G601", "Implicit memory aliasing in RangeStmt", NewImplicitAliasing},
-		{"G602", "Usage of Rat.SetString in math/big with an overflow", NewUsingOldMathBig},
 	}
 
 	ruleMap := make(map[string]RuleDefinition)

--- a/rules/rulelist.go
+++ b/rules/rulelist.go
@@ -106,6 +106,7 @@ func Generate(trackSuppressions bool, filters ...RuleFilter) RuleList {
 
 		// memory safety
 		{"G601", "Implicit memory aliasing in RangeStmt", NewImplicitAliasing},
+		{"G602", "Usage of Rat.SetString in math/big with an overflow", NewUsingOldMathBig},
 	}
 
 	ruleMap := make(map[string]RuleDefinition)

--- a/rules/rules_test.go
+++ b/rules/rules_test.go
@@ -101,6 +101,15 @@ var _ = Describe("gosec rules", func() {
 			runner("G112", testutils.SampleCodeG112)
 		})
 
+		versionParts := strings.Split(runtime.Version(), ".")
+		minor, _ := strconv.Atoi(versionParts[1])
+		build, _ := strconv.Atoi(versionParts[2])
+		if versionParts[0] == "go1" && (minor == 16 && build < 14 || minor == 17 && build < 7) {
+			It("should detect usage of Rat.SetString in math/big with an overflow", func() {
+				runner("G113", testutils.SampleCodeG113)
+			})
+		}
+
 		It("should detect sql injection via format strings", func() {
 			runner("G201", testutils.SampleCodeG201)
 		})
@@ -188,14 +197,5 @@ var _ = Describe("gosec rules", func() {
 		It("should detect implicit aliasing in ForRange", func() {
 			runner("G601", testutils.SampleCodeG601)
 		})
-
-		versionParts := strings.Split(runtime.Version(), ".")
-		minor, _ := strconv.Atoi(versionParts[1])
-		build, _ := strconv.Atoi(versionParts[2])
-		if versionParts[0] == "go1" && (minor == 16 && build < 14 || minor == 17 && build < 7) {
-			It("should detect usage of Rat.SetString in math/big with an overflow", func() {
-				runner("G602", testutils.SampleCodeG602)
-			})
-		}
 	})
 })

--- a/rules/rules_test.go
+++ b/rules/rules_test.go
@@ -3,6 +3,9 @@ package rules_test
 import (
 	"fmt"
 	"log"
+	"runtime"
+	"strconv"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -185,5 +188,14 @@ var _ = Describe("gosec rules", func() {
 		It("should detect implicit aliasing in ForRange", func() {
 			runner("G601", testutils.SampleCodeG601)
 		})
+
+		versionParts := strings.Split(runtime.Version(), ".")
+		minor, _ := strconv.Atoi(versionParts[1])
+		build, _ := strconv.Atoi(versionParts[2])
+		if versionParts[0] == "go1" && (minor == 16 && build < 14 || minor == 17 && build < 7) {
+			It("should detect usage of Rat.SetString in math/big with an overflow", func() {
+				runner("G602", testutils.SampleCodeG602)
+			})
+		}
 	})
 })

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -3166,6 +3166,25 @@ func main() {
 }`}, 0, gosec.NewConfig()},
 	}
 
+	// SampleCodeG602 - Usage of Rat.SetString in math/big with an overflow
+	SampleCodeG602 = []CodeSample{
+		{[]string{
+			`
+package main
+
+import (
+        "math/big"
+)
+
+func main() {
+        r := big.Rat{}
+        r.SetString("13e-9223372036854775808")
+
+		fmt.Println(r)
+}`,
+		}, 1, gosec.NewConfig()},
+	}
+
 	// SampleCodeBuildTag - G601 build tags
 	SampleCodeBuildTag = []CodeSample{{[]string{`
 // +build tag

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -1052,6 +1052,25 @@ func HelloServer(w http.ResponseWriter, r *http.Request) {
 		`}, 0, gosec.NewConfig()},
 	}
 
+	// SampleCodeG113 - Usage of Rat.SetString in math/big with an overflow
+	SampleCodeG113 = []CodeSample{
+		{[]string{
+			`
+package main
+
+import (
+        "math/big"
+)
+
+func main() {
+        r := big.Rat{}
+        r.SetString("13e-9223372036854775808")
+
+		fmt.Println(r)
+}`,
+		}, 1, gosec.NewConfig()},
+	}
+
 	// SampleCodeG201 - SQL injection via format string
 	SampleCodeG201 = []CodeSample{
 		{[]string{`
@@ -3164,25 +3183,6 @@ func main() {
         fmt.Println(sampleString)
     }
 }`}, 0, gosec.NewConfig()},
-	}
-
-	// SampleCodeG602 - Usage of Rat.SetString in math/big with an overflow
-	SampleCodeG602 = []CodeSample{
-		{[]string{
-			`
-package main
-
-import (
-        "math/big"
-)
-
-func main() {
-        r := big.Rat{}
-        r.SetString("13e-9223372036854775808")
-
-		fmt.Println(r)
-}`,
-		}, 1, gosec.NewConfig()},
 	}
 
 	// SampleCodeBuildTag - G601 build tags


### PR DESCRIPTION
Rat.SetString in math/big in Go before 1.16.14 and 1.17.x before 1.17.7
has an overflow that can lead to Uncontrolled Memory Consumption.

It is the CVE-2022-23772.