### PR TITLE
Fix ReadTimeout for G112

### DIFF
--- a/rules/slowloris.go
+++ b/rules/slowloris.go
@@ -35,7 +35,7 @@ func containsReadHeaderTimeout(node *ast.CompositeLit) bool {
 	for _, elt := range node.Elts {
 		if kv, ok := elt.(*ast.KeyValueExpr); ok {
 			if ident, ok := kv.Key.(*ast.Ident); ok {
-				if ident.Name == "ReadHeaderTimeout" {
+				if ident.Name == "ReadHeaderTimeout" || ident.Name == "ReadTimeout" {
 					return true
 				}
 			}

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -1050,6 +1050,29 @@ func HelloServer(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		`}, 0, gosec.NewConfig()},
+		{[]string{`
+		package main
+
+		import (
+			"fmt"
+			"time"
+			"net/http"
+		)
+		
+		func main() {
+			http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprintf(w, "Hello, %s!", r.URL.Path[1:])
+			})
+			server := &http.Server{
+				Addr:              ":1234",
+				ReadTimeout:  	   1 * time.Second,
+			}
+			err := server.ListenAndServe()
+			if err != nil {
+				panic(err)
+			}
+		}
+		`}, 0, gosec.NewConfig()},
 	}
 
 	// SampleCodeG113 - Usage of Rat.SetString in math/big with an overflow


### PR DESCRIPTION
fix issue #823:

if `http.Server.ReadTimeout` is set, G112 should not report error.