### PR TITLE
Update gosec image version to 2.17.0 in the Github action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
 
 runs:
     using: 'docker'
-    image: 'docker://securego/gosec:2.16.0'
+    image: 'docker://securego/gosec:2.17.0'
     args:
       - ${{ inputs.args }}
 


### PR DESCRIPTION
This version bump fixes go version 1.21.0