### PR TITLE
Fix for Dockerfile smell DL3059

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 ARG GO_VERSION
 FROM golang:${GO_VERSION}-alpine AS builder
-RUN apk add --no-cache ca-certificates make git curl gcc libc-dev
-RUN mkdir -p /build
+RUN apk add --no-cache ca-certificates make git curl gcc libc-dev \
+    && mkdir -p /build
 WORKDIR /build
 COPY . /build/
-RUN go mod download
-RUN make build-linux
+RUN go mod download \
+    && make build-linux
 
 FROM golang:${GO_VERSION}-alpine 
 RUN apk add --no-cache ca-certificates bash git gcc libc-dev openssh


### PR DESCRIPTION
Hi!
The Dockerfile placed at "Dockerfile" contains the best practice violation [DL3059](https://github.com/hadolint/hadolint/wiki/DL3059) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3059 occurs if there are multiple consecutive RUN instructions. Each RUN will correspond to a layer of the final Docker image, thus is recommended to compact them to reduce the number of layers for the final image.
This pull request proposes a fix for that smell generated by my fixing tool. The patch was manually verified before opening the pull request. To fix this smell, specifically, The consecutive RUN instructions have been chained until a comment or a different instruction appears.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance
