### PR TITLE
Exclude maps from slince bounce check rule

### DIFF
--- a/rules/slice_bounds.go
+++ b/rules/slice_bounds.go
@@ -233,6 +233,11 @@ func (s *sliceOutOfBounds) matchSliceMake(funcCall *ast.CallExpr, sliceName stri
 		return nil, nil // Unexpected, args should always be 2 or 3
 	}
 
+	// Check if the type of the slice is a map, since they should no be checked.
+	if _, ok := funcCall.Args[0].(*ast.MapType); ok {
+		return nil, nil
+	}
+
 	// Check and get the capacity of the slice passed to make. It must be a literal value, since we aren't evaluating the expression.
 	sliceCapLit, ok := funcCall.Args[capacityArg].(*ast.BasicLit)
 	if !ok {

--- a/testutils/source.go
+++ b/testutils/source.go
@@ -3966,5 +3966,19 @@ func doStuff(x []int) {
 	newSlice2 := x[:6]
 	fmt.Println(newSlice2)
 }`}, 2, gosec.NewConfig()},
+		{[]string{`
+package main
+
+import "fmt"
+
+func main() {
+  testMap := make(map[string]any, 0)
+  testMap["test1"] = map[string]interface{}{
+    "test2": map[string]interface{}{
+      "value": 0,
+    },
+  }
+  fmt.Println(testMap)
+}`}, 0, gosec.NewConfig()},
 	}
 )


### PR DESCRIPTION
This exclude maps type form slice bounds checks. 

This is a partial fix for #1005
