### PR TITLE
fix github release url

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -281,10 +281,10 @@ github_release() {
   owner_repo=$1
   version=$2
   test -z "$version" && version="latest"
-  giturl="https://github.com/${owner_repo}/releases/${version}"
+  giturl="https://api.github.com/repos/${owner_repo}/releases/tags/${version}"
   json=$(http_copy "$giturl" "Accept:application/json")
   test -z "$json" && return 1
-  version=$(echo "$json" | tr -s '\n' ' ' | sed 's/.*"tag_name":"//' | sed 's/".*//')
+  version=$(echo "$json" | tr -s '\n' ' ' | sed 's/.*"tag_name": *"//' | sed 's/".*//')
   test -z "$version" && return 1
   echo "$version"
 }


### PR DESCRIPTION
Fix CI installation using `install.sh`.

https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#get-a-release-by-tag-name