### PR TITLE
Remove the depguard from the list of enabled linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,6 @@ linters:
   enable:
     - asciicheck
     - bodyclose
-    - depguard
     - dogsled
     - durationcheck
     - errcheck


### PR DESCRIPTION
It seems that it flags some imports which are part of the project.


