### PR TITLE
Support Golang 1.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
         go_version:
           - '1.18.10' # TODO: remove this once actions/setup-go@v3 uses latest as latest; see https://github.com/securego/gosec/pull/880
           - '1.19.5' # TODO: remove this once actions/setup-go@v3 uses latest as latest; see https://github.com/securego/gosec/pull/880
+          - '1.20' # TODO: remove this once actions/setup-go@v3 uses latest as latest; see https://github.com/securego/gosec/pull/880
     runs-on: ubuntu-latest
     env:
       GO111MODULE: on
@@ -44,7 +45,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.19.5' # TODO: remove this once actions/setup-go@v3 uses latest as latest; see https://github.com/securego/gosec/pull/880
+          go-version: '1.20' # TODO: remove this once actions/setup-go@v3 uses latest as latest; see https://github.com/securego/gosec/pull/880
       - name: Checkout Source 
         uses: actions/checkout@v3
       - uses: actions/cache@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.19.5'
+          go-version: '1.20'
       - name: Install Cosign
         uses: sigstore/cosign-installer@v2
         with:
@@ -66,7 +66,7 @@ jobs:
           tags: ${{steps.meta.outputs.tags}}
           labels: ${{steps.meta.outputs.labels}}
           push: true
-          build-args: GO_VERSION=1.19
+          build-args: GO_VERSION=1.20
       - name: Sign Docker Image
         run: cosign sign -key /tmp/cosign.key ${TAGS}
         env:

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ GOSEC ?= $(GOBIN)/gosec
 GINKGO ?= $(GOBIN)/ginkgo
 GO_MINOR_VERSION = $(shell $(GO) version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f2)
 GOVULN_MIN_VERSION = 17
-GO_VERSION = 1.19
+GO_VERSION = 1.20
 
 default:
 	$(MAKE) build


### PR DESCRIPTION
The current master branch fails on v1.20 with the following:

```
2023/02/05 15:27:31 internal error: package "net/http" without types was imported from "command-line-arguments"
```