### PR TITLE
Fix typos in struct fields, comments, vars, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ directory you can supply `./...` as the input argument.
 - G304: File path provided as taint input
 - G305: File traversal when extracting zip/tar archive
 - G306: Poor file permissions used when writing to a new file
-- G307: Poor file permissions used when crating a file with os.Create
+- G307: Poor file permissions used when creating a file with os.Create
 - G401: Detect the usage of DES, RC4, MD5 or SHA1
 - G402: Look for bad TLS connection settings
 - G403: Ensure minimum RSA key length of 2048 bits

--- a/cmd/tlsconfig/tlsconfig.go
+++ b/cmd/tlsconfig/tlsconfig.go
@@ -46,8 +46,8 @@ type Configuration struct {
 	ECDHParamSize         float64  `json:"ecdh_param_size"`
 	HstsMinAge            float64  `json:"hsts_min_age"`
 	OldestClients         []string `json:"oldest_clients"`
-	OCSPStample           bool     `json:"ocsp_staple"`
-	ServerPreferedOrder   bool     `json:"server_preferred_order"`
+	OCSPStaple            bool     `json:"ocsp_staple"`
+	ServerPreferredOrder  bool     `json:"server_preferred_order"`
 	MaxCertLifespan       float64  `json:"maximum_certificate_lifespan"`
 }
 
@@ -121,27 +121,27 @@ func getGoTLSConf() (goTLSConfiguration, error) {
 		panic(msg)
 	}
 
-	tlsConfg := goTLSConfiguration{}
+	tlsConfig := goTLSConfiguration{}
 
 	modern, err := getGoCipherConfig("modern", *sstls)
 	if err != nil {
-		return tlsConfg, err
+		return tlsConfig, err
 	}
-	tlsConfg.cipherConfigs = append(tlsConfg.cipherConfigs, modern)
+	tlsConfig.cipherConfigs = append(tlsConfig.cipherConfigs, modern)
 
 	intermediate, err := getGoCipherConfig("intermediate", *sstls)
 	if err != nil {
-		return tlsConfg, err
+		return tlsConfig, err
 	}
-	tlsConfg.cipherConfigs = append(tlsConfg.cipherConfigs, intermediate)
+	tlsConfig.cipherConfigs = append(tlsConfig.cipherConfigs, intermediate)
 
 	old, err := getGoCipherConfig("old", *sstls)
 	if err != nil {
-		return tlsConfg, err
+		return tlsConfig, err
 	}
-	tlsConfg.cipherConfigs = append(tlsConfg.cipherConfigs, old)
+	tlsConfig.cipherConfigs = append(tlsConfig.cipherConfigs, old)
 
-	return tlsConfg, nil
+	return tlsConfig, nil
 }
 
 func getCurrentDir() (string, error) {

--- a/helpers.go
+++ b/helpers.go
@@ -100,7 +100,7 @@ func GetChar(n ast.Node) (byte, error) {
 // Unlike the other getters, it does _not_ raise an error for unknown ast.Node types. At the base, the recursion will hit a non-BinaryExpr type,
 // either BasicLit or other, so it's not an error case. It will only error if `strconv.Unquote` errors. This matters, because there's
 // currently functionality that relies on error values being returned by GetString if and when it hits a non-basiclit string node type,
-// hence for cases where recursion is needed, we use this separate function, so that we can still be backwards compatbile.
+// hence for cases where recursion is needed, we use this separate function, so that we can still be backwards compatible.
 //
 // This was added to handle a SQL injection concatenation case where the injected value is infixed between two strings, not at the start or end. See example below
 //

--- a/issue/issue_test.go
+++ b/issue/issue_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Issue", func() {
 			ast.Walk(v, ctx.Root)
 			Expect(target).ShouldNot(BeNil())
 
-			// Use hardcodeded rule to check assignment
+			// Use hardcoded rule to check assignment
 			cfg := gosec.NewConfig()
 			rule, _ := rules.NewHardcodedCredentials("TEST", cfg)
 			foundIssue, err := rule.Match(target, ctx)

--- a/report/sarif/builder.go
+++ b/report/sarif/builder.go
@@ -8,7 +8,7 @@ func NewReport(version string, schema string) *Report {
 	}
 }
 
-// WithRuns dafines runs for the current report
+// WithRuns defines runs for the current report
 func (r *Report) WithRuns(runs ...*Run) *Report {
 	r.Runs = runs
 	return r


### PR DESCRIPTION
This PR corrects spelling mistakes.