### PR TITLE
Fix wrong location for G109

### DIFF
--- a/rules/integer_overflow.go
+++ b/rules/integer_overflow.go
@@ -61,7 +61,7 @@ func (i *integerOverflowCheck) Match(node ast.Node, ctx *gosec.Context) (*gosec.
 		if fun, ok := n.Fun.(*ast.Ident); ok {
 			if fun.Name == "int32" || fun.Name == "int16" {
 				if idt, ok := n.Args[0].(*ast.Ident); ok {
-					if n, ok := atoiVarObj[idt.Obj]; ok {
+					if _, ok := atoiVarObj[idt.Obj]; ok {
 						// Detect int32(v) and int16(v)
 						return gosec.NewIssue(ctx, n, i.ID(), i.What, i.Severity, i.Confidence), nil
 					}

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -795,7 +795,8 @@ func main() {
 	}
 	value := int32(bigValue)
 	fmt.Println(value)
-}`}, 1, gosec.NewConfig()}, {[]string{`
+}`}, 1, gosec.NewConfig()},
+		{[]string{`
 package main
 
 import (
@@ -811,7 +812,8 @@ func main() {
 	if int16(bigValue) < 0 {
 		fmt.Println(bigValue)
 	}
-}`}, 1, gosec.NewConfig()}, {[]string{`
+}`}, 1, gosec.NewConfig()},
+		{[]string{`
 package main
 
 import (
@@ -825,7 +827,8 @@ func main() {
 		panic(err)
 	}
 	fmt.Println(bigValue)
-}`}, 0, gosec.NewConfig()}, {[]string{`
+}`}, 0, gosec.NewConfig()},
+		{[]string{`
 package main
 
 import (
@@ -846,7 +849,8 @@ func test() {
 	bigValue := 30
 	value := int32(bigValue)
 	fmt.Println(value)
-}`}, 0, gosec.NewConfig()}, {[]string{`
+}`}, 0, gosec.NewConfig()},
+		{[]string{`
 package main
 
 import (
@@ -862,6 +866,17 @@ func main() {
 	}
 	v := int32(value)
 	fmt.Println(v)
+}`}, 0, gosec.NewConfig()},
+		{[]string{`
+package main
+import (
+    "fmt"
+    "strconv"
+)
+func main() {
+    a, err := strconv.Atoi("a")
+    b := int32(a) //#nosec G109
+    fmt.Println(b, err)
 }`}, 0, gosec.NewConfig()},
 	}
 


### PR DESCRIPTION
Fix #742 : G109 tells the location at strconv.Atoi instead of strconv.Atoi result conversion to int16/32. 

Before this commit, G109 will report on `strconv.Atoi`.
After this, it will report on the convertion like`int32(a)`.