### PR TITLE
fix linting job

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,3 +31,6 @@ linters:
   - unused
   - varcheck
   - wastedassign
+
+run:
+  timeout: 5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,6 @@ linters:
   enable:
   - asciicheck
   - bodyclose
-  - deadcode
   - depguard
   - dogsled
   - durationcheck
@@ -24,12 +23,10 @@ linters:
   - nolintlint
   - revive
   - staticcheck
-  - structcheck
   - typecheck
   - unconvert
   - unparam
   - unused
-  - varcheck
   - wastedassign
 
 run:


### PR DESCRIPTION
Increase timeout to 5 minutes and remove deprecated linters.

Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>