### PR TITLE
Fix conversion overflow false positive when using ParseUint

### DIFF
--- a/analyzers/conversion_overflow.go
+++ b/analyzers/conversion_overflow.go
@@ -134,9 +134,10 @@ func isStringToIntConversion(instr *ssa.Convert, dstType string) bool {
 	for {
 		switch v := original.(type) {
 		case *ssa.Call:
-			if v.Call.StaticCallee() != nil && v.Call.StaticCallee().Name() == "ParseInt" {
+			if v.Call.StaticCallee() != nil && (v.Call.StaticCallee().Name() == "ParseInt" || v.Call.StaticCallee().Name() == "ParseUint") {
 				if len(v.Call.Args) == 3 {
 					if bitSize, ok := v.Call.Args[2].(*ssa.Const); ok {
+						signed := v.Call.StaticCallee().Name() == "ParseInt"
 						bitSizeValue, err := strconv.Atoi(bitSize.Value.String())
 						if err != nil {
 							return false
@@ -145,7 +146,7 @@ func isStringToIntConversion(instr *ssa.Convert, dstType string) bool {
 						if err != nil {
 							return false
 						}
-						isSafe := bitSizeValue <= dstInt.size
+						isSafe := bitSizeValue <= dstInt.size && signed == dstInt.signed
 						return isSafe
 					}
 				}

--- a/testutils/g115_samples.go
+++ b/testutils/g115_samples.go
@@ -356,4 +356,38 @@ func main() {
 }
 	`,
 	}, 0, gosec.NewConfig()},
+	{[]string{
+		`
+package main
+
+import (
+        "fmt"
+        "strconv"
+)
+
+func main() {
+        var a string = "13"
+        b, _ := strconv.ParseUint(a, 10, 8)
+        c := uint8(b)
+        fmt.Printf("%d\n", c)
+}
+	`,
+	}, 0, gosec.NewConfig()},
+	{[]string{
+		`
+package main
+
+import (
+        "fmt"
+        "strconv"
+)
+
+func main() {
+        var a string = "13"
+        b, _ := strconv.ParseInt(a, 10, 8)
+        c := uint8(b)
+        fmt.Printf("%d\n", c)
+}
+	`,
+	}, 1, gosec.NewConfig()},
 }


### PR DESCRIPTION
Extends the check for ParseInt (with proper bit size) to ParseUint.

Two tests were added.

1. To check that ParseUint does not cause a false positive
2. To check that ParseInt causes a true positive when casting to unsigned