### PR TITLE
Resolve underlying type to detect overflows in type aliases

### DIFF
--- a/analyzers/conversion_overflow.go
+++ b/analyzers/conversion_overflow.go
@@ -47,8 +47,8 @@ func runConversionOverflow(pass *analysis.Pass) (interface{}, error) {
 			for _, instr := range block.Instrs {
 				switch instr := instr.(type) {
 				case *ssa.Convert:
-					src := instr.X.Type().String()
-					dst := instr.Type().String()
+					src := instr.X.Type().Underlying().String()
+					dst := instr.Type().Underlying().String()
 					if isIntOverflow(src, dst) {
 						issue := newIssue(pass.Analyzer.Name,
 							fmt.Sprintf("integer overflow conversion %s -> %s", src, dst),

--- a/testutils/g115_samples.go
+++ b/testutils/g115_samples.go
@@ -154,4 +154,40 @@ func ExampleFunction() {
 }
 `,
 	}, 0, gosec.NewConfig()},
+	{[]string{
+		`
+package main
+
+import (
+	"fmt"
+	"math"
+)
+
+type Uint uint
+
+func main() {
+    var a uint8 = math.MaxUint8
+    b := Uint(a)
+    fmt.Println(b)
+}
+	`,
+	}, 0, gosec.NewConfig()},
+	{[]string{
+		`
+package main
+
+import (
+	"fmt"
+	"math"
+)
+
+type CustomType int
+
+func main() {
+    var a uint = math.MaxUint
+    b := CustomType(a)
+    fmt.Println(b)
+}
+	`,
+	}, 1, gosec.NewConfig()},
 }


### PR DESCRIPTION
Calling `Underlying()` will get the underlying type [if there is one](https://github.com/golang/go/blob/959b3fd4265d7e4efb18af454cd18799ed70b8fe/src/go/types/alias.go#L50).

This allows correctly testing for overflows with type aliases.