### PR TITLE
G104 now raises an issue in case of reassignment err variable without checking

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -31,10 +31,9 @@ import (
 	"strings"
 	"sync"
 
+	"golang.org/x/tools/go/packages"
 	"golang.org/x/tools/go/ssa"
 	"golang.org/x/tools/go/ssa/ssautil"
-
-	"golang.org/x/tools/go/packages"
 )
 
 // LoadMode controls the amount of details to return when loading the packages

--- a/analyzer.go
+++ b/analyzer.go
@@ -21,8 +21,6 @@ import (
 	"go/build"
 	"go/token"
 	"go/types"
-	"golang.org/x/tools/go/ssa"
-	"golang.org/x/tools/go/ssa/ssautil"
 	"log"
 	"os"
 	"path"
@@ -32,6 +30,9 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+
+	"golang.org/x/tools/go/ssa"
+	"golang.org/x/tools/go/ssa/ssautil"
 
 	"golang.org/x/tools/go/packages"
 )

--- a/cmd/gosec/main.go
+++ b/cmd/gosec/main.go
@@ -142,6 +142,9 @@ var (
 	// output suppression information for auditing purposes
 	flagTrackSuppressions = flag.Bool("track-suppressions", false, "Output suppression information, including its kind and justification")
 
+	// audit flag
+	flagAudit = flag.Bool("audit", false, "Audit mode")
+
 	// exlude the folders from scan
 	flagDirsExclude arrayFlags
 
@@ -191,6 +194,9 @@ func loadConfig(configFile string) (gosec.Config, error) {
 	}
 	if *flagAlternativeNoSec != "" {
 		config.SetGlobal(gosec.NoSecAlternative, *flagAlternativeNoSec)
+	}
+	if *flagAudit {
+		config.SetGlobal(gosec.Audit, "true")
 	}
 	// set global option IncludeRules ,when flag set or global option IncludeRules  is nil
 	if v, _ := config.GetGlobal(gosec.IncludeRules); *flagRulesInclude != "" || v == "" {

--- a/helpers.go
+++ b/helpers.go
@@ -20,6 +20,7 @@ import (
 	"go/ast"
 	"go/token"
 	"go/types"
+	"golang.org/x/tools/go/ssa"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -470,4 +471,18 @@ func parseGoVersion(version string) (int, int, int) {
 	build, _ := strconv.Atoi(parts[3])
 
 	return major, minor, build
+}
+
+// OnlyDebugRef returns true if ssa.Value has only DebugRefs
+func OnlyDebugRef(value ssa.Value) bool {
+	onlyDbgRef := true
+	if value.Referrers() != nil {
+		for _, ref := range *value.Referrers() {
+			if _, ok := ref.(*ssa.DebugRef); !ok {
+				onlyDbgRef = false
+				break
+			}
+		}
+	}
+	return onlyDbgRef
 }

--- a/helpers.go
+++ b/helpers.go
@@ -20,7 +20,6 @@ import (
 	"go/ast"
 	"go/token"
 	"go/types"
-	"golang.org/x/tools/go/ssa"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -28,6 +27,8 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+
+	"golang.org/x/tools/go/ssa"
 )
 
 // MatchCallByPackage ensures that the specified package is imported,

--- a/rules/errors.go
+++ b/rules/errors.go
@@ -17,6 +17,7 @@ package rules
 import (
 	"go/ast"
 	"go/types"
+
 	"golang.org/x/tools/go/ast/astutil"
 	"golang.org/x/tools/go/ssa"
 

--- a/rules/errors.go
+++ b/rules/errors.go
@@ -18,10 +18,9 @@ import (
 	"go/ast"
 	"go/types"
 
+	"github.com/securego/gosec/v2"
 	"golang.org/x/tools/go/ast/astutil"
 	"golang.org/x/tools/go/ssa"
-
-	"github.com/securego/gosec/v2"
 )
 
 type noErrorCheck struct {

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -556,7 +556,31 @@ func main() {
 package main
 
 func dummy(){}
-`}, 0, gosec.Config{gosec.Globals: map[gosec.GlobalOption]string{gosec.Audit: "enabled"}}},
+`}, 0, gosec.Config{gosec.Globals: map[gosec.GlobalOption]string{gosec.Audit: "enabled"}}}, {[]string{`
+package main
+
+import (
+	"io"
+	"log"
+	"os"
+)
+
+func main() {
+	_, _ = io.WriteString(os.Stdout, "Hello World") // # this is ok
+
+	_, err := io.WriteString(os.Stdout, "Hello World")
+	if err != nil { // good
+		log.Fatal(err)
+	}
+
+	_, err = io.WriteString(os.Stdout, "Hello World") // # this err will not be checked
+	_, err = io.WriteString(os.Stdout, "Hello World") // # this err will be checked
+
+	if err != nil { // checking the second err but not the first one
+		log.Fatal(err)
+	}
+
+}`}, 2, gosec.Config{gosec.Globals: map[gosec.GlobalOption]string{gosec.Audit: "enabled"}}},
 	}
 
 	// SampleCodeG106 - ssh InsecureIgnoreHostKey


### PR DESCRIPTION
This PR is related to https://github.com/securego/gosec/issues/891 issue

Now the G104 also checks for reassignments by checking referrers of err variable. 

An issue will be raised only in case if no other expression related to the err variable exists:
<img width="996" alt="Screenshot 2022-11-25 at 2 31 09" src="https://user-images.githubusercontent.com/1677800/203882807-6040c327-def9-476b-bf3a-ab680aeef34c.png">

This check was made using SSA(https://pkg.go.dev/golang.org/x/tools/go/ssa) 
