### PR TITLE
Phase out support for Go 1.16 since is not supported anymore by Go team

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
     strategy:
       matrix:
         go_version:
-          - '1.16'
           - '1.17'
           - '1.18'
     runs-on: ubuntu-latest


### PR DESCRIPTION
Signed-off-by: Cosmin Cojocar <gcojocar@adobe.com>
