### PR TITLE
Refactor to support duplicate imports with different aliases

### DIFF
--- a/import_tracker_test.go
+++ b/import_tracker_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Import Tracker", func() {
 			files := pkgs[0].Syntax
 			Expect(files).Should(HaveLen(1))
 			tracker.TrackFile(files[0])
-			Expect(tracker.Imported).Should(Equal(map[string]string{"fmt": "fmt"}))
+			Expect(tracker.Imported).Should(Equal(map[string][]string{"fmt": {"fmt"}}))
 		})
 		It("should parse the named imports from file", func() {
 			tracker := gosec.NewImportTracker()
@@ -47,7 +47,7 @@ var _ = Describe("Import Tracker", func() {
 			files := pkgs[0].Syntax
 			Expect(files).Should(HaveLen(1))
 			tracker.TrackFile(files[0])
-			Expect(tracker.Imported).Should(Equal(map[string]string{"fmt": "fmt"}))
+			Expect(tracker.Imported).Should(Equal(map[string][]string{"fmt": {"fm"}}))
 		})
 	})
 })

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -3196,6 +3196,25 @@ func main() {
 	println(bad)
 }
 `}, 1, gosec.NewConfig()},
+		{[]string{`
+package main
+
+import (
+	crand "crypto/rand"
+	"math/big"
+	"math/rand"
+	rand2 "math/rand"
+	rand3 "math/rand"
+)
+
+func main() {
+	_, _ = crand.Int(crand.Reader, big.NewInt(int64(2))) // good
+
+	_ = rand.Intn(2) // bad
+	_ = rand2.Intn(2)  // bad
+	_ = rand3.Intn(2)  // bad
+}
+`}, 3, gosec.NewConfig()},
 	}
 
 	// SampleCodeG501 - Blocklisted import MD5


### PR DESCRIPTION
The existing code assumed imports to be either imported, or imported with an
alias. Badly formatted files may have duplicate imports for a package, using
different aliases.

This patch refactors the code, and;

Introduces a new `GetImportedNames` function, which returns all name(s) and
aliase(s) for a package, which effectively combines `GetAliasedName` and
`GetImportedName`, but adding support for duplicate imports.

The old `GetAliasedName` and `GetImportedName` functions have been rewritten to
use the new function and marked deprecated, but could be removed if there are no
external consumers.

With this patch, the linter is able to detect issues in files such as;

    package main

    import (
        crand "crypto/rand"
        "math/big"
        "math/rand"
        rand2 "math/rand"
        rand3 "math/rand"
    )

    func main() {
        _, _ = crand.Int(crand.Reader, big.NewInt(int64(2))) // good

        _ = rand.Intn(2) // bad
        _ = rand2.Intn(2)  // bad
        _ = rand3.Intn(2)  // bad
    }

Before this patch, only a single issue would be detected:

    gosec --quiet .

    [main.go:14] - G404 (CWE-338): Use of weak random number generator (math/rand instead of crypto/rand) (Confidence: MEDIUM, Severity: HIGH)
        13:
      > 14: 	_ = rand.Intn(2) // bad
        15: 	_ = rand2.Intn(2)  // bad

With this patch, all issues are identified:

    gosec --quiet .

    [main.go:16] - G404 (CWE-338): Use of weak random number generator (math/rand instead of crypto/rand) (Confidence: MEDIUM, Severity: HIGH)
        15: 	_ = rand2.Intn(2)  // bad
      > 16: 	_ = rand3.Intn(2)  // bad
        17: }

    [main.go:15] - G404 (CWE-338): Use of weak random number generator (math/rand instead of crypto/rand) (Confidence: MEDIUM, Severity: HIGH)
        14: 	_ = rand.Intn(2) // bad
      > 15: 	_ = rand2.Intn(2)  // bad
        16: 	_ = rand3.Intn(2)  // bad

    [main.go:14] - G404 (CWE-338): Use of weak random number generator (math/rand instead of crypto/rand) (Confidence: MEDIUM, Severity: HIGH)
        13:
      > 14: 	_ = rand.Intn(2) // bad
        15: 	_ = rand2.Intn(2)  // bad

