### PR TITLE
Feature: G602 Slice Bound Checking

### DIFF
--- a/issue/issue.go
+++ b/issue/issue.go
@@ -87,6 +87,7 @@ var ruleToCWE = map[string]string{
 	"G504": "327",
 	"G505": "327",
 	"G601": "118",
+	"G602": "118",
 }
 
 // Issue is returned by a gosec rule if it discovers an issue with the scanned code.

--- a/rules/rulelist.go
+++ b/rules/rulelist.go
@@ -107,7 +107,7 @@ func Generate(trackSuppressions bool, filters ...RuleFilter) RuleList {
 
 		// memory safety
 		{"G601", "Implicit memory aliasing in RangeStmt", NewImplicitAliasing},
-		{"G602", "Slice out of bounds", NewSliceBoundCheck},
+		{"G602", "Slice access out of bounds", NewSliceBoundCheck},
 	}
 
 	ruleMap := make(map[string]RuleDefinition)

--- a/rules/rulelist.go
+++ b/rules/rulelist.go
@@ -107,6 +107,7 @@ func Generate(trackSuppressions bool, filters ...RuleFilter) RuleList {
 
 		// memory safety
 		{"G601", "Implicit memory aliasing in RangeStmt", NewImplicitAliasing},
+		{"G602", "Slice out of bounds", NewSliceBoundCheck},
 	}
 
 	ruleMap := make(map[string]RuleDefinition)

--- a/rules/rules_test.go
+++ b/rules/rules_test.go
@@ -194,5 +194,9 @@ var _ = Describe("gosec rules", func() {
 		It("should detect implicit aliasing in ForRange", func() {
 			runner("G601", testutils.SampleCodeG601)
 		})
+
+		It("should detect out of bounds slice access", func() {
+			runner("G602", testutils.SampleCodeG602)
+		})
 	})
 })

--- a/rules/slice_bounds.go
+++ b/rules/slice_bounds.go
@@ -1,0 +1,118 @@
+package rules
+
+import (
+	"go/ast"
+
+	"github.com/securego/gosec/v2"
+	"github.com/securego/gosec/v2/issue"
+)
+
+type sliceOutOfBounds struct {
+	calls      gosec.CallList
+	sliceSizes map[string]int64
+	issue.MetaData
+}
+
+func (s *sliceOutOfBounds) ID() string {
+	return s.MetaData.ID
+}
+
+func (s *sliceOutOfBounds) Match(node ast.Node, ctx *gosec.Context) (*issue.Issue, error) {
+	switch node := node.(type) {
+	case *ast.AssignStmt:
+		return s.matchAssign(node, ctx)
+	case *ast.SliceExpr:
+		return s.matchSliceExpr(node, ctx)
+	}
+	return nil, nil
+}
+
+func (s *sliceOutOfBounds) matchAssign(node *ast.AssignStmt, ctx *gosec.Context) (*issue.Issue, error) {
+	// Check RHS for calls to make() so we can get the actual size of the slice
+	for it, i := range node.Rhs {
+		funcCall, ok := i.(*ast.CallExpr)
+		if !ok {
+			return nil, nil
+		}
+
+		_, funcName, err := gosec.GetCallInfo(i, ctx)
+		if err != nil || funcName != "make" {
+			return nil, nil
+		}
+
+		if len(funcCall.Args) < 2 {
+			return nil, nil // No size passed
+		}
+
+		// Check and get the size of the slice passed to make. It must be a literal value, since we aren't evaluating the expression.
+		sliceSizeLit, ok := funcCall.Args[1].(*ast.BasicLit)
+		if !ok {
+			return nil, nil
+		}
+
+		sliceSize, err := gosec.GetInt(sliceSizeLit)
+		if err != nil {
+			return nil, nil
+		}
+
+		// Get the slice name so we can associate the size with the slice in the map
+		sliceIdent, ok := node.Lhs[it].(*ast.Ident)
+		if !ok {
+			return nil, nil
+		}
+
+		sliceName := sliceIdent.Name
+		if err != nil {
+			return nil, nil
+		}
+
+		s.sliceSizes[sliceName] = sliceSize
+	}
+	return nil, nil
+}
+
+func (s *sliceOutOfBounds) matchSliceExpr(node *ast.SliceExpr, ctx *gosec.Context) (*issue.Issue, error) {
+	// First get the slice name so we can check the size in our map
+	ident, ok := node.X.(*ast.Ident)
+	if !ok {
+		return nil, nil
+	}
+
+	// Get slice size from the map to compare it against high and low
+	sliceSize, ok := s.sliceSizes[ident.Name]
+	if !ok {
+		return nil, nil // Slice is not present in map, so doing nothing
+	}
+
+	// Get and check low value
+	highIdent, ok := node.High.(*ast.BasicLit)
+	if ok && highIdent != nil {
+		high, _ := gosec.GetInt(highIdent)
+		if high > sliceSize {
+			return ctx.NewIssue(node, s.ID(), s.What, s.Severity, s.Confidence), nil
+		}
+	}
+
+	// Get and check low value
+	lowIdent, ok := node.Low.(*ast.BasicLit)
+	if ok && lowIdent != nil {
+		low, _ := gosec.GetInt(lowIdent)
+		if low > sliceSize {
+			return ctx.NewIssue(node, s.ID(), s.What, s.Severity, s.Confidence), nil
+		}
+	}
+
+	return nil, nil
+}
+
+func NewSliceBoundCheck(id string, _ gosec.Config) (gosec.Rule, []ast.Node) {
+	return &sliceOutOfBounds{
+		sliceSizes: make(map[string]int64),
+		MetaData: issue.MetaData{
+			ID:         id,
+			Severity:   issue.Medium,
+			Confidence: issue.Medium,
+			What:       "Potentially accessing slice out of bounds",
+		},
+	}, []ast.Node{(*ast.AssignStmt)(nil), (*ast.ValueSpec)(nil), (*ast.BinaryExpr)(nil), (*ast.SliceExpr)(nil)}
+}

--- a/rules/slice_bounds.go
+++ b/rules/slice_bounds.go
@@ -352,6 +352,8 @@ func (s *sliceOutOfBounds) matchIndexExpr(node *ast.IndexExpr, ctx *gosec.Contex
 	return nil, nil
 }
 
+// NewSliceBoundsCheck attempts to find any slices being accessed out of bounds
+// by reslicing or by being indexed.
 func NewSliceBoundCheck(id string, _ gosec.Config) (gosec.Rule, []ast.Node) {
 	sliceMapNil := make(map[string]*int64)
 	sliceMap := make(map[*ast.CallExpr]map[string]*int64)

--- a/rules/slice_bounds.go
+++ b/rules/slice_bounds.go
@@ -2,16 +2,17 @@ package rules
 
 import (
 	"go/ast"
-	"log"
+	"go/types"
 
 	"github.com/securego/gosec/v2"
 	"github.com/securego/gosec/v2/issue"
 )
 
 type sliceOutOfBounds struct {
-	sliceCaps       map[string]int64 // Capacities of slices
-	currentScope    *ast.Scope       // Current scope. Map is cleared when scope changes.
-	currentFuncName string           // Current function. Slices are stored as funcName/sliceName.
+	sliceCaps       map[*ast.CallExpr]map[string]*int64 // Capacities of slices. Maps function call -> var name -> value
+	currentScope    *types.Scope                        // Current scope. Map is cleared when scope changes.
+	currentFuncName string                              // Current function
+	funcCallArgs    map[string][]*int64                 // Caps to load once a func declaration is scanned
 	issue.MetaData
 }
 
@@ -21,10 +22,15 @@ func (s *sliceOutOfBounds) ID() string {
 
 func (s *sliceOutOfBounds) Match(node ast.Node, ctx *gosec.Context) (*issue.Issue, error) {
 	if s.currentScope == nil {
-		s.currentScope = ctx.Root.Scope
-	} else if s.currentScope != ctx.Root.Scope {
-		s.currentScope = ctx.Root.Scope
-		s.sliceCaps = make(map[string]int64)
+		s.currentScope = ctx.Pkg.Scope()
+	} else if s.currentScope != ctx.Pkg.Scope() {
+		s.currentScope = ctx.Pkg.Scope()
+
+		// Clear slice map, since we are in a new scope
+		sliceMapNil := make(map[string]*int64)
+		sliceCaps := make(map[*ast.CallExpr]map[string]*int64)
+		sliceCaps[nil] = sliceMapNil
+		s.sliceCaps = sliceCaps
 	}
 
 	switch node := node.(type) {
@@ -36,10 +42,150 @@ func (s *sliceOutOfBounds) Match(node ast.Node, ctx *gosec.Context) (*issue.Issu
 		return s.matchIndexExpr(node, ctx)
 	case *ast.FuncDecl:
 		s.currentFuncName = node.Name.Name
-		//case *ast.CallExpr:
-		//return s.matchCallExpr(node, ctx)
+		s.loadArgCaps(node, ctx)
+	case *ast.CallExpr:
+		sliceMap := make(map[string]*int64)
+		s.sliceCaps[node] = sliceMap
+		s.setupCallArgCaps(node, ctx)
 	}
 	return nil, nil
+}
+
+func (s *sliceOutOfBounds) updateSliceCaps(varName string, caps map[*ast.CallExpr]*int64) {
+	for callExpr, cap := range caps {
+		s.sliceCaps[callExpr][varName] = cap
+	}
+}
+
+// Get all calls for the current function
+func (s *sliceOutOfBounds) getAllCalls(funcName string, ctx *gosec.Context) []*ast.CallExpr {
+	calls := []*ast.CallExpr{}
+
+	for callExpr, _ := range s.sliceCaps {
+		if callExpr != nil {
+			// Compare the names of the function the code is scanning with the current call we are iterating over
+			_, funcName, err := gosec.GetCallInfo(callExpr, ctx)
+			if err != nil {
+				continue
+			}
+
+			if funcName == s.currentFuncName {
+				calls = append(calls, callExpr)
+			}
+		} else {
+			calls = append(calls, callExpr)
+		}
+	}
+	return calls
+}
+
+// Gets all the capacities for slice with given name that are stored for each call to the current function we are looking at
+func (s *sliceOutOfBounds) getSliceCapsForFunc(funcName string, varName string, ctx *gosec.Context) map[*ast.CallExpr]*int64 {
+	caps := make(map[*ast.CallExpr]*int64)
+
+	calls := s.getAllCalls(funcName, ctx)
+	for _, call := range calls {
+		caps[call] = s.sliceCaps[call][varName]
+	}
+
+	return caps
+}
+
+// Evaluate and save the caps for any slices in the args so they can be validated when the function is scanned
+func (s *sliceOutOfBounds) setupCallArgCaps(callExpr *ast.CallExpr, ctx *gosec.Context) {
+	// Array of caps to be loaded once the function declaration is scanned
+	funcCallArgs := []*int64{}
+
+	// Get function name
+	_, funcName, err := gosec.GetCallInfo(callExpr, ctx)
+	if err != nil {
+		return
+	}
+
+	for _, arg := range callExpr.Args {
+		switch node := arg.(type) {
+		case *ast.SliceExpr:
+			caps := s.evaluateSliceExpr(node, ctx)
+
+			// Simplifying assumption: use the lowest capacity. Storing all possibly capacities for slices passed
+			// to a function call would catch the most issues, but would require a data structure like a stack and a
+			// reworking of the code for scanning itself. Use the lowest capacity, as this would be more likely to
+			// raise an issue for being out of bounds.
+			var lowestCap *int64 = nil
+			for _, cap := range caps {
+				if lowestCap == nil {
+					lowestCap = cap
+				} else if *lowestCap > *cap {
+					lowestCap = cap
+				}
+			}
+
+			if lowestCap == nil {
+				continue
+			}
+
+			// Now create a map of just this value to add it to the sliceCaps
+			funcCallArgs = append(funcCallArgs, lowestCap)
+		case *ast.Ident:
+			ident := arg.(*ast.Ident)
+			caps := s.getSliceCapsForFunc(funcName, ident.Name, ctx)
+
+			var lowestCap *int64 = nil
+			for _, cap := range caps {
+				if cap == nil {
+					continue
+				}
+				if lowestCap == nil {
+					lowestCap = cap
+				} else if *lowestCap > *cap {
+					lowestCap = cap
+				}
+			}
+
+			if lowestCap == nil {
+				continue
+			}
+
+			// Now create a map of just this value to add it to the sliceCaps
+			funcCallArgs = append(funcCallArgs, lowestCap)
+		default:
+			funcCallArgs = append(funcCallArgs, nil)
+		}
+	}
+	s.funcCallArgs[funcName] = funcCallArgs
+}
+
+// Load caps that were saved for a call to this function
+func (s *sliceOutOfBounds) loadArgCaps(funcDecl *ast.FuncDecl, ctx *gosec.Context) {
+	sliceMap := make(map[string]*int64)
+	funcName := funcDecl.Name.Name
+
+	argCaps, ok := s.funcCallArgs[funcName]
+	if !ok || len(argCaps) == 0 {
+		s.sliceCaps[nil] = sliceMap
+		return
+	}
+
+	params := funcDecl.Type.Params.List
+	if len(params) > len(argCaps) {
+		return
+	}
+
+	for it := range params {
+		cap := argCaps[it]
+		if cap == nil {
+			continue
+		}
+
+		if len(params[it].Names) == 0 {
+			continue
+		}
+
+		paramName := params[it].Names[0].Name
+		sliceMap[paramName] = cap
+	}
+
+	s.sliceCaps[nil] = sliceMap
 }
 
 // Matches calls to make() and stores the capacity of the new slice in the map to compare against future slice usage
@@ -66,14 +212,46 @@ func (s *sliceOutOfBounds) matchSliceMake(funcCall *ast.CallExpr, sliceName stri
 		return nil, nil
 	}
 
-	sliceCap, err := gosec.GetInt(sliceCapLit)
+	cap, err := gosec.GetInt(sliceCapLit)
 	if err != nil {
 		return nil, nil
 	}
 
-	s.sliceCaps[s.currentFuncName+"/"+sliceName] = sliceCap
-	log.Print(s.sliceCaps)
+	caps := s.getSliceCapsForFunc(s.currentFuncName, sliceName, ctx)
+	for callExpr, _ := range caps {
+		caps[callExpr] = &cap
+	}
+
+	s.updateSliceCaps(sliceName, caps)
 	return nil, nil
+}
+
+func (s *sliceOutOfBounds) evaluateSliceExpr(node *ast.SliceExpr, ctx *gosec.Context) map[*ast.CallExpr]*int64 {
+	// Get ident to get name
+	ident, ok := node.X.(*ast.Ident)
+	if !ok {
+		return nil
+	}
+
+	// Get cap of old slice to calculate this new slice's cap
+	caps := s.getSliceCapsForFunc(s.currentFuncName, ident.Name, ctx)
+	for callExpr, oldCap := range caps {
+		if oldCap == nil {
+			continue
+		}
+		// Get and check low value
+		lowIdent, ok := node.Low.(*ast.BasicLit)
+		if ok && lowIdent != nil {
+			low, _ := gosec.GetInt(lowIdent)
+
+			newCap := *oldCap - low
+			caps[callExpr] = &newCap
+		} else if lowIdent == nil { // If no lower bound, capacity will be same
+			continue
+		}
+	}
+
+	return caps
 }
 
 // Matches slice assignments, calculates capacity of slice if possible to store it in map
@@ -84,30 +262,8 @@ func (s *sliceOutOfBounds) matchSliceAssignment(node *ast.SliceExpr, sliceName s
 	}
 
 	// Now that the assignment is (presumably) successfully, we can calculate the capacity and add this new slice to the map
-	// Get ident to get name
-	ident, ok := node.X.(*ast.Ident)
-	if !ok {
-		return nil, nil
-	}
-
-	// Get cap of old slice to calculate this new slice's cap
-	oldCap, ok := s.sliceCaps[s.currentFuncName+"/"+ident.Name]
-	if !ok {
-		return nil, nil
-	}
-
-	// Get and check low value
-	lowIdent, ok := node.Low.(*ast.BasicLit)
-	if ok && lowIdent != nil {
-		low, _ := gosec.GetInt(lowIdent)
-
-		newCap := oldCap - low
-		s.sliceCaps[s.currentFuncName+"/"+sliceName] = newCap
-	} else if lowIdent == nil { // If no lower bound, capacity will be same
-		s.sliceCaps[s.currentFuncName+"/"+sliceName] = oldCap
-	}
-
-	log.Print(s.sliceCaps)
+	caps := s.evaluateSliceExpr(node, ctx)
+	s.updateSliceCaps(sliceName, caps)
 
 	return nil, nil
 }
@@ -140,30 +296,31 @@ func (s *sliceOutOfBounds) matchSliceExpr(node *ast.SliceExpr, ctx *gosec.Contex
 	}
 
 	// Get slice cap from the map to compare it against high and low
-	sliceCap, ok := s.sliceCaps[s.currentFuncName+"/"+ident.Name]
-	if !ok {
-		return nil, nil // Slice is not present in map, so doing nothing
-	}
+	caps := s.getSliceCapsForFunc(s.currentFuncName, ident.Name, ctx)
 
-	// Get and check high value
-	highIdent, ok := node.High.(*ast.BasicLit)
-	if ok && highIdent != nil {
-		high, _ := gosec.GetInt(highIdent)
-		if high > sliceCap {
-			return ctx.NewIssue(node, s.ID(), s.What, s.Severity, s.Confidence), nil
+	for _, cap := range caps {
+		if cap == nil {
+			continue
+		}
+
+		// Get and check high value
+		highIdent, ok := node.High.(*ast.BasicLit)
+		if ok && highIdent != nil {
+			high, _ := gosec.GetInt(highIdent)
+			if high > *cap {
+				return ctx.NewIssue(node, s.ID(), s.What, s.Severity, s.Confidence), nil
+			}
+		}
+
+		// Get and check low value
+		lowIdent, ok := node.Low.(*ast.BasicLit)
+		if ok && lowIdent != nil {
+			low, _ := gosec.GetInt(lowIdent)
+			if low > *cap {
+				return ctx.NewIssue(node, s.ID(), s.What, s.Severity, s.Confidence), nil
+			}
 		}
 	}
-
-	// Get and check low value
-	lowIdent, ok := node.Low.(*ast.BasicLit)
-	if ok && lowIdent != nil {
-		low, _ := gosec.GetInt(lowIdent)
-		if low > sliceCap {
-			return ctx.NewIssue(node, s.ID(), s.What, s.Severity, s.Confidence), nil
-		}
-	}
-
-	log.Print(s.sliceCaps)
 
 	return nil, nil
 }
@@ -176,34 +333,39 @@ func (s *sliceOutOfBounds) matchIndexExpr(node *ast.IndexExpr, ctx *gosec.Contex
 	}
 
 	// Get slice cap from the map to compare it against high and low
-	sliceSize, ok := s.sliceCaps[s.currentFuncName+"/"+ident.Name]
-	if !ok {
-		return nil, nil // Slice is not present in map, so doing nothing
-	}
+	caps := s.getSliceCapsForFunc(s.currentFuncName, ident.Name, ctx)
 
-	// Get the index literal
-	indexIdent, ok := node.Index.(*ast.BasicLit)
-	if ok && indexIdent != nil {
-		index, _ := gosec.GetInt(indexIdent)
-		if index >= sliceSize {
-			return ctx.NewIssue(node, s.ID(), s.What, s.Severity, s.Confidence), nil
+	for _, cap := range caps {
+		if cap == nil {
+			continue
+		}
+		// Get the index literal
+		indexIdent, ok := node.Index.(*ast.BasicLit)
+		if ok && indexIdent != nil {
+			index, _ := gosec.GetInt(indexIdent)
+			if index >= *cap {
+				return ctx.NewIssue(node, s.ID(), s.What, s.Severity, s.Confidence), nil
+			}
 		}
 	}
 
 	return nil, nil
 }
 
-//func (s *sliceOutOfBounds) matchAssign(node *ast.AssignStmt, ctx *gosec.Context) (*issue.Issue, error) {
-//}
-
 func NewSliceBoundCheck(id string, _ gosec.Config) (gosec.Rule, []ast.Node) {
+	sliceMapNil := make(map[string]*int64)
+	sliceMap := make(map[*ast.CallExpr]map[string]*int64)
+	sliceMap[nil] = sliceMapNil
+
 	return &sliceOutOfBounds{
-		sliceCaps: make(map[string]int64),
+		sliceCaps:       sliceMap,
+		currentFuncName: "",
+		funcCallArgs:    make(map[string][]*int64),
 		MetaData: issue.MetaData{
 			ID:         id,
 			Severity:   issue.Medium,
 			Confidence: issue.Medium,
 			What:       "Potentially accessing slice out of bounds",
 		},
-	}, []ast.Node{(*ast.AssignStmt)(nil), (*ast.SliceExpr)(nil), (*ast.IndexExpr)(nil), (*ast.CallExpr)(nil), (*ast.FuncDecl)(nil)}
+	}, []ast.Node{(*ast.CallExpr)(nil), (*ast.FuncDecl)(nil), (*ast.AssignStmt)(nil), (*ast.SliceExpr)(nil), (*ast.IndexExpr)(nil)}
 }

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -3831,7 +3831,7 @@ func main() {
 }
 
 func doStuff(x []int) {
-	newSice := x[:10]
+	newSlice := x[:10]
 	fmt.Println(newSlice)
 }`}, 1, gosec.NewConfig()},
 	}

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -3834,5 +3834,27 @@ func doStuff(x []int) {
 	newSlice := x[:10]
 	fmt.Println(newSlice)
 }`}, 1, gosec.NewConfig()},
+		{[]string{`
+package main
+
+import "fmt"
+
+func main() {
+
+	s := make([]int, 0, 30)
+	doStuff(s)
+	x := make([]int, 20)
+	y := x[10:]
+	doStuff(y)
+	z := y[5:]
+	doStuff(z)
+}
+
+func doStuff(x []int) {
+	newSlice := x[:10]
+	fmt.Println(newSlice)
+	newSlice2 := x[:6]
+	fmt.Println(newSlice2)
+}`}, 2, gosec.NewConfig()},
 	}
 )

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -3682,20 +3682,89 @@ func main() {
 
 	// SampleCodeG602 - Slice access out of bounds
 	SampleCodeG602 = []CodeSample{
-		{[]string{
-			`
+		{[]string{`
 package main
 
 import "fmt"
 
 func main() {
 
-	bb := make([]byte, 0)
+	s := make([]byte, 0)
 
-	fmt.Println(bb[:3])
+	fmt.Println(s[:3])
 
-}
-`,
-		}, 1, gosec.NewConfig()},
+}`}, 1, gosec.NewConfig()},
+		{[]string{`
+package main
+
+import "fmt"
+
+func main() {
+
+	s := make([]byte, 0)
+
+	fmt.Println(s[3:])
+
+}`}, 1, gosec.NewConfig()},
+		{[]string{`
+package main
+
+import "fmt"
+
+func main() {
+
+	s := make([]byte, 16)
+
+	fmt.Println(s[:17])
+
+}`}, 1, gosec.NewConfig()},
+		{[]string{`
+package main
+
+import "fmt"
+
+func main() {
+
+	s := make([]byte, 16)
+
+	fmt.Println(s[:16])
+
+}`}, 0, gosec.NewConfig()},
+		{[]string{`
+package main
+
+import "fmt"
+
+func main() {
+
+	s := make([]byte, 16)
+
+	fmt.Println(s[5:17])
+
+}`}, 1, gosec.NewConfig()},
+		{[]string{`
+package main
+
+import "fmt"
+
+func main() {
+
+	s := make([]byte, 4)
+
+	fmt.Println(s[3])
+
+}`}, 0, gosec.NewConfig()},
+		{[]string{`
+package main
+
+import "fmt"
+
+func main() {
+
+	s := make([]byte, 4)
+
+	fmt.Println(s[5])
+
+}`}, 1, gosec.NewConfig()},
 	}
 )

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -3766,5 +3766,18 @@ func main() {
 	fmt.Println(s[5])
 
 }`}, 1, gosec.NewConfig()},
+		{[]string{`
+package main
+
+import "fmt"
+
+func main() {
+
+	s := make([]byte, 0)
+	s = make([]byte, 3)
+
+	fmt.Println(s[:3])
+
+}`}, 0, gosec.NewConfig()},
 	}
 )

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -3679,4 +3679,23 @@ func main() {
         C.printData(cData)
 }
 `}, 0, gosec.NewConfig()}}
+
+	// SampleCodeG602 - Slice access out of bounds
+	SampleCodeG602 = []CodeSample{
+		{[]string{
+			`
+package main
+
+import "fmt"
+
+func main() {
+
+	bb := make([]byte, 0)
+
+	fmt.Println(bb[:3])
+
+}
+`,
+		}, 1, gosec.NewConfig()},
+	}
 )

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -3779,5 +3779,60 @@ func main() {
 	fmt.Println(s[:3])
 
 }`}, 0, gosec.NewConfig()},
+
+		{[]string{`
+package main
+
+import "fmt"
+
+func main() {
+
+	s := make([]byte, 0, 4)
+
+	fmt.Println(s[:3])
+	fmt.Println(s[3])
+
+}`}, 0, gosec.NewConfig()},
+		{[]string{`
+package main
+
+import "fmt"
+
+func main() {
+
+	s := make([]byte, 0, 4)
+
+	fmt.Println(s[:5])
+	fmt.Println(s[7])
+
+}`}, 2, gosec.NewConfig()},
+		{[]string{`
+package main
+
+import "fmt"
+
+func main() {
+
+	s := make([]byte, 0, 4)
+	x := s[:2]
+	y := x[:10]
+	fmt.Println(y)
+}`}, 1, gosec.NewConfig()},
+
+		{[]string{`
+package main
+
+import "fmt"
+
+func main() {
+
+	s := make([]int, 0, 4)
+	doStuff(s)
+}
+
+func doStuff(x []int) {
+	newSice := x[:10]
+	fmt.Println(newSlice)
+}`}, 1, gosec.NewConfig()},
 	}
 )


### PR DESCRIPTION
This PR addresses this issue: #954 

This adds a new rule which checks slice bounds access (reslicing and indexing) to ensure that slices are not accessed out of bounds. This only works for slice bounds defined by a `make([]..., len)` or `make([]..., len, capacity)` where len/capacity is defined as a literal integer. For example it works for:
```go
s := make([]float, 10, 20)
```
But not for:
```go
s := make([]float, 10*3)
```
Since we don't evaluate expressions. It also will calculate and validate slice capacities for new slices made by reslicing when possible, such as:
```go
s := make([]float, 10)
x := s[5:]
```
The capacity for the new slice, `x`, will be validated in any subsequent usage. In addition, slices passed to functions are validated when possible by storing function-call-specific capacities. For example:
```go
func main() {
	s := make([]int, 0, 30)
	doStuff(s)
	x := make([]int, 20)
	y := x[10:]
	doStuff(y)
	z := y[5:]
	doStuff(z)
}

func doStuff(x []int) {
	newSlice := x[:10]
	fmt.Println(newSlice)
	newSlice2 := x[:6]
	fmt.Println(newSlice2)
}`
```
will cause an error on creation of `newSlice` and `newSlice2`, since when `z` is passed to it, it is accessed out of bounds.