### PR TITLE
Use standard function to check if a file is generated

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -55,8 +55,6 @@ const externalSuppressionJustification = "Globally suppressed."
 
 const aliasOfAllRules = "*"
 
-var generatedCodePattern = regexp.MustCompile(`^// Code generated .* DO NOT EDIT\.$`)
-
 type ignore struct {
 	start        int
 	end          int

--- a/analyzer.go
+++ b/analyzer.go
@@ -31,11 +31,12 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/securego/gosec/v2/analyzers"
-	"github.com/securego/gosec/v2/issue"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/buildssa"
 	"golang.org/x/tools/go/packages"
+
+	"github.com/securego/gosec/v2/analyzers"
+	"github.com/securego/gosec/v2/issue"
 )
 
 // LoadMode controls the amount of details to return when loading the packages

--- a/analyzer.go
+++ b/analyzer.go
@@ -376,7 +376,7 @@ func (gosec *Analyzer) CheckRules(pkg *packages.Package) {
 		if filepath.Ext(checkedFile) != ".go" {
 			continue
 		}
-		if gosec.excludeGenerated && isGeneratedFile(file) {
+		if gosec.excludeGenerated && ast.IsGenerated(file) {
 			gosec.logger.Println("Ignoring generated file:", checkedFile)
 			continue
 		}
@@ -459,7 +459,7 @@ func (gosec *Analyzer) CheckAnalyzers(pkg *packages.Package) {
 func (gosec *Analyzer) generatedFiles(pkg *packages.Package) map[string]bool {
 	generatedFiles := map[string]bool{}
 	for _, file := range pkg.Syntax {
-		if isGeneratedFile(file) {
+		if ast.IsGenerated(file) {
 			fp := pkg.Fset.File(file.Pos())
 			if fp == nil {
 				// skip files which cannot be located
@@ -498,17 +498,6 @@ func (gosec *Analyzer) buildSSA(pkg *packages.Package) (interface{}, error) {
 	}
 
 	return ssaPass.Analyzer.Run(ssaPass)
-}
-
-func isGeneratedFile(file *ast.File) bool {
-	for _, comment := range file.Comments {
-		for _, row := range comment.List {
-			if generatedCodePattern.MatchString(row.Text) {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 // ParseErrors parses the errors from given package

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -498,8 +498,8 @@ var _ = Describe("Analyzer", func() {
 			pkg := testutils.NewTestPackage()
 			defer pkg.Close()
 			pkg.AddFile("foo.go", `
-				package foo
 				// Code generated some-generator DO NOT EDIT.
+				package foo
 				func test() error {
 				  return nil
 				}
@@ -541,8 +541,8 @@ var _ = Describe("Analyzer", func() {
 			pkg := testutils.NewTestPackage()
 			defer pkg.Close()
 			pkg.AddFile("foo.go", `
-				package main
 				// Code generated some-generator DO NOT EDIT.
+				package main
         import (
           "fmt"
         )


### PR DESCRIPTION
As of Go1.21, we can utilize standard package function [`ast.IsGenerated`](https://pkg.go.dev/go/ast#IsGenerated) to check if a file is generated or not. This PR replace `isGeneratedFile` with that new standard function.

Second commit updates test source. 
Standard `ast.IsGenerated` returns `false` for original test sources, because it does not comply with
https://pkg.go.dev/cmd/go#hdr-Generate_Go_files_by_processing_source

> This line must appear before the first non-comment, non-blank text in the file.

Original test source does not satisfy this condition, so original `isGeneratedFile` function returns `true` when it should return `false`.


I would assume we should update the test cases, but this change can be breaking for some users. I wonder if we should do that.
