### PR TITLE
fix: filepaths with git anywhere in them being erroneously excluded

### DIFF
--- a/cmd/gosec/main.go
+++ b/cmd/gosec/main.go
@@ -306,9 +306,9 @@ func main() {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "\nError: failed to exclude the %q directory from scan", "vendor")
 	}
-	err = flag.Set("exclude-dir", ".git")
+	err = flag.Set("exclude-dir", "\\.git/")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "\nError: failed to exclude the %q directory from scan", ".git")
+		fmt.Fprintf(os.Stderr, "\nError: failed to exclude the %q directory from scan", "\\.git/")
 	}
 
 	// set for exclude


### PR DESCRIPTION
This fix addresses an issue where the default exclude aimed to exclude `.git` folders is erroneously excluding any file paths with `git` in them.

For example, given a path like `src/git-client/main.go` or `client-git/main.go` the current implementation fails to scan that directory. This causes `gosec` to error with `No packages found` when a folder being scanned only contains `.go` files in these erroneously matched paths.

I verified this by using regexpal.com and the strings `src/git-client/main.go` and `client-git/main.go` mentioned above. The existing exclude `.git` compiles to `([\\/])?.git([\\/])?` which causes the problem as the `.` isnt escaped. The fixed `\\.git/` compiles to `([\\/])?\.git\/([\\/])?` which escapes the leading `.` and adds the protection of the required trailing `/` indicating that it's a directory. This prevents file paths like `src/.git-client/main.go` from being excluded while leaving the behavior originally desired in #485 intact.