### PR TITLE
Add gosec version as an input parameter to GitHub action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,12 @@ jobs:
       - name: lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: ${{ matrix.version.golangci }}
+         version: ${{ matrix.version.golangci }}
+      - name: Run Gosec Security Scanner
+        uses: securego/gosec@master
+        with:
+          version: '2.15.0'
+          args: ./...
       - name: Run Tests
         run: make test
   coverage:

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ jobs:
       - name: Run Gosec Security Scanner
         uses: securego/gosec@master
         with:
+          version: 'latest'
           args: ./...
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -3,6 +3,10 @@ description: 'Runs the gosec security checker'
 author: '@ccojocar'
 
 inputs:
+  version:
+    description: 'Version of gosec to use (e.g. 2.15.0)'
+    required: false
+    default: 'latest'
   args:
     description: 'Arguments for gosec'
     required: true
@@ -10,7 +14,7 @@ inputs:
 
 runs:
     using: 'docker'
-    image: 'docker://securego/gosec'
+    image: 'docker://securego/gosec:${{inputs.version}}'
     args:
       - ${{ inputs.args }}
 


### PR DESCRIPTION
- Add gosec version as a paramter to the Github action
- Run gosec as a github action as part of CI

fixes #926
