### PR TITLE
Remove additional `--update` for apk in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG GO_VERSION
 FROM golang:${GO_VERSION}-alpine AS builder
-RUN apk add --update --no-cache ca-certificates make git curl gcc libc-dev
+RUN apk add --no-cache ca-certificates make git curl gcc libc-dev
 RUN mkdir -p /build
 WORKDIR /build
 COPY . /build/
@@ -8,7 +8,7 @@ RUN go mod download
 RUN make build-linux
 
 FROM golang:${GO_VERSION}-alpine 
-RUN apk add --update --no-cache ca-certificates bash git gcc libc-dev openssh
+RUN apk add --no-cache ca-certificates bash git gcc libc-dev openssh
 ENV GO111MODULE on
 COPY --from=builder /build/gosec /bin/gosec
 COPY entrypoint.sh /bin/entrypoint.sh


### PR DESCRIPTION
There is no need to use --update with --no-cache when using apk on
Alpine Linux, as using --no-cache will fetch the index every time and
leave no local cache, so the index will always be the latest without
temporary files remain in the image.