### PR TITLE
Add an environment variable which disables the parsing of Go version from the module file present in the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,12 @@ You can also configure the hard-coded credentials rule `G101` with additional pa
 }
 ```
 
+#### Go version
+
+Some rules require a specific Go version which is retrieved from the Go module file present in the project. If this version cannot be found, it will fallback to Go runtime version.
+
+The Go module version is parsed using the `go list` command which in some cases might lead to performance degradation. In this situation, the go module version can be easily disabled by setting the environment variable `GOSECNOMODVERSION=on`.
+
 ### Dependencies
 
 gosec will fetch automatically the dependencies of the code which is being analyzed when go module is turned on (e.g.`GO111MODULE=on`). If this is not the case,

--- a/helpers.go
+++ b/helpers.go
@@ -32,6 +32,9 @@ import (
 	"strings"
 )
 
+// noGoModVersion disables the parsing of  go version from go module file present in the project
+const noGoModVersion = "GOSECNOMODVERSION"
+
 // MatchCallByPackage ensures that the specified package is imported,
 // adjusts the name for any aliases and ignores cases that are
 // initialization only imports.
@@ -498,12 +501,13 @@ func RootPath(root string) (string, error) {
 
 // GoVersion returns parsed version of Go mod version and fallback to runtime version if not found.
 func GoVersion() (int, int, int) {
-	goVersion, err := goModVersion()
-	if err != nil {
-		return parseGoVersion(strings.TrimPrefix(runtime.Version(), "go"))
+	_, ok := os.LookupEnv(noGoModVersion)
+	if ok {
+		if goModVersion, err := goModVersion(); err == nil {
+			return parseGoVersion(goModVersion)
+		}
 	}
-
-	return parseGoVersion(goVersion)
+	return parseGoVersion(strings.TrimPrefix(runtime.Version(), "go"))
 }
 
 type goListOutput struct {


### PR DESCRIPTION
fixes #1143 