### PR TITLE
Add a new flag terse to show only the results and summary

### DIFF
--- a/cmd/gosec/main.go
+++ b/cmd/gosec/main.go
@@ -143,6 +143,9 @@ var (
 	// output suppression information for auditing purposes
 	flagTrackSuppressions = flag.Bool("track-suppressions", false, "Output suppression information, including its kind and justification")
 
+	// flagTerse shows only the summary of scan discarding all the logs
+	flagTerse = flag.Bool("terse", false, "Shows only the results and summary")
+
 	// exclude the folders from scan
 	flagDirsExclude arrayFlags
 
@@ -354,7 +357,7 @@ func main() {
 		}
 	}
 
-	if *flagQuiet {
+	if *flagQuiet || *flagTerse {
 		logger = log.New(io.Discard, "", 0)
 	} else {
 		logger = log.New(logWriter, "[gosec] ", log.LstdFlags)


### PR DESCRIPTION
The new flag '-terse' will only show the results and summary ignoring any logs occurred during a scan.

fixes #985
