### PR TITLE
Fix no-sec alternative tag

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -449,10 +449,12 @@ func (gosec *Analyzer) ignore(n ast.Node) map[string]issue.SuppressionInfo {
 	if groups, ok := gosec.context.Comments[n]; ok && !gosec.ignoreNosec {
 
 		// Checks if an alternative for #nosec is set and, if not, uses the default.
-		noSecDefaultTag := "#nosec"
+		noSecDefaultTag := NoSecTag(string(Nosec))
 		noSecAlternativeTag, err := gosec.config.GetGlobal(NoSecAlternative)
 		if err != nil {
 			noSecAlternativeTag = noSecDefaultTag
+		} else {
+			noSecAlternativeTag = NoSecTag(noSecAlternativeTag)
 		}
 
 		for _, group := range groups {

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -407,7 +407,7 @@ var _ = Describe("Analyzer", func() {
 
 			// overwrite nosec option
 			nosecIgnoreConfig := gosec.NewConfig()
-			nosecIgnoreConfig.SetGlobal(gosec.NoSecAlternative, "#falsePositive")
+			nosecIgnoreConfig.SetGlobal(gosec.NoSecAlternative, "falsePositive")
 			customAnalyzer := gosec.NewAnalyzer(nosecIgnoreConfig, tests, false, false, 1, logger)
 			customAnalyzer.LoadRules(rules.Generate(false, rules.NewRuleFilter(false, "G401")).RulesInfo())
 
@@ -430,7 +430,7 @@ var _ = Describe("Analyzer", func() {
 
 			// overwrite nosec option
 			nosecIgnoreConfig := gosec.NewConfig()
-			nosecIgnoreConfig.SetGlobal(gosec.NoSecAlternative, "#falsePositive")
+			nosecIgnoreConfig.SetGlobal(gosec.NoSecAlternative, "falsePositive")
 			customAnalyzer := gosec.NewAnalyzer(nosecIgnoreConfig, tests, false, false, 1, logger)
 			customAnalyzer.LoadRules(rules.Generate(false, rules.NewRuleFilter(false, "G401")).RulesInfo())
 

--- a/config.go
+++ b/config.go
@@ -33,6 +33,11 @@ const (
 	SSA GlobalOption = "ssa"
 )
 
+// NoSecTag returns the tag used to disable gosec for a line of code.
+func NoSecTag(tag string) string {
+	return fmt.Sprintf("%s%s", "#", tag)
+}
+
 // Config is used to provide configuration and customization to each of the rules.
 type Config map[string]interface{}
 


### PR DESCRIPTION
The no-sec alternative tag prepends now automatically the # symbol

fixes #961

Signed-off-by: Cosmin Cojocar <gcojocar@adobe.com>
