### PR TITLE
Add a way to use private repositories on GitHub

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,4 +4,8 @@
 # provides all arguments concatenated as a single string.
 ARGS=("$@")
 
+if [[ ! -z "${GITHUB_AUTHENTICATION_TOKEN}" ]]; then
+  git config --global --add url."https://x-access-token:${GITHUB_AUTHENTICATION_TOKEN}@github.com/".insteadOf "https://github.com/"
+fi
+
 /bin/gosec ${ARGS[*]}


### PR DESCRIPTION
Would be great to have something like this inside the Docker image for working with private repositories.
Especially when running local and there's no other way than vendoring at the moment.