### PR TITLE
Fix conversion overflow false positive when value is explicitly checked

### DIFF
--- a/analyzers/conversion_overflow.go
+++ b/analyzers/conversion_overflow.go
@@ -115,13 +115,14 @@ func isConstantInRange(constVal *ssa.Const, dstType string) bool {
 }
 
 func hasExplicitRangeCheck(instr *ssa.Convert) bool {
-	block := instr.Block()
-	for _, i := range block.Instrs {
-		if binOp, ok := i.(*ssa.BinOp); ok {
-			// Check if either operand of the BinOp is the result of the Convert instruction
-			if (binOp.X == instr || binOp.Y == instr) &&
-				(binOp.Op == token.LSS || binOp.Op == token.LEQ || binOp.Op == token.GTR || binOp.Op == token.GEQ) {
-				return true
+	for _, block := range instr.Block().Parent().Blocks {
+		for _, i := range block.Instrs {
+			if binOp, ok := i.(*ssa.BinOp); ok {
+				// Check if either operand of the BinOp is the result of the Convert instruction
+				if (binOp.X == instr.X || binOp.Y == instr.X) &&
+					(binOp.Op == token.LSS || binOp.Op == token.LEQ || binOp.Op == token.GTR || binOp.Op == token.GEQ) {
+					return true
+				}
 			}
 		}
 	}

--- a/testutils/g115_samples.go
+++ b/testutils/g115_samples.go
@@ -311,14 +311,14 @@ import (
 
 func main() {
         a := rand.Int63()
-        if a < math.MinInt64 || a > math.MaxInt32 {
+        if a < math.MinInt32 || a > math.MaxInt32 {
             panic("out of range")
         }
         b := int32(a)
         fmt.Printf("%d\n", b)
 }
 	`,
-	}, 1, gosec.NewConfig()},
+	}, 0, gosec.NewConfig()},
 	{[]string{
 		`
 package main


### PR DESCRIPTION
Fixes #1187

TO DO:

- [ ] Iterate blocks backwards to exclude checks performed after the conversion?
- [ ] Validate comparisons ensure proper bounds?
- [ ] Allow for equality comparisons?