### PR TITLE
fix: parsing of the Go version

### DIFF
--- a/cmd/gosec/main.go
+++ b/cmd/gosec/main.go
@@ -71,7 +71,7 @@ func (a *arrayFlags) Set(value string) error {
 }
 
 var (
-	//#nosec flag
+	// #nosec flag
 	flagIgnoreNoSec = flag.Bool("nosec", false, "Ignores #nosec comments when set")
 
 	// show ignored
@@ -80,7 +80,7 @@ var (
 	// format output
 	flagFormat = flag.String("fmt", "text", "Set output format. Valid options are: json, yaml, csv, junit-xml, html, sonarqube, golint, sarif or text")
 
-	//#nosec alternative tag
+	// #nosec alternative tag
 	flagAlternativeNoSec = flag.String("nosec-tag", "", "Set an alternative string for #nosec. Some examples: #dontanalyze, #falsepositive")
 
 	// output file
@@ -148,7 +148,7 @@ var (
 	logger *log.Logger
 )
 
-//#nosec
+// #nosec
 func usage() {
 	usageText := fmt.Sprintf(usageText, Version, GitTag, BuildDate)
 	fmt.Fprintln(os.Stderr, usageText)
@@ -173,12 +173,12 @@ func usage() {
 func loadConfig(configFile string) (gosec.Config, error) {
 	config := gosec.NewConfig()
 	if configFile != "" {
-		//#nosec
+		// #nosec
 		file, err := os.Open(configFile)
 		if err != nil {
 			return nil, err
 		}
-		defer file.Close() //#nosec G307
+		defer file.Close() // #nosec G307
 		if _, err := config.ReadFrom(file); err != nil {
 			return nil, err
 		}
@@ -253,11 +253,11 @@ func printReport(format string, color bool, rootPaths []string, reportInfo *gose
 }
 
 func saveReport(filename, format string, rootPaths []string, reportInfo *gosec.ReportInfo) error {
-	outfile, err := os.Create(filename) //#nosec G304
+	outfile, err := os.Create(filename) // #nosec G304
 	if err != nil {
 		return err
 	}
-	defer outfile.Close() //#nosec G307
+	defer outfile.Close() // #nosec G307
 	err = report.CreateReport(outfile, format, false, rootPaths, reportInfo)
 	if err != nil {
 		return err
@@ -337,7 +337,7 @@ func main() {
 
 	// Ensure at least one file was specified or that the recursive -r flag was set.
 	if flag.NArg() == 0 && !*flagRecursive {
-		fmt.Fprintf(os.Stderr, "\nError: FILE [FILE...] or './...' or -r expected\n") //#nosec
+		fmt.Fprintf(os.Stderr, "\nError: FILE [FILE...] or './...' or -r expected\n") // #nosec
 		flag.Usage()
 		os.Exit(1)
 	}
@@ -460,7 +460,7 @@ func main() {
 	}
 
 	// Finalize logging
-	logWriter.Close() //#nosec
+	logWriter.Close() // #nosec
 
 	exit(issues, errors, *flagNoFail)
 }

--- a/helpers.go
+++ b/helpers.go
@@ -34,8 +34,8 @@ import (
 // initialization only imports.
 //
 // Usage:
-// 	node, matched := MatchCallByPackage(n, ctx, "math/rand", "Read")
 //
+//	node, matched := MatchCallByPackage(n, ctx, "math/rand", "Read")
 func MatchCallByPackage(n ast.Node, c *Context, pkg string, names ...string) (*ast.CallExpr, bool) {
 	importedName, found := GetImportedName(pkg, c)
 	if !found {
@@ -474,9 +474,25 @@ func RootPath(root string) (string, error) {
 
 // GoVersion returns parsed version of Go from runtime
 func GoVersion() (int, int, int) {
-	versionParts := strings.Split(runtime.Version(), ".")
-	major, _ := strconv.Atoi(versionParts[0][2:])
-	minor, _ := strconv.Atoi(versionParts[1])
-	build, _ := strconv.Atoi(versionParts[2])
+	return parseGoVersion(runtime.Version())
+}
+
+// parseGoVersion parses Go version.
+// example:
+// - go1.19rc2
+// - go1.19beta2
+// - go1.19.4
+// - go1.19
+func parseGoVersion(version string) (int, int, int) {
+	exp := regexp.MustCompile(`go(\d+).(\d+)(?:.(\d+))?.*`)
+	parts := exp.FindStringSubmatch(version)
+	if len(parts) <= 1 {
+		return 0, 0, 0
+	}
+
+	major, _ := strconv.Atoi(parts[1])
+	minor, _ := strconv.Atoi(parts[2])
+	build, _ := strconv.Atoi(parts[3])
+
 	return major, minor, build
 }


### PR DESCRIPTION
The parsing of the Go version inside the function `GoVersion` is based on an incorrect assumption.
https://github.com/securego/gosec/blob/0c8e63ed86f8fc2da42787e0a653114490078d6c/helpers.go#L476-L482

The Go version follows a specific pattern.

- go1.19rc2
- go1.19beta2
- go1.19.4
- go1.19

The current version of Go is `go1.19` then `versionParts[2]` panic (`runtime error: index out of range [2] with length 2`)

Fixes #843

The problem has been introduced by #819

Related to https://github.com/golangci/golangci-lint/issues/3071