### PR TITLE
Update README with upload-sarif v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ jobs:
           # we let the report trigger content trigger a failure using the GitHub Security features.
           args: '-no-fail -fmt sarif -out results.sarif ./...'
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v2
         with:
           # Path to SARIF file relative to the root of the repository
           sarif_file: results.sarif


### PR DESCRIPTION
GitHub action upload-sarif v1 is deprecated and action fails if used. Updated README with v2 so workflow can be copy and use without modiciations

Fixes #1077