### PR TITLE
Adding s390x support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,6 +18,7 @@ builds:
     goarch:
       - amd64
       - arm64
+      - s390x
     ldflags: -X main.Version={{.Version}} -X main.GitTag={{.Tag}} -X main.BuildDate={{.Date}}
     env:
       - CGO_ENABLED=0


### PR DESCRIPTION
- Updated .goreleaser.yaml to support Linux on IBM Z ( s390x )

Signed-off-by: Dave Hay <david_hay@uk.ibm.com>