### PR TITLE
Additional types for bad defer check

### DIFF
--- a/cmd/tlsconfig/tlsconfig.go
+++ b/cmd/tlsconfig/tlsconfig.go
@@ -68,7 +68,7 @@ func getTLSConfFromURL(url string) (*ServerSideTLSJson, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer r.Body.Close()
+	defer r.Body.Close() //#nosec G307
 
 	var sstls ServerSideTLSJson
 	err = json.NewDecoder(r.Body).Decode(&sstls)

--- a/rules/bad_defer.go
+++ b/rules/bad_defer.go
@@ -57,6 +57,34 @@ func NewDeferredClosing(id string, conf gosec.Config) (gosec.Rule, []ast.Node) {
 				typ:     "os.File",
 				methods: []string{"Close"},
 			},
+			{
+				typ:     "io.ReadCloser",
+				methods: []string{"Close"},
+			},
+			{
+				typ:     "io.WriteCloser",
+				methods: []string{"Close"},
+			},
+			{
+				typ:     "io.ReadWriteCloser",
+				methods: []string{"Close"},
+			},
+			{
+				typ:     "io.ReadSeekCloser",
+				methods: []string{"Close"},
+			},
+			{
+				typ:     "io.Closer",
+				methods: []string{"Close"},
+			},
+			{
+				typ:     "net.Conn",
+				methods: []string{"Close"},
+			},
+			{
+				typ:     "net.Listener",
+				methods: []string{"Close"},
+			},
 		},
 		MetaData: gosec.MetaData{
 			ID:         id,

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -2756,7 +2756,23 @@ func main() {
 	n4, err := w.WriteString("buffered\n")
 	fmt.Printf("wrote %d bytes\n", n4)
 	w.Flush()
-}`}, 1, gosec.NewConfig()},
+}`}, 1, gosec.NewConfig()}, {[]string{`
+package main
+
+import (
+	"net"
+	"net/http"
+)
+
+func main() {
+	response, _ := http.Get("https://127.0.0.1")
+
+	defer response.Body.Close() // io.ReadCloser
+
+	conn, _ := net.Dial("tcp", "127.0.0.1:8080")
+	defer conn.Close() // net.Conn
+
+}`}, 2, gosec.NewConfig()},
 	}
 
 	// SampleCodeG401 - Use of weak crypto MD5


### PR DESCRIPTION
Simply adds some additional type for bad-close check.

Will fix https://github.com/securego/gosec/issues/890 but maybe we need to redesign the check in future to catch possible cases(Close() method with error ret value)