### PR TITLE
Added ppc64le support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
         uses: docker/build-push-action@v5
         id: relimage
         with:
-          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le
           tags: ${{steps.meta.outputs.tags}}
           labels: ${{steps.meta.outputs.labels}}
           push: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,6 +19,7 @@ builds:
       - amd64
       - arm64
       - s390x
+      - ppc64le
     ldflags: -X main.Version={{.Version}} -X main.GitTag={{.Tag}} -X main.BuildDate={{.Date}}
     env:
       - CGO_ENABLED=0


### PR DESCRIPTION
Hello Team,

I've updated the specified files to enable the release of ppc64le binaries and docker image for gosec.
- Updated **.github/workflows/release.yml** & **.goreleaser.yml** to support Linux on IBM Power ( ppc64le )

Signed-off-by: Pooja Shah [Pooja.Shah4@ibm.com](mailto:Pooja.Shah4@ibm.com)