### PR TITLE
Fix multifile analyzer ignores

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -390,7 +390,6 @@ func (gosec *Analyzer) CheckRules(pkg *packages.Package) {
 		gosec.context.PkgFiles = pkg.Syntax
 		gosec.context.Imports = NewImportTracker()
 		gosec.context.PassedValues = make(map[string]interface{})
-		gosec.context.Ignores = newIgnores()
 		gosec.updateIgnores()
 		ast.Walk(gosec, file)
 		gosec.stats.NumFiles++

--- a/testutils/g115_samples.go
+++ b/testutils/g115_samples.go
@@ -115,4 +115,43 @@ func main() {
     fmt.Println(b)
 }
 	`}, 1, gosec.NewConfig()},
+	{[]string{
+		`
+package main
+
+import (
+	"fmt"
+	"math"
+)
+
+func main() {
+	var a uint = math.MaxUint
+	// #nosec G115
+	b := int64(a)
+	fmt.Println(b)
+}
+		`,
+	}, 0, gosec.NewConfig()},
+	{[]string{
+		`
+package main
+
+import (
+	"fmt"
+	"math"
+)
+
+func main() {
+    var a uint = math.MaxUint
+	// #nosec G115
+    b := int64(a)
+    fmt.Println(b)
+}
+	`, `
+package main
+
+func ExampleFunction() {
+}
+`,
+	}, 0, gosec.NewConfig()},
 }


### PR DESCRIPTION
On `master`, `#nosec G115` will not work if your package has multiple files. This appears to be because the ignores populated in `CheckRules` are cleared after every file. These ignores are needed in the `CheckAnalyzers` call that happen after `CheckRules`.

Fix this by not clearing the ignores every loop. All tests cases appear to still pass:

```
ginkgo run
<snip>
Ran 144 of 144 Specs in 6.095 seconds
SUCCESS! -- 144 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
```