### PR TITLE
Add more types to templates rule

### DIFF
--- a/rules/templates.go
+++ b/rules/templates.go
@@ -45,9 +45,12 @@ func (t *templateCheck) Match(n ast.Node, c *gosec.Context) (*issue.Issue, error
 // find use of templates where HTML/JS escaping is not being used
 func NewTemplateCheck(id string, _ gosec.Config) (gosec.Rule, []ast.Node) {
 	calls := gosec.NewCallList()
+	calls.Add("html/template", "CSS")
 	calls.Add("html/template", "HTML")
 	calls.Add("html/template", "HTMLAttr")
 	calls.Add("html/template", "JS")
+	calls.Add("html/template", "JSStr")
+	calls.Add("html/template", "Srcset")
 	calls.Add("html/template", "URL")
 	return &templateCheck{
 		calls: calls,


### PR DESCRIPTION
Add additional types such as CSS, JSStr and Srcset to the template rule. These types are marked as a security risk in the godoc https://pkg.go.dev/html/template.

fixes #496 