### PR TITLE
Feature: G101 match variable values and names

### DIFF
--- a/rules/hardcoded_credentials.go
+++ b/rules/hardcoded_credentials.go
@@ -151,9 +151,9 @@ func (r *credentials) matchEqualityCheck(binaryExpr *ast.BinaryExpr, ctx *gosec.
 			identStrConst, ok = binaryExpr.Y.(*ast.BasicLit)
 		}
 
-		if ok { // Match for literals
-			s, err := gosec.GetString(identStrConst)
-			if err == nil && r.patternValue.MatchString(s) {
+		if ok && identStrConst.Kind == token.STRING { // Match for literals
+			s, _ := gosec.GetString(identStrConst)
+			if r.patternValue.MatchString(s) {
 				if r.ignoreEntropy || r.isHighEntropyString(s) {
 					return ctx.NewIssue(binaryExpr, r.ID(), r.What, r.Severity, r.Confidence), nil
 				}

--- a/rules/hardcoded_credentials.go
+++ b/rules/hardcoded_credentials.go
@@ -167,7 +167,7 @@ func (r *credentials) matchEqualityCheck(binaryExpr *ast.BinaryExpr, ctx *gosec.
 // assigned to variables that appear to be related to credentials.
 func NewHardcodedCredentials(id string, conf gosec.Config) (gosec.Rule, []ast.Node) {
 	pattern := `(?i)passwd|pass|password|pwd|secret|token|pw|apiKey|bearer|cred`
-	patternValue := "^(?i)[a-f0-9]{64}$"
+	patternValue := "(?i)^(.*[:;,](\\s)*)?[a-f0-9]{64}$"
 	entropyThreshold := 80.0
 	perCharThreshold := 3.0
 	ignoreEntropy := false

--- a/rules/hardcoded_credentials.go
+++ b/rules/hardcoded_credentials.go
@@ -84,11 +84,15 @@ func (r *credentials) matchAssign(assign *ast.AssignStmt, ctx *gosec.Context) (*
 
 			// Match the value assigned
 			for _, e := range assign.Rhs {
-				if val, err := gosec.GetString(e); err == nil {
-					if r.patternValue.MatchString(val) {
-						if r.ignoreEntropy || r.isHighEntropyString(val) {
-							return ctx.NewIssue(assign, r.ID(), r.What, r.Severity, r.Confidence), nil
-						}
+				val, err := gosec.GetString(e); 
+				
+				if err != nil {
+					continue
+				}
+
+				if r.patternValue.MatchString(val) {
+					if r.ignoreEntropy || r.isHighEntropyString(val) {
+						return ctx.NewIssue(assign, r.ID(), r.What, r.Severity, r.Confidence), nil
 					}
 				}
 			}

--- a/rules/hardcoded_credentials.go
+++ b/rules/hardcoded_credentials.go
@@ -173,7 +173,7 @@ func (r *credentials) matchEqualityCheck(binaryExpr *ast.BinaryExpr, ctx *gosec.
 // assigned to variables that appear to be related to credentials.
 func NewHardcodedCredentials(id string, conf gosec.Config) (gosec.Rule, []ast.Node) {
 	pattern := `(?i)passwd|pass|password|pwd|secret|token|pw|apiKey|bearer|cred`
-	patternValue := "(?i)^(.*[:;,](\\s)*)?[a-f0-9]{64}$"
+	patternValue := "(?i)(^(.*[:;,](\\s)*)?[a-f0-9]{64}$)|(AIza[0-9A-Za-z-_]{35})|(^(.*[:;,](\\s)*)?github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}$)|(^(.*[:;,](\\s)*)?[0-9a-zA-Z-_]{24}$)"
 	entropyThreshold := 80.0
 	perCharThreshold := 3.0
 	ignoreEntropy := false

--- a/rules/hardcoded_credentials.go
+++ b/rules/hardcoded_credentials.go
@@ -98,6 +98,7 @@ func (r *credentials) matchAssign(assign *ast.AssignStmt, ctx *gosec.Context) (*
 }
 
 func (r *credentials) matchValueSpec(valueSpec *ast.ValueSpec, ctx *gosec.Context) (*issue.Issue, error) {
+	// Match name
 	for index, ident := range valueSpec.Names {
 		if r.pattern.MatchString(ident.Name) && valueSpec.Values != nil {
 			// const foo, bar = "same value"
@@ -111,6 +112,18 @@ func (r *credentials) matchValueSpec(valueSpec *ast.ValueSpec, ctx *gosec.Contex
 			}
 		}
 	}
+
+	// Match values
+	for _, ident := range valueSpec.Values {
+		if val, err := gosec.GetString(ident); err == nil {
+			if r.patternValue.MatchString(val) {
+				if r.ignoreEntropy || (!r.ignoreEntropy && r.isHighEntropyString(val)) {
+					return ctx.NewIssue(valueSpec, r.ID(), r.What, r.Severity, r.Confidence), nil
+				}
+			}
+		}
+	}
+
 	return nil, nil
 }
 

--- a/rules/hardcoded_credentials.go
+++ b/rules/hardcoded_credentials.go
@@ -29,7 +29,7 @@ import (
 type credentials struct {
 	issue.MetaData
 	pattern          *regexp.Regexp
-	patternValue	 *regexp.Regexp // Pattern for matching string values (LHS on assign statements)
+	patternValue     *regexp.Regexp // Pattern for matching string values (LHS on assign statements)
 	entropyThreshold float64
 	perCharThreshold float64
 	truncate         int
@@ -153,7 +153,7 @@ func (r *credentials) matchEqualityCheck(binaryExpr *ast.BinaryExpr, ctx *gosec.
 		}
 		if okLit { // Match for literals
 			s, err := gosec.GetString(identStrConst)
-			if err == nil &&  r.patternValue.MatchString(s) {
+			if err == nil && r.patternValue.MatchString(s) {
 				if r.ignoreEntropy || (!r.ignoreEntropy && r.isHighEntropyString(s)) {
 					return ctx.NewIssue(binaryExpr, r.ID(), r.What, r.Severity, r.Confidence), nil
 				}
@@ -216,7 +216,7 @@ func NewHardcodedCredentials(id string, conf gosec.Config) (gosec.Rule, []ast.No
 
 	return &credentials{
 		pattern:          regexp.MustCompile(pattern),
-		patternValue:	  regexp.MustCompile(patternValue),
+		patternValue:     regexp.MustCompile(patternValue),
 		entropyThreshold: entropyThreshold,
 		perCharThreshold: perCharThreshold,
 		ignoreEntropy:    ignoreEntropy,

--- a/rules/rules_test.go
+++ b/rules/rules_test.go
@@ -55,6 +55,10 @@ var _ = Describe("gosec rules", func() {
 			runner("G101", testutils.SampleCodeG101)
 		})
 
+		It("should detect hardcoded credential values", func() {
+			runner("G101", testutils.SampleCodeG101Values)
+		})
+
 		It("should detect binding to all network interfaces", func() {
 			runner("G102", testutils.SampleCodeG102)
 		})

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -346,7 +346,7 @@ func main() {
 		fmt.Println(compareTooLong)
 	}
 }`}, 0, gosec.NewConfig()},
-	{[]string{`
+		{[]string{`
 package main
 
 import "fmt"
@@ -357,7 +357,7 @@ func main() {
 		fmt.Println(compareGoogleAPI)
 	}
 }`}, 1, gosec.NewConfig()},
-	{[]string{`
+		{[]string{`
 package main
 
 import "fmt"
@@ -369,7 +369,7 @@ const (
 func main() {
 	fmt.Println(githubPAT)
 }`}, 1, gosec.NewConfig()},
-{[]string{`
+		{[]string{`
 package main
 
 import "fmt"

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -346,6 +346,39 @@ func main() {
 		fmt.Println(compareTooLong)
 	}
 }`}, 0, gosec.NewConfig()},
+	{[]string{`
+package main
+
+import "fmt"
+
+func main() {
+	compareGoogleAPI := "test"
+	if compareGoogleAPI == "AIzajtGS_aJGkoiAmSbXzu9I-1eytAi9Lrlh-vT" {
+		fmt.Println(compareGoogleAPI)
+	}
+}`}, 1, gosec.NewConfig()},
+	{[]string{`
+package main
+
+import "fmt"
+
+const (
+	githubPAT = "key: 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"
+)
+
+func main() {
+	fmt.Println(githubPAT)
+}`}, 1, gosec.NewConfig()},
+{[]string{`
+package main
+
+import "fmt"
+
+func main() {
+	username := "admin"
+	googOAuthSec := "uibYYslvAUKn2ORRJ7EaZtMs"
+	fmt.Println("Logging in with: ", username, googOAuthSec)
+}`}, 1, gosec.NewConfig()},
 	}
 
 	// SampleCodeG102 code snippets for network binding

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -265,7 +265,7 @@ func main() {
 }`}, 1, gosec.NewConfig()},
 	}
 
-	// SampleCodeG101 code snippets for hardcoded credentials
+	// SampleCodeG101Values code snippets for hardcoded credentials
 	SampleCodeG101Values = []CodeSample{
 		{[]string{`
 package main

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -295,11 +295,23 @@ package main
 import "fmt"
 
 const (
-	tooLong = "key: c0df7a0f9b4a6a336029689b5df0712459a4f396c609ab05fd21a9097b4264f71294129"
+	tooLongConst = "key: c0df7a0f9b4a6a336029689b5df0712459a4f396c609ab05fd21a9097b4264f71294129"
 )
 
 func main() {
-	fmt.Println(tooLong)
+	fmt.Println(tooLongConst)
+}`}, 0, gosec.NewConfig()},
+		{[]string{`
+package main
+
+import "fmt"
+
+const (
+	tooShortConst = "key: c0df7a0f9b4a6a336029689b5df0712459a4f396c609ab05fd21a9097b4264f71294"
+)
+
+func main() {
+	fmt.Println(tooShortConst)
 }`}, 0, gosec.NewConfig()},
 		{[]string{`
 package main
@@ -307,11 +319,33 @@ package main
 import "fmt"
 
 func main() {
-	b := "test"
-	if b == "b7997caa846af0c50c095d63d212be2fbaffd35c22c735a905ddba87d85618fd" {
-		fmt.Println(b)
+	compareStr := "test"
+	if compareStr == "b7997caa846af0c50c095d63d212be2fbaffd35c22c735a905ddba87d85618fd" {
+		fmt.Println(compareStr)
 	}
 }`}, 1, gosec.NewConfig()},
+		{[]string{`
+package main
+
+import "fmt"
+
+func main() {
+	compareTooShort := "test"
+	if compareTooShort == "b7997caa846af0c50c095d63d212be2fbaffd35c22c735a905ddba87d85618d" {
+		fmt.Println(compareTooShort)
+	}
+}`}, 0, gosec.NewConfig()},
+		{[]string{`
+package main
+
+import "fmt"
+
+func main() {
+	compareTooLong := "test"
+	if compareTooLong == "b7997caa846af0c50c095d63d212be2fbaffd35c22c735a905ddba87d85618fd11" {
+		fmt.Println(compareTooLong)
+	}
+}`}, 0, gosec.NewConfig()},
 	}
 
 	// SampleCodeG102 code snippets for network binding

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -265,6 +265,55 @@ func main() {
 }`}, 1, gosec.NewConfig()},
 	}
 
+	// SampleCodeG101 code snippets for hardcoded credentials
+	SampleCodeG101Values = []CodeSample{
+		{[]string{`
+package main
+
+import "fmt"
+
+func main() {
+	username := "admin"
+	key := "472bb6c8c1871887cc117742ead362d688707d0442de930f7588db9d5ba091cc"
+	fmt.Println("Logging in with: ", username, key)
+}`}, 1, gosec.NewConfig()},
+		{[]string{`
+package main
+
+import "fmt"
+
+const (
+	b = "Bearer: c0df7a0f9b4a6a336029689b5df0712459a4f396c609ab05fd21a9097b4264f7"
+)
+
+func main() {
+	fmt.Println(b)
+}`}, 1, gosec.NewConfig()},
+		{[]string{`
+package main
+
+import "fmt"
+
+const (
+	tooLong = "key: c0df7a0f9b4a6a336029689b5df0712459a4f396c609ab05fd21a9097b4264f71294129"
+)
+
+func main() {
+	fmt.Println(tooLong)
+}`}, 0, gosec.NewConfig()},
+		{[]string{`
+package main
+
+import "fmt"
+
+func main() {
+	b := "test"
+	if b == "b7997caa846af0c50c095d63d212be2fbaffd35c22c735a905ddba87d85618fd" {
+		fmt.Println(b)
+	}
+}`}, 1, gosec.NewConfig()},
+	}
+
 	// SampleCodeG102 code snippets for network binding
 	SampleCodeG102 = []CodeSample{
 		// Bind to all networks explicitly


### PR DESCRIPTION
I updated the HardcodedCredentials code to apply regex against the actual values themselves in assignment statements, valuespecs, and equalities.  The intention is to search for secrets, such as API keys, by looking for the values. For example if we have:

`key = "3490b39bc66f7e7730e8fa68041da2e4f7c0a6a8cb119466c3ddc5245bda1781"`

this would previously not be caught by gosec, because gosec only looks at the variable names. 

Now, with these changes, the code matches values too using a new regex pattern that will look for secrets such as this. I added a new config variable called "patternValue," with a default regex which searches for VirusTotal API keys (or other keys with the same format). 