### PR TITLE
Add support for math/rand/v2 added in Go 1.22

### DIFF
--- a/import_tracker.go
+++ b/import_tracker.go
@@ -19,9 +19,7 @@ import (
 	"strings"
 )
 
-var (
-	versioningPackagePattern = regexp.MustCompile(`v[0-9]+$`)
-)
+var versioningPackagePattern = regexp.MustCompile(`v[0-9]+$`)
 
 // ImportTracker is used to normalize the packages that have been imported
 // by a source file. It is able to differentiate between plain imports, aliased

--- a/import_tracker.go
+++ b/import_tracker.go
@@ -15,7 +15,12 @@ package gosec
 import (
 	"go/ast"
 	"go/types"
+	"regexp"
 	"strings"
+)
+
+var (
+	versioningPackagePattern = regexp.MustCompile(`v[0-9]+$`)
 )
 
 // ImportTracker is used to normalize the packages that have been imported
@@ -65,6 +70,11 @@ func importName(importPath string) string {
 	name := importPath
 	if len(parts) > 0 {
 		name = parts[len(parts)-1]
+	}
+	// If the last segment of the path is version information, consider the second to last segment as the package name.
+	// (e.g., `math/rand/v2` would be `rand`)
+	if len(parts) > 1 && versioningPackagePattern.MatchString(name) {
+		name = parts[len(parts)-2]
 	}
 	return name
 }

--- a/testutils/g404_samples.go
+++ b/testutils/g404_samples.go
@@ -27,6 +27,16 @@ func main() {
 	{[]string{`
 package main
 
+import "math/rand/v2"
+
+func main() {
+	bad := rand.Int()
+	println(bad)
+}
+`}, 1, gosec.NewConfig()},
+	{[]string{`
+package main
+
 import (
 	"crypto/rand"
 	mrand "math/rand"
@@ -36,6 +46,21 @@ func main() {
 	good, _ := rand.Read(nil)
 	println(good)
 	bad := mrand.Int31()
+	println(bad)
+}
+`}, 1, gosec.NewConfig()},
+	{[]string{`
+package main
+
+import (
+	"crypto/rand"
+	mrand "math/rand/v2"
+)
+
+func main() {
+	good, _ := rand.Read(nil)
+	println(good)
+	bad := mrand.Int32()
 	println(bad)
 }
 `}, 1, gosec.NewConfig()},
@@ -56,11 +81,36 @@ func main() {
 package main
 
 import (
+	"math/rand/v2"
+)
+
+func main() {
+	gen := rand.New(rand.NewPCG(1, 2))
+	bad := gen.Int()
+	println(bad)
+}
+`}, 1, gosec.NewConfig()},
+	{[]string{`
+package main
+
+import (
 	"math/rand"
 )
 
 func main() {
 	bad := rand.Intn(10)
+	println(bad)
+}
+`}, 1, gosec.NewConfig()},
+	{[]string{`
+package main
+
+import (
+	"math/rand/v2"
+)
+
+func main() {
+	bad := rand.IntN(10)
 	println(bad)
 }
 `}, 1, gosec.NewConfig()},
@@ -84,6 +134,22 @@ func main() {
 package main
 
 import (
+	"crypto/rand"
+	"math/big"
+	rnd "math/rand/v2"
+)
+
+func main() {
+	good, _ := rand.Int(rand.Reader, big.NewInt(int64(2)))
+	println(good)
+	bad := rnd.IntN(2)
+	println(bad)
+}
+`}, 1, gosec.NewConfig()},
+	{[]string{`
+package main
+
+import (
 	crand "crypto/rand"
 	"math/big"
 	"math/rand"
@@ -97,6 +163,25 @@ func main() {
 	_ = rand.Intn(2) // bad
 	_ = rand2.Intn(2)  // bad
 	_ = rand3.Intn(2)  // bad
+}
+`}, 3, gosec.NewConfig()},
+	{[]string{`
+package main
+
+import (
+	crand "crypto/rand"
+	"math/big"
+	"math/rand/v2"
+	rand2 "math/rand/v2"
+	rand3 "math/rand/v2"
+)
+
+func main() {
+	_, _ = crand.Int(crand.Reader, big.NewInt(int64(2))) // good
+
+	_ = rand.IntN(2) // bad
+	_ = rand2.IntN(2)  // bad
+	_ = rand3.IntN(2)  // bad
 }
 `}, 3, gosec.NewConfig()},
 }


### PR DESCRIPTION
### Summary

Fix for issue #1109

### Changes

- Add support for math/rand/v2 to the existing rule (G404).
- Modified the function used to extract import names to handle paths with version information.
