### PR TITLE
Disable dot-imports in revive linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,6 +36,10 @@ linters-settings:
       - standard
       - default
       - prefix(github.com/securego)
+  revive:
+    rules:
+      - name: dot-imports
+        disabled: true
 
 run:
   timeout: 5m


### PR DESCRIPTION
Signed-off-by: Cosmin Cojocar <gcojocar@adobe.com>
