### PR TITLE
Fix regression of github latest URL

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -280,8 +280,10 @@ http_copy() {
 github_release() {
   owner_repo=$1
   version=$2
-  test -z "$version" && version="latest"
   giturl="https://api.github.com/repos/${owner_repo}/releases/tags/${version}"
+  if [ -z "${version}" ]; then
+    giturl="https://api.github.com/repos/${owner_repo}/releases/latest"
+  fi
   json=$(http_copy "$giturl" "Accept:application/json")
   test -z "$json" && return 1
   version=$(echo "$json" | tr -s '\n' ' ' | sed 's/.*"tag_name": *"//' | sed 's/".*//')


### PR DESCRIPTION
Fix install.sh. on empty tag.
latest release url: https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#get-the-latest-release

error message
```sh
Run curl -sSfL https://raw.githubusercontent.com/securego/gosec/master/install.sh |
  curl -sSfL https://raw.githubusercontent.com/securego/gosec/master/install.sh |
    sh -s -- -b $GOPATH/bin
  shell: /usr/bin/bash -e {0}
  env:
    GOPRIVATE: github.com/Kyash/*
    GOPATH: /home/runner/go
securego/gosec info checking GitHub for latest tag
securego/gosec crit unable to find '' - use 'latest' or see https://github.com/securego/gosec/releases for details
Error: Process completed with exit code 1.
```
