### PR TITLE
fix(hardcoded): remove duplicated `Stripe API Key`

### DIFF
--- a/rules/hardcoded_credentials.go
+++ b/rules/hardcoded_credentials.go
@@ -154,10 +154,6 @@ var secretsPatterns = [...]secretPattern{
 		regexp: regexp.MustCompile(`sk_live_[0-9a-zA-Z]{24}`),
 	},
 	{
-		name:   "Stripe API Key",
-		regexp: regexp.MustCompile(`sk_live_[0-9a-zA-Z]{24}`),
-	},
-	{
 		name:   "Stripe Restricted API Key",
 		regexp: regexp.MustCompile(`rk_live_[0-9a-zA-Z]{24}`),
 	},


### PR DESCRIPTION
While looking for the regex associated with harcoded credentials, I noticed that the `Stripe API Key` one seemed to be duplicated. This Pull request aims to remove the duplicate.