### PR TITLE
Update release build script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@v2
         with:
-          cosign-release: 'v1.6.0'
+          cosign-release: 'v1.13.1'
       - name: Store Cosign private key in a file
         run: 'echo "$COSIGN_KEY" > /tmp/cosign.key'
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}


### PR DESCRIPTION
- Remove deprecated goreleaser flag from release build script
- Update cosign version to v1.13.1
