### PR TITLE
Refactor how ignored issues are tracked

### DIFF
--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -743,25 +743,6 @@ var _ = Describe("Analyzer", func() {
 			Expect(issues[0].Suppressions[0].Justification).To(Equal(""))
 		})
 
-		It("should track multiple suppressions if the violation is suppressed by both #nosec and #nosec RuleList", func() {
-			sample := testutils.SampleCodeG101[0]
-			source := sample.Code[0]
-			analyzer.LoadRules(rules.Generate(false, rules.NewRuleFilter(false, "G101")).RulesInfo())
-
-			nosecPackage := testutils.NewTestPackage()
-			defer nosecPackage.Close()
-			nosecSource := strings.Replace(source, "}", "} //#nosec G101 -- Justification", 1)
-			nosecSource = strings.Replace(nosecSource, "func", "//#nosec\nfunc", 1)
-			nosecPackage.AddFile("pwd.go", nosecSource)
-			err := nosecPackage.Build()
-			Expect(err).ShouldNot(HaveOccurred())
-			err = analyzer.Process(buildTags, nosecPackage.Path)
-			Expect(err).ShouldNot(HaveOccurred())
-			issues, _, _ := analyzer.Report()
-			Expect(issues).To(HaveLen(sample.Errors))
-			Expect(issues[0].Suppressions).To(HaveLen(2))
-		})
-
 		It("should not report an error if the rule is not included", func() {
 			sample := testutils.SampleCodeG101[0]
 			source := sample.Code[0]
@@ -807,7 +788,7 @@ var _ = Describe("Analyzer", func() {
 
 			nosecPackage := testutils.NewTestPackage()
 			defer nosecPackage.Close()
-			nosecSource := strings.Replace(source, "}", "} //#nosec G101 -- Justification", 1)
+			nosecSource := strings.Replace(source, "password := \"f62e5bcda4fae4f82370da0c6f20697b8f8447ef\"", "password := \"f62e5bcda4fae4f82370da0c6f20697b8f8447ef\" //#nosec G101 -- Justification", 1)
 			nosecPackage.AddFile("pwd.go", nosecSource)
 			err := nosecPackage.Build()
 			Expect(err).ShouldNot(HaveOccurred())

--- a/cmd/tlsconfig/tlsconfig.go
+++ b/cmd/tlsconfig/tlsconfig.go
@@ -187,7 +187,7 @@ func main() {
 	}
 
 	outputPath := filepath.Join(dir, *outputFile)
-	if err := os.WriteFile(outputPath, src, 0o644); err != nil {
+	if err := os.WriteFile(outputPath, src, 0o644); err != nil /*#nosec G306*/ {
 		log.Fatalf("Writing output: %s", err)
-	} //#nosec G306
+	}
 }

--- a/issue/issue.go
+++ b/issue/issue.go
@@ -178,11 +178,7 @@ func codeSnippetEndLine(node ast.Node, fobj *token.File) int64 {
 // New creates a new Issue
 func New(fobj *token.File, node ast.Node, ruleID, desc string, severity, confidence Score) *Issue {
 	name := fobj.Name()
-	start, end := fobj.Line(node.Pos()), fobj.Line(node.End())
-	line := strconv.Itoa(start)
-	if start != end {
-		line = fmt.Sprintf("%d-%d", start, end)
-	}
+	line := GetLine(fobj, node)
 	col := strconv.Itoa(fobj.Position(node.Pos()).Column)
 
 	var code string
@@ -216,4 +212,14 @@ func New(fobj *token.File, node ast.Node, ruleID, desc string, severity, confide
 func (i *Issue) WithSuppressions(suppressions []SuppressionInfo) *Issue {
 	i.Suppressions = suppressions
 	return i
+}
+
+// GetLine returns the line number of a given ast.Node
+func GetLine(fobj *token.File, node ast.Node) string {
+	start, end := fobj.Line(node.Pos()), fobj.Line(node.End())
+	line := strconv.Itoa(start)
+	if start != end {
+		line = fmt.Sprintf("%d-%d", start, end)
+	}
+	return line
 }

--- a/testutils/pkg.go
+++ b/testutils/pkg.go
@@ -53,9 +53,9 @@ func (p *TestPackage) write() error {
 		return nil
 	}
 	for filename, content := range p.Files {
-		if e := os.WriteFile(filename, []byte(content), 0o644); e != nil {
+		if e := os.WriteFile(filename, []byte(content), 0o644); e != nil /* #nosec G306 */ {
 			return e
-		} //#nosec G306
+		}
 	}
 	p.onDisk = true
 	return nil


### PR DESCRIPTION
Track ignored issues using file location instead of a AST node. There are issues linked to a different AST node than the original node used to start the scan.

fixes #1041
