### PR TITLE
Auto-detect TLS MinVersion integer base

### DIFF
--- a/rules/tls.go
+++ b/rules/tls.go
@@ -107,7 +107,7 @@ func (t *insecureConfigTLS) processTLSConfVal(n *ast.KeyValueExpr, c *gosec.Cont
 								tObj := imp.Scope().Lookup(sel)
 								if cst, ok := tObj.(*types.Const); ok {
 									// ..got the value check if this can be translated
-									if minVersion, err := strconv.ParseInt(cst.Val().String(), 10, 64); err == nil {
+									if minVersion, err := strconv.ParseInt(cst.Val().String(), 0, 64); err == nil {
 										t.actualMinVersion = minVersion
 									}
 								}


### PR DESCRIPTION
From [strconv.ParseInt](https://pkg.go.dev/strconv#ParseInt):

> If the base argument is 0, the true base is implied by the string's prefix following the sign (if present): 2 for "0b", 8 for "0" or "0o", 16 for "0x", and 10 otherwise. Also, for argument base 0 only, underscore characters are permitted as defined by the Go syntax for [integer literals](https://go.dev/ref/spec#Integer_literals).

This is useful for example for hex constants from the [crypto/tls](https://cs.opensource.google/go/go/+/master:src/crypto/tls/common.go;l=32), e.g.:
```
VersionTLS13 = 0x0304
```

PS. Codepath in the `MinVersion` parsing looks quite fragile.
PPS. Code in Min/Max should likely be the same.