### PR TITLE
Fix nosec directive when applied to a block

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -122,7 +122,7 @@ func (i ignores) get(file string, line string) map[string][]issue.SuppressionInf
 	start, end := i.parseLine(line)
 	if is, ok := i[file]; ok {
 		for _, i := range is {
-			if start <= i.start && end >= i.end {
+			if i.start <= start && i.end >= end || start <= i.start && end >= i.end {
 				return i.suppressions
 			}
 		}

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -220,6 +220,52 @@ var _ = Describe("Analyzer", func() {
 			Expect(nosecIssues).Should(BeEmpty())
 		})
 
+		It("should not report errors when a nosec  block and line comment are present", func() {
+			sample := testutils.SampleCodeG101[23]
+			source := sample.Code[0]
+			analyzer.LoadRules(rules.Generate(false, rules.NewRuleFilter(false, "G101")).RulesInfo())
+
+			nosecPackage := testutils.NewTestPackage()
+			defer nosecPackage.Close()
+			nosecPackage.AddFile("g101.go", source)
+			err := nosecPackage.Build()
+			Expect(err).ShouldNot(HaveOccurred())
+			err = analyzer.Process(buildTags, nosecPackage.Path)
+			Expect(err).ShouldNot(HaveOccurred())
+			nosecIssues, _, _ := analyzer.Report()
+			Expect(nosecIssues).Should(BeEmpty())
+		})
+		It("should not report errors when only a nosec  block is present", func() {
+			sample := testutils.SampleCodeG101[24]
+			source := sample.Code[0]
+			analyzer.LoadRules(rules.Generate(false, rules.NewRuleFilter(false, "G101")).RulesInfo())
+
+			nosecPackage := testutils.NewTestPackage()
+			defer nosecPackage.Close()
+			nosecPackage.AddFile("g101.go", source)
+			err := nosecPackage.Build()
+			Expect(err).ShouldNot(HaveOccurred())
+			err = analyzer.Process(buildTags, nosecPackage.Path)
+			Expect(err).ShouldNot(HaveOccurred())
+			nosecIssues, _, _ := analyzer.Report()
+			Expect(nosecIssues).Should(BeEmpty())
+		})
+		It("should not report errors when a single line nosec  is present on a multi-line issue", func() {
+			sample := testutils.SampleCodeG112[3]
+			source := sample.Code[0]
+			analyzer.LoadRules(rules.Generate(false, rules.NewRuleFilter(false, "G112")).RulesInfo())
+
+			nosecPackage := testutils.NewTestPackage()
+			defer nosecPackage.Close()
+			nosecPackage.AddFile("g112.go", source)
+			err := nosecPackage.Build()
+			Expect(err).ShouldNot(HaveOccurred())
+			err = analyzer.Process(buildTags, nosecPackage.Path)
+			Expect(err).ShouldNot(HaveOccurred())
+			nosecIssues, _, _ := analyzer.Report()
+			Expect(nosecIssues).Should(BeEmpty())
+		})
+
 		It("should report errors when an exclude comment is present for a different rule", func() {
 			sample := testutils.SampleCodeG401[0]
 			source := sample.Code[0]

--- a/testutils/g101_samples.go
+++ b/testutils/g101_samples.go
@@ -278,6 +278,50 @@ func main() {
 	fmt.Println(bearer)
 }
 `}, 1, gosec.NewConfig()},
+		{[]string{`
+package main
+
+import "fmt"
+
+// #nosec G101
+const (
+	ConfigLearnerTokenAuth string = "learner_auth_token_config" // #nosec G101
+)
+
+func main() {
+	fmt.Printf("%s\n", ConfigLearnerTokenAuth)
+}
+
+`}, 0, gosec.NewConfig()},
+		{[]string{`
+package main
+
+import "fmt"
+
+// #nosec G101
+const (
+	ConfigLearnerTokenAuth string = "learner_auth_token_config"
+)
+
+func main() {
+	fmt.Printf("%s\n", ConfigLearnerTokenAuth)
+}
+	
+`}, 0, gosec.NewConfig()},
+		{[]string{`
+package main
+
+import "fmt"
+
+const (
+	ConfigLearnerTokenAuth string = "learner_auth_token_config" // #nosec G101
+)
+
+func main() {
+	fmt.Printf("%s\n", ConfigLearnerTokenAuth)
+}
+	
+`}, 0, gosec.NewConfig()},
 	}
 
 	// SampleCodeG101Values code snippets for hardcoded credentials


### PR DESCRIPTION
Handle properly nosec directive when applied to a block or as a single line on a multi-line issue.

fixes #1105