### PR TITLE
Fix typos in comments, vars and tests

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -59,7 +59,7 @@ var generatedCodePattern = regexp.MustCompile(`^// Code generated .* DO NOT EDIT
 
 // The Context is populated with data parsed from the source code as it is scanned.
 // It is passed through to all rule functions as they are called. Rules may use
-// this data in conjunction withe the encountered AST node.
+// this data in conjunction with the encountered AST node.
 type Context struct {
 	FileSet      *token.FileSet
 	Comments     ast.CommentMap

--- a/analyzers/ssrf.go
+++ b/analyzers/ssrf.go
@@ -46,7 +46,7 @@ func runSSRF(pass *analysis.Pass) (interface{}, error) {
 					if callee != nil {
 						ssaResult.Logger.Printf("callee: %s\n", callee)
 						return newIssue(pass.Analyzer.Name,
-							"not implemeted",
+							"not implemented",
 							pass.Fset, instr.Call.Pos(), issue.Low, issue.High), nil
 					}
 				}

--- a/analyzers/util.go
+++ b/analyzers/util.go
@@ -28,7 +28,7 @@ import (
 )
 
 // SSAAnalyzerResult contains various information returned by the
-// SSA analysis along with some configuraion
+// SSA analysis along with some configuration
 type SSAAnalyzerResult struct {
 	Config map[string]interface{}
 	Logger *log.Logger
@@ -42,7 +42,7 @@ func BuildDefaultAnalyzers() []*analysis.Analyzer {
 	}
 }
 
-// getSSAResult retrives the SSA result from analysis pass
+// getSSAResult retrieves the SSA result from analysis pass
 func getSSAResult(pass *analysis.Pass) (*SSAAnalyzerResult, error) {
 	result, ok := pass.ResultOf[buildssa.Analyzer]
 	if !ok {

--- a/cmd/gosec/main.go
+++ b/cmd/gosec/main.go
@@ -143,7 +143,7 @@ var (
 	// output suppression information for auditing purposes
 	flagTrackSuppressions = flag.Bool("track-suppressions", false, "Output suppression information, including its kind and justification")
 
-	// exlude the folders from scan
+	// exclude the folders from scan
 	flagDirsExclude arrayFlags
 
 	logger *log.Logger

--- a/helpers.go
+++ b/helpers.go
@@ -301,7 +301,7 @@ func Getenv(key, userDefault string) string {
 	return userDefault
 }
 
-// GetPkgRelativePath returns the Go relative relative path derived
+// GetPkgRelativePath returns the Go relative path derived
 // form the given path
 func GetPkgRelativePath(path string) (string, error) {
 	abspath, err := filepath.Abs(path)

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Helpers", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(paths).Should(Equal([]string{dir}))
 		})
-		It("should return the package package path", func() {
+		It("should return the package path", func() {
 			paths, err := gosec.PackagePaths(dir+"/...", nil)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(paths).Should(Equal([]string{dir}))

--- a/report/formatter_test.go
+++ b/report/formatter_test.go
@@ -188,7 +188,7 @@ var _ = Describe("Formatter", func() {
 			Expect(*issues).To(Equal(*want))
 		})
 
-		It("it should parse the report info for multiple projects projects", func() {
+		It("it should parse the report info for multiple projects", func() {
 			data := &gosec.ReportInfo{
 				Errors: map[string][]gosec.Error{},
 				Issues: []*issue.Issue{

--- a/report/sarif/sarif_test.go
+++ b/report/sarif/sarif_test.go
@@ -162,15 +162,15 @@ var _ = Describe("Sarif Formatter", func() {
 			sarifReport, err := sarif.GenerateReport([]string{}, reportInfo)
 
 			Expect(err).ShouldNot(HaveOccurred())
-			resultRuleIdexes := map[string]int{}
+			resultRuleIndexes := map[string]int{}
 			for _, result := range sarifReport.Runs[0].Results {
-				resultRuleIdexes[result.RuleID] = result.RuleIndex
+				resultRuleIndexes[result.RuleID] = result.RuleIndex
 			}
 			driverRuleIndexes := map[string]int{}
 			for ruleIndex, rule := range sarifReport.Runs[0].Tool.Driver.Rules {
 				driverRuleIndexes[rule.ID] = ruleIndex
 			}
-			Expect(resultRuleIdexes).Should(Equal(driverRuleIndexes))
+			Expect(resultRuleIndexes).Should(Equal(driverRuleIndexes))
 		})
 	})
 })

--- a/report/sonar/sonar_test.go
+++ b/report/sonar/sonar_test.go
@@ -140,7 +140,7 @@ var _ = Describe("Sonar Formatter", func() {
 			Expect(*issues).To(Equal(*want))
 		})
 
-		It("it should parse the report info for multiple projects projects", func() {
+		It("it should parse the report info for multiple projects", func() {
 			data := &gosec.ReportInfo{
 				Errors: map[string][]gosec.Error{},
 				Issues: []*issue.Issue{

--- a/rule.go
+++ b/rule.go
@@ -43,7 +43,7 @@ func NewRuleSet() RuleSet {
 	return RuleSet{make(map[reflect.Type][]Rule), make(map[string]bool)}
 }
 
-// Register adds a trigger for the supplied rule for the the
+// Register adds a trigger for the supplied rule for the
 // specified ast nodes.
 func (r RuleSet) Register(rule Rule, isSuppressed bool, nodes ...ast.Node) {
 	for _, n := range nodes {

--- a/rules/subproc.go
+++ b/rules/subproc.go
@@ -97,7 +97,7 @@ func (r *subprocess) Match(n ast.Node, c *gosec.Context) (*issue.Issue, error) {
 }
 
 // isContext checks whether or not the node is a CommandContext call or not
-// Thi is required in order to skip the first argument from the check.
+// This is required in order to skip the first argument from the check.
 func (r *subprocess) isContext(n ast.Node, ctx *gosec.Context) bool {
 	selector, indent, err := gosec.GetCallInfo(n, ctx)
 	if err != nil {

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -517,7 +517,7 @@ func main() {
 	b := createBuffer()
 	b.WriteString("*bytes.Buffer")
 }`}, 0, gosec.NewConfig()},
-	} // it shoudn't return any errors because all method calls are whitelisted by default
+	} // it shouldn't return any errors because all method calls are whitelisted by default
 
 	// SampleCodeG104Audit finds errors that aren't being handled in audit mode
 	SampleCodeG104Audit = []CodeSample{
@@ -1931,7 +1931,7 @@ import (
 )
 
 func main() {
-	err := exec.CommandContext(context.Background(), "git", "rev-parse", "--show-toplavel").Run()
+	err := exec.CommandContext(context.Background(), "git", "rev-parse", "--show-toplevel").Run()
  	if err != nil {
 		log.Fatal(err)
 	}
@@ -1980,7 +1980,7 @@ func main() {
 }`}, 1, gosec.NewConfig()},
 		{[]string{`
 // gosec doesn't have enough context to decide that the
-// command argument of the RunCmd function is harcoded string
+// command argument of the RunCmd function is hardcoded string
 // and that's why it's better to warn the user so he can audit it
 package main
 
@@ -2032,7 +2032,7 @@ func main() {
 	RunCmd("ll", "ls")
 }`}, 0, gosec.NewConfig()},
 		{[]string{`
-// syscall.Exec function called with harcoded arguments
+// syscall.Exec function called with hardcoded arguments
 // shouldn't be consider as a command injection
 package main
 
@@ -2090,7 +2090,7 @@ func main() {
 		{[]string{`
 // starting a process with a variable as an argument
 // even if not constant is not considered as dangerous
-// because it has harcoded value
+// because it has hardcoded value
 package main
 
 import (


### PR DESCRIPTION
This PR corrects spellings in comments, variable names, and test cases.