### PR TITLE
Ignore 'implicit memory aliasing' rule for Go 1.22+

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ directory you can supply `./...` as the input argument.
 - G503: Import blocklist: crypto/rc4
 - G504: Import blocklist: net/http/cgi
 - G505: Import blocklist: crypto/sha1
-- G601: Implicit memory aliasing of items from a range statement
+- G601: Implicit memory aliasing of items from a range statement (only for Go 1.21 or lower)
 - G602: Slice access out of bounds
 
 ### Retired rules

--- a/rules/implicit_aliasing.go
+++ b/rules/implicit_aliasing.go
@@ -47,6 +47,12 @@ func doGetIdentExpr(expr ast.Expr, hasSelector bool) (*ast.Ident, bool) {
 }
 
 func (r *implicitAliasing) Match(n ast.Node, c *gosec.Context) (*issue.Issue, error) {
+	// This rule does not apply for Go 1.22, see https://tip.golang.org/doc/go1.22#language.
+	major, minor, _ := gosec.GoVersion()
+	if major >= 1 && minor >= 22 {
+		return nil, nil
+	}
+
 	switch node := n.(type) {
 	case *ast.RangeStmt:
 		// When presented with a range statement, get the underlying Object bound to


### PR DESCRIPTION
After the recent changes in language in Go 1.22 we no longer need to check for "implicit memory aliasing" rule. Doing:
```
for _, item := range items {
	cpItem = &item
	break
}
```
is now valid because `item` is a new variable in memory for every iteration (and not as it was before the same variable in memory what caused all the problems).

Closes: https://github.com/securego/gosec/issues/1090