### PR TITLE
Allow excluding analyzers globally

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -182,7 +182,7 @@ type Analyzer struct {
 	showIgnored       bool
 	trackSuppressions bool
 	concurrency       int
-	analyzerList      []*analysis.Analyzer
+	analyzerSet       *analyzers.AnalyzerSet
 	mu                sync.Mutex
 }
 
@@ -213,7 +213,7 @@ func NewAnalyzer(conf Config, tests bool, excludeGenerated bool, trackSuppressio
 		concurrency:       concurrency,
 		excludeGenerated:  excludeGenerated,
 		trackSuppressions: trackSuppressions,
-		analyzerList:      analyzers.BuildDefaultAnalyzers(),
+		analyzerSet:       analyzers.NewAnalyzerSet(),
 	}
 }
 
@@ -233,6 +233,15 @@ func (gosec *Analyzer) LoadRules(ruleDefinitions map[string]RuleBuilder, ruleSup
 	for id, def := range ruleDefinitions {
 		r, nodes := def(id, gosec.config)
 		gosec.ruleset.Register(r, ruleSuppressed[id], nodes...)
+	}
+}
+
+// LoadAnalyzers instantiates all the analyzers to be used when analyzing source
+// packages
+func (gosec *Analyzer) LoadAnalyzers(analyzerDefinitions map[string]analyzers.AnalyzerDefinition, analyzerSuppressed map[string]bool) {
+	for id, def := range analyzerDefinitions {
+		r := def.Create(def.ID, def.Description)
+		gosec.analyzerSet.Register(r, analyzerSuppressed[id])
 	}
 }
 
@@ -415,7 +424,7 @@ func (gosec *Analyzer) CheckAnalyzers(pkg *packages.Package) {
 
 	generatedFiles := gosec.generatedFiles(pkg)
 
-	for _, analyzer := range gosec.analyzerList {
+	for _, analyzer := range gosec.analyzerSet.Analyzers {
 		pass := &analysis.Pass{
 			Analyzer:          analyzer,
 			Fset:              pkg.Fset,
@@ -666,7 +675,7 @@ func (gosec *Analyzer) getSuppressionsAtLineInFile(file string, line string, id 
 	suppressions := append(generalSuppressions, ruleSuppressions...)
 
 	// Track external suppressions of this rule.
-	if gosec.ruleset.IsRuleSuppressed(id) {
+	if gosec.ruleset.IsRuleSuppressed(id) || gosec.analyzerSet.IsSuppressed(id) {
 		ignored = true
 		suppressions = append(suppressions, issue.SuppressionInfo{
 			Kind:          "external",
@@ -705,4 +714,5 @@ func (gosec *Analyzer) Reset() {
 	gosec.issues = make([]*issue.Issue, 0, 16)
 	gosec.stats = &Metrics{}
 	gosec.ruleset = NewRuleSet()
+	gosec.analyzerSet = analyzers.NewAnalyzerSet()
 }

--- a/analyzers/analyzers_set.go
+++ b/analyzers/analyzers_set.go
@@ -1,0 +1,38 @@
+// (c) Copyright gosec's authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analyzers
+
+import "golang.org/x/tools/go/analysis"
+
+type AnalyzerSet struct {
+	Analyzers             []*analysis.Analyzer
+	AnalyzerSuppressedMap map[string]bool
+}
+
+// NewAnalyzerSet constructs a new AnalyzerSet
+func NewAnalyzerSet() *AnalyzerSet {
+	return &AnalyzerSet{nil, make(map[string]bool)}
+}
+
+// Register adds a trigger for the supplied analyzer
+func (a *AnalyzerSet) Register(analyzer *analysis.Analyzer, isSuppressed bool) {
+	a.Analyzers = append(a.Analyzers, analyzer)
+	a.AnalyzerSuppressedMap[analyzer.Name] = isSuppressed
+}
+
+// IsSuppressed will return whether the Analyzer is suppressed.
+func (a *AnalyzerSet) IsSuppressed(ruleID string) bool {
+	return a.AnalyzerSuppressedMap[ruleID]
+}

--- a/analyzers/analyzers_test.go
+++ b/analyzers/analyzers_test.go
@@ -1,0 +1,62 @@
+package analyzers_test
+
+import (
+	"fmt"
+	"log"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/securego/gosec/v2"
+	"github.com/securego/gosec/v2/analyzers"
+	"github.com/securego/gosec/v2/testutils"
+)
+
+var _ = Describe("gosec analyzers", func() {
+	var (
+		logger    *log.Logger
+		config    gosec.Config
+		analyzer  *gosec.Analyzer
+		runner    func(string, []testutils.CodeSample)
+		buildTags []string
+		tests     bool
+	)
+
+	BeforeEach(func() {
+		logger, _ = testutils.NewLogger()
+		config = gosec.NewConfig()
+		analyzer = gosec.NewAnalyzer(config, tests, false, false, 1, logger)
+		runner = func(analyzerId string, samples []testutils.CodeSample) {
+			for n, sample := range samples {
+				analyzer.Reset()
+				analyzer.SetConfig(sample.Config)
+				analyzer.LoadAnalyzers(analyzers.Generate(false, analyzers.NewAnalyzerFilter(false, analyzerId)).AnalyzersInfo())
+				pkg := testutils.NewTestPackage()
+				defer pkg.Close()
+				for i, code := range sample.Code {
+					pkg.AddFile(fmt.Sprintf("sample_%d_%d.go", n, i), code)
+				}
+				err := pkg.Build()
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(pkg.PrintErrors()).Should(BeZero())
+				err = analyzer.Process(buildTags, pkg.Path)
+				Expect(err).ShouldNot(HaveOccurred())
+				issues, _, _ := analyzer.Report()
+				if len(issues) != sample.Errors {
+					fmt.Println(sample.Code)
+				}
+				Expect(issues).Should(HaveLen(sample.Errors))
+			}
+		}
+	})
+
+	Context("report correct errors for all samples", func() {
+		It("should detect integer conversion overflow", func() {
+			runner("G115", testutils.SampleCodeG115)
+		})
+
+		It("should detect out of bounds slice access", func() {
+			runner("G602", testutils.SampleCodeG602)
+		})
+	})
+})

--- a/analyzers/analyzerslist.go
+++ b/analyzers/analyzerslist.go
@@ -1,0 +1,94 @@
+// (c) Copyright gosec's authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analyzers
+
+import (
+	"golang.org/x/tools/go/analysis"
+)
+
+// AnalyzerDefinition contains the description of an analyzer and a mechanism to
+// create it.
+type AnalyzerDefinition struct {
+	ID          string
+	Description string
+	Create      AnalyzerBuilder
+}
+
+// AnalyzerBuilder is used to register an analyzer definition with the analyzer
+type AnalyzerBuilder func(id string, description string) *analysis.Analyzer
+
+// AnalyzerList contains a mapping of analyzer ID's to analyzer definitions and a mapping
+// of analyzer ID's to whether analyzers are suppressed.
+type AnalyzerList struct {
+	Analyzers          map[string]AnalyzerDefinition
+	AnalyzerSuppressed map[string]bool
+}
+
+// AnalyzersInfo returns all the create methods and the analyzer suppressed map for a
+// given list
+func (al *AnalyzerList) AnalyzersInfo() (map[string]AnalyzerDefinition, map[string]bool) {
+	builders := make(map[string]AnalyzerDefinition)
+	for _, def := range al.Analyzers {
+		builders[def.ID] = def
+	}
+	return builders, al.AnalyzerSuppressed
+}
+
+// AnalyzerFilter can be used to include or exclude an analyzer depending on the return
+// value of the function
+type AnalyzerFilter func(string) bool
+
+// NewAnalyzerFilter is a closure that will include/exclude the analyzer ID's based on
+// the supplied boolean value.
+func NewAnalyzerFilter(action bool, analyzerIDs ...string) AnalyzerFilter {
+	analyzerlist := make(map[string]bool)
+	for _, analyzer := range analyzerIDs {
+		analyzerlist[analyzer] = true
+	}
+	return func(analyzer string) bool {
+		if _, found := analyzerlist[analyzer]; found {
+			return action
+		}
+		return !action
+	}
+}
+
+var defaultAnalyzers = []AnalyzerDefinition{
+	{"G115", "Type conversion which leads to integer overflow", newConversionOverflowAnalyzer},
+	{"G602", "Possible slice bounds out of range", newSliceBoundsAnalyzer},
+}
+
+// Generate the list of analyzers to use
+func Generate(trackSuppressions bool, filters ...AnalyzerFilter) *AnalyzerList {
+	analyzerMap := make(map[string]AnalyzerDefinition)
+	analyzerSuppressedMap := make(map[string]bool)
+
+	for _, analyzer := range defaultAnalyzers {
+		analyzerSuppressedMap[analyzer.ID] = false
+		addToAnalyzerList := true
+		for _, filter := range filters {
+			if filter(analyzer.ID) {
+				analyzerSuppressedMap[analyzer.ID] = true
+				if !trackSuppressions {
+					addToAnalyzerList = false
+				}
+			}
+		}
+		if addToAnalyzerList {
+			analyzerMap[analyzer.ID] = analyzer
+		}
+	}
+	return &AnalyzerList{Analyzers: analyzerMap, AnalyzerSuppressed: analyzerSuppressedMap}
+}

--- a/analyzers/anaylzers_suite_test.go
+++ b/analyzers/anaylzers_suite_test.go
@@ -1,0 +1,13 @@
+package analyzers_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestAnalyzers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Analyzers Suite")
+}

--- a/analyzers/util.go
+++ b/analyzers/util.go
@@ -35,14 +35,6 @@ type SSAAnalyzerResult struct {
 	SSA    *buildssa.SSA
 }
 
-// BuildDefaultAnalyzers returns the default list of analyzers
-func BuildDefaultAnalyzers() []*analysis.Analyzer {
-	return []*analysis.Analyzer{
-		newConversionOverflowAnalyzer("G115", "Type conversion which leads to integer overflow"),
-		newSliceBoundsAnalyzer("G602", "Possible slice bounds out of range"),
-	}
-}
-
 // getSSAResult retrieves the SSA result from analysis pass
 func getSSAResult(pass *analysis.Pass) (*SSAAnalyzerResult, error) {
 	result, ok := pass.ResultOf[buildssa.Analyzer]

--- a/rules/rules_test.go
+++ b/rules/rules_test.go
@@ -111,10 +111,6 @@ var _ = Describe("gosec rules", func() {
 			runner("G114", testutils.SampleCodeG114)
 		})
 
-		It("should detect integer conversion overflow", func() {
-			runner("G115", testutils.SampleCodeG115)
-		})
-
 		It("should detect sql injection via format strings", func() {
 			runner("G201", testutils.SampleCodeG201)
 		})
@@ -224,10 +220,6 @@ var _ = Describe("gosec rules", func() {
 			if major <= 1 && minor < 22 {
 				runner("G601", testutils.SampleCodeG601)
 			}
-		})
-
-		It("should detect out of bounds slice access", func() {
-			runner("G602", testutils.SampleCodeG602)
 		})
 	})
 })

--- a/testutils/g103_samples.go
+++ b/testutils/g103_samples.go
@@ -27,7 +27,7 @@ func main() {
 	intPtr = (*int)(unsafe.Pointer(addressHolder))
 	fmt.Printf("\nintPtr=%p, *intPtr=%d.\n\n", intPtr, *intPtr)
 }
-`}, 3, gosec.NewConfig()},
+`}, 2, gosec.NewConfig()},
 	{[]string{`
 package main
 

--- a/testutils/g109_samples.go
+++ b/testutils/g109_samples.go
@@ -20,7 +20,7 @@ func main() {
 	value := int32(bigValue)
 	fmt.Println(value)
 }
-`}, 2, gosec.NewConfig()},
+`}, 1, gosec.NewConfig()},
 	{[]string{`
 package main
 
@@ -38,7 +38,7 @@ func main() {
 		fmt.Println(bigValue)
 	}
 }
-`}, 2, gosec.NewConfig()},
+`}, 1, gosec.NewConfig()},
 	{[]string{`
 package main
 


### PR DESCRIPTION
* This change does not exclude analyzers for inline comment
* Changed the expected issues count for G103, G109. Previously G115 has been included in those issues count.
* Show analyzers IDs(G115, G602) in gosec usage help
* See #1175

fixes #1175