### PR TITLE
docs: add reMarkable to users list

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -15,6 +15,7 @@ This is a list of gosec's users. Please send a pull request with your organisati
 9. [PingCAP/tidb](https://github.com/pingcap/tidb)
 10. [Checkmarx](https://www.checkmarx.com/)
 11. [SeatGeek](https://www.seatgeek.com/)
+12. [reMarkable](https://remarkable.com)
 
 ## Projects
 


### PR DESCRIPTION
We're super happy with gosec. Thanks for all the great work! We'd love to be on the user-list. 
