### PR TITLE
Fix for G402. Check package path instead of package name

### DIFF
--- a/rules/tls.go
+++ b/rules/tls.go
@@ -122,8 +122,10 @@ func (t *insecureConfigTLS) processTLSConfVal(n *ast.KeyValueExpr, c *gosec.Cont
 				t.actualMinVersion = ival
 			} else {
 				if se, ok := n.Value.(*ast.SelectorExpr); ok {
-					if pkg, ok := se.X.(*ast.Ident); ok && pkg.Name == "tls" {
-						t.actualMinVersion = t.mapVersion(se.Sel.Name)
+					if pkg, ok := se.X.(*ast.Ident); ok {
+						if ip, ok := gosec.GetImportPath(pkg.Name, c); ok && ip == "crypto/tls" {
+							t.actualMinVersion = t.mapVersion(se.Sel.Name)
+						}
 					}
 				}
 			}
@@ -133,8 +135,10 @@ func (t *insecureConfigTLS) processTLSConfVal(n *ast.KeyValueExpr, c *gosec.Cont
 				t.actualMaxVersion = ival
 			} else {
 				if se, ok := n.Value.(*ast.SelectorExpr); ok {
-					if pkg, ok := se.X.(*ast.Ident); ok && pkg.Name == "tls" {
-						t.actualMaxVersion = t.mapVersion(se.Sel.Name)
+					if pkg, ok := se.X.(*ast.Ident); ok {
+						if ip, ok := gosec.GetImportPath(pkg.Name, c); ok && ip == "crypto/tls" {
+							t.actualMaxVersion = t.mapVersion(se.Sel.Name)
+						}
 					}
 				}
 			}

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -3009,6 +3009,19 @@ import "crypto/tls"
 
 const MinVer = tls.VersionTLS13
 `}, 0, gosec.NewConfig()},
+		{[]string{`
+package main
+
+import (
+	"crypto/tls"
+	cryptotls "crypto/tls"
+)
+
+func main() {
+	_ = tls.Config{MinVersion: tls.VersionTLS12}
+	_ = cryptotls.Config{MinVersion: cryptotls.VersionTLS12}
+}
+`}, 0, gosec.NewConfig()},
 	}
 
 	// SampleCodeG403 - weak key strength


### PR DESCRIPTION
This PR fixes https://github.com/securego/gosec/issues/820 issue

This PR contains several changes



1. Check package path instead of package name. 
Comparing by package path is more trustful than comparing by package name. It's the only source of truth(after resolving the aliases) to check what exactly package was imported(=accessed in our case).

2. Move "unaliasing" from GetImportedName to GetImportPath
It will help us to get exact information about imported package. 
