### PR TITLE
Improvement the int conversion overflow logic to handle bound checks

### DIFF
--- a/analyzers/conversion_overflow.go
+++ b/analyzers/conversion_overflow.go
@@ -140,9 +140,22 @@ func parseIntType(intType string) (integer, error) {
 	var max uint
 
 	if signed {
-		max = (1 << uint(intSize-1)) - 1
+		shiftAmount := intSize - 1
+
+		// Perform a bounds check
+		if shiftAmount < 0 {
+			return integer{}, fmt.Errorf("invalid shift amount: %d", shiftAmount)
+		}
+
+		max = (1 << uint(shiftAmount)) - 1
 		min = -1 << (intSize - 1)
+
 	} else {
+		// Perform a bounds check
+		if intSize < 0 {
+			return integer{}, fmt.Errorf("invalid bit size: %d", intSize)
+		}
+
 		max = (1 << uint(intSize)) - 1
 		min = 0
 	}

--- a/analyzers/conversion_overflow.go
+++ b/analyzers/conversion_overflow.go
@@ -391,7 +391,7 @@ func updateResultFromBinOp(result *rangeResult, binOp *ssa.BinOp, instr *ssa.Con
 			result.maxValue = uint(min)
 		}
 		if max <= math.MaxInt {
-			result.minValue = int(max)
+			result.minValue = int(max) //nolint:gosec
 		}
 	}
 }

--- a/analyzers/conversion_overflow.go
+++ b/analyzers/conversion_overflow.go
@@ -387,10 +387,10 @@ func updateResultFromBinOp(result *rangeResult, binOp *ssa.BinOp, instr *ssa.Con
 		min := result.minValue
 		max := result.maxValue
 
-		if min > 0 {
+		if min >= 0 {
 			result.maxValue = uint(min)
 		}
-		if max < math.MaxInt {
+		if max <= math.MaxInt {
 			result.minValue = int(max)
 		}
 	}

--- a/analyzers/conversion_overflow.go
+++ b/analyzers/conversion_overflow.go
@@ -229,6 +229,15 @@ func checkBlockForRangeCheck(block *ssa.BasicBlock, instr *ssa.Convert, dstInt i
 					}
 				}
 			}
+		case *ssa.Call:
+			// len(slice) results in an int that is guaranteed >= 0, which
+			// satisfies the lower bound check for int -> uint conversion
+			if v != instr.X {
+				continue
+			}
+			if fn, isBuiltin := v.Call.Value.(*ssa.Builtin); isBuiltin && fn.Name() == "len" && !dstInt.signed {
+				minBoundChecked = true
+			}
 		case *ssa.Phi:
 			// Handle logical operations
 			continue

--- a/analyzers/conversion_overflow.go
+++ b/analyzers/conversion_overflow.go
@@ -141,7 +141,7 @@ func parseIntType(intType string) (integer, error) {
 
 	if signed {
 		max = (1 << uint(intSize-1)) - 1
-		min = -int(max) - 1
+		min = -1 << (intSize - 1)
 	} else {
 		max = (1 << uint(intSize)) - 1
 		min = 0

--- a/analyzers/conversion_overflow.go
+++ b/analyzers/conversion_overflow.go
@@ -155,16 +155,13 @@ func hasExplicitRangeCheck(instr *ssa.Convert, dstType string) bool {
 		return false
 	}
 
-	minBoundChecked := false
-	maxBoundChecked := false
-
 	srcInt, err := parseIntType(instr.X.Type().String())
 	if err != nil {
 		return false
 	}
 
-	minBoundChecked = checkSourceMinBound(srcInt, dstInt)
-	maxBoundChecked = checkSourceMaxBound(srcInt, dstInt)
+	minBoundChecked := checkSourceMinBound(srcInt, dstInt)
+	maxBoundChecked := checkSourceMaxBound(srcInt, dstInt)
 
 	// If both bounds are already checked, return true
 	if minBoundChecked && maxBoundChecked {
@@ -176,12 +173,10 @@ func hasExplicitRangeCheck(instr *ssa.Convert, dstType string) bool {
 	checkPredecessors = func(block *ssa.BasicBlock) bool {
 		for _, pred := range block.Preds {
 			minChecked, maxChecked := checkBlockForRangeCheck(pred, instr, dstInt)
-			if minChecked {
-				minBoundChecked = true
-			}
-			if maxChecked {
-				maxBoundChecked = true
-			}
+
+			minBoundChecked = minBoundChecked || minChecked
+			maxBoundChecked = maxBoundChecked || maxChecked
+
 			if minBoundChecked && maxBoundChecked {
 				return true
 			}

--- a/analyzers/conversion_overflow_test.go
+++ b/analyzers/conversion_overflow_test.go
@@ -1,0 +1,139 @@
+package analyzers
+
+import (
+	"math"
+	"strconv"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ParseIntType", func() {
+	Context("with valid input", func() {
+		DescribeTable("should correctly parse and calculate bounds for",
+			func(intType string, expectedSigned bool, expectedSize int, expectedMin int, expectedMax uint) {
+				result, err := parseIntType(intType)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.signed).To(Equal(expectedSigned))
+				Expect(result.size).To(Equal(expectedSize))
+				Expect(result.min).To(Equal(expectedMin))
+				Expect(result.max).To(Equal(expectedMax))
+			},
+			Entry("uint8", "uint8", false, 8, 0, uint(math.MaxUint8)),
+			Entry("int8", "int8", true, 8, math.MinInt8, uint(math.MaxInt8)),
+			Entry("uint16", "uint16", false, 16, 0, uint(math.MaxUint16)),
+			Entry("int16", "int16", true, 16, math.MinInt16, uint(math.MaxInt16)),
+			Entry("uint32", "uint32", false, 32, 0, uint(math.MaxUint32)),
+			Entry("int32", "int32", true, 32, math.MinInt32, uint(math.MaxInt32)),
+			Entry("uint64", "uint64", false, 64, 0, uint(math.MaxUint64)),
+			Entry("int64", "int64", true, 64, math.MinInt64, uint(math.MaxInt64)),
+		)
+
+		It("should use system's int size for 'int' and 'uint'", func() {
+			intResult, err := parseIntType("int")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(intResult.size).To(Equal(strconv.IntSize))
+
+			uintResult, err := parseIntType("uint")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(uintResult.size).To(Equal(strconv.IntSize))
+		})
+	})
+
+	Context("with invalid input", func() {
+		DescribeTable("should return an error for",
+			func(intType string, expectedErrorString string) {
+				_, err := parseIntType(intType)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(expectedErrorString))
+			},
+			Entry("empty string", "", "no integer type match found for "),
+			Entry("invalid type", "float64", "no integer type match found for float64"),
+			Entry("invalid size", "int65", "invalid bit size: 65"),
+			Entry("negative size", "int-8", "no integer type match found for int-8"),
+			Entry("non-numeric size", "intABC", "no integer type match found for intABC"),
+		)
+	})
+})
+
+var _ = Describe("IsIntOverflow", func() {
+	DescribeTable("should correctly identify overflow scenarios on a 64-bit system",
+		func(src string, dst string, expectedOverflow bool) {
+			result := isIntOverflow(src, dst)
+			Expect(result).To(Equal(expectedOverflow))
+		},
+		// Unsigned to Signed conversions
+		Entry("uint8 to int8", "uint8", "int8", true),
+		Entry("uint8 to int16", "uint8", "int16", false),
+		Entry("uint8 to int32", "uint8", "int32", false),
+		Entry("uint8 to int64", "uint8", "int64", false),
+		Entry("uint16 to int8", "uint16", "int8", true),
+		Entry("uint16 to int16", "uint16", "int16", true),
+		Entry("uint16 to int32", "uint16", "int32", false),
+		Entry("uint16 to int64", "uint16", "int64", false),
+		Entry("uint32 to int8", "uint32", "int8", true),
+		Entry("uint32 to int16", "uint32", "int16", true),
+		Entry("uint32 to int32", "uint32", "int32", true),
+		Entry("uint32 to int64", "uint32", "int64", false),
+		Entry("uint64 to int8", "uint64", "int8", true),
+		Entry("uint64 to int16", "uint64", "int16", true),
+		Entry("uint64 to int32", "uint64", "int32", true),
+		Entry("uint64 to int64", "uint64", "int64", true),
+
+		// Unsigned to Unsigned conversions
+		Entry("uint8 to uint16", "uint8", "uint16", false),
+		Entry("uint8 to uint32", "uint8", "uint32", false),
+		Entry("uint8 to uint64", "uint8", "uint64", false),
+		Entry("uint16 to uint8", "uint16", "uint8", true),
+		Entry("uint16 to uint32", "uint16", "uint32", false),
+		Entry("uint16 to uint64", "uint16", "uint64", false),
+		Entry("uint32 to uint8", "uint32", "uint8", true),
+		Entry("uint32 to uint16", "uint32", "uint16", true),
+		Entry("uint32 to uint64", "uint32", "uint64", false),
+		Entry("uint64 to uint8", "uint64", "uint8", true),
+		Entry("uint64 to uint16", "uint64", "uint16", true),
+		Entry("uint64 to uint32", "uint64", "uint32", true),
+
+		// Signed to Unsigned conversions
+		Entry("int8 to uint8", "int8", "uint8", true),
+		Entry("int8 to uint16", "int8", "uint16", true),
+		Entry("int8 to uint32", "int8", "uint32", true),
+		Entry("int8 to uint64", "int8", "uint64", true),
+		Entry("int16 to uint8", "int16", "uint8", true),
+		Entry("int16 to uint16", "int16", "uint16", true),
+		Entry("int16 to uint32", "int16", "uint32", true),
+		Entry("int16 to uint64", "int16", "uint64", true),
+		Entry("int32 to uint8", "int32", "uint8", true),
+		Entry("int32 to uint16", "int32", "uint16", true),
+		Entry("int32 to uint32", "int32", "uint32", true),
+		Entry("int32 to uint64", "int32", "uint64", true),
+		Entry("int64 to uint8", "int64", "uint8", true),
+		Entry("int64 to uint16", "int64", "uint16", true),
+		Entry("int64 to uint32", "int64", "uint32", true),
+		Entry("int64 to uint64", "int64", "uint64", true),
+
+		// Signed to Signed conversions
+		Entry("int8 to int16", "int8", "int16", false),
+		Entry("int8 to int32", "int8", "int32", false),
+		Entry("int8 to int64", "int8", "int64", false),
+		Entry("int16 to int8", "int16", "int8", true),
+		Entry("int16 to int32", "int16", "int32", false),
+		Entry("int16 to int64", "int16", "int64", false),
+		Entry("int32 to int8", "int32", "int8", true),
+		Entry("int32 to int16", "int32", "int16", true),
+		Entry("int32 to int64", "int32", "int64", false),
+		Entry("int64 to int8", "int64", "int8", true),
+		Entry("int64 to int16", "int64", "int16", true),
+		Entry("int64 to int32", "int64", "int32", true),
+
+		// Same type conversions (should never overflow)
+		Entry("uint8 to uint8", "uint8", "uint8", false),
+		Entry("uint16 to uint16", "uint16", "uint16", false),
+		Entry("uint32 to uint32", "uint32", "uint32", false),
+		Entry("uint64 to uint64", "uint64", "uint64", false),
+		Entry("int8 to int8", "int8", "int8", false),
+		Entry("int16 to int16", "int16", "int16", false),
+		Entry("int32 to int32", "int32", "int32", false),
+		Entry("int64 to int64", "int64", "int64", false),
+	)
+})

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/onsi/gomega v1.34.2
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/crypto v0.26.0
+	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
 	golang.org/x/text v0.17.0
 	golang.org/x/tools v0.24.0

--- a/go.sum
+++ b/go.sum
@@ -428,6 +428,8 @@ golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20200331195152-e8c3332aa8e5/go.mod h1:4M0jN8W1tt0AVLNr8HDosyJCDCDuyL9N9+3m7wDWgKw=
+golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 h1:2dVuKD2vS7b0QIHQbpyTISPd0LeHDbnYEryqj5Q1ug8=
+golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56/go.mod h1:M4RDyNAINzryxdtnbRXRL/OHtkFuWGRjvuhBJpk2IlY=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/testutils/g115_samples.go
+++ b/testutils/g115_samples.go
@@ -495,4 +495,21 @@ func foo(x int) uint32 {
 }
 `,
 	}, 0, gosec.NewConfig()},
+	{[]string{
+		`
+package main
+
+import (
+        "math"
+)
+
+func foo(items []string) uint32 {
+        x := len(items)
+        if x > math.MaxUint32 {
+            return math.MaxUint32
+        }
+        return uint32(x)
+}
+`,
+	}, 0, gosec.NewConfig()},
 }

--- a/testutils/g115_samples.go
+++ b/testutils/g115_samples.go
@@ -322,7 +322,7 @@ func main() {
         fmt.Printf("%d\n", b)
 }
 	`,
-	}, 0, gosec.NewConfig()},
+	}, 1, gosec.NewConfig()},
 	{[]string{
 		`
 package main
@@ -342,7 +342,7 @@ func main() {
         fmt.Printf("%d\n", b)
 }
 	`,
-	}, 1, gosec.NewConfig()},
+	}, 0, gosec.NewConfig()},
 	{[]string{
 		`
 package main
@@ -355,7 +355,7 @@ import (
 
 func main() {
         a := rand.Int63()
-        if a < math.MinInt64 && a > math.MaxInt32 {
+        if a < math.MinInt64 || a > math.MaxInt32 {
             panic("out of range")
         }
         b := int32(a)

--- a/testutils/g115_samples.go
+++ b/testutils/g115_samples.go
@@ -512,4 +512,121 @@ func foo(items []string) uint32 {
 }
 `,
 	}, 0, gosec.NewConfig()},
+	{[]string{
+		`
+package main
+
+import (
+        "math"
+)
+
+func foo(items []string) uint32 {
+        x := len(items)
+        if x < math.MaxUint32 {
+            return uint32(x)
+        }
+        return math.MaxUint32
+}
+`,
+	}, 0, gosec.NewConfig()},
+	{[]string{
+		`
+package main
+
+import (
+        "fmt"
+        "math"
+        "math/rand"
+)
+
+func main() {
+        a := rand.Int63()
+        if a >= math.MinInt32 && a <= math.MaxInt32 {
+            b := int32(a)
+            fmt.Printf("%d\n", b)
+        }
+        panic("out of range")
+}
+	`,
+	}, 0, gosec.NewConfig()},
+	{[]string{
+		`
+package main
+
+import (
+        "fmt"
+        "math"
+        "math/rand"
+)
+
+func main() {
+        a := rand.Int63()
+        if a >= math.MinInt32 && a <= math.MaxInt32 {
+            b := int32(a)
+            fmt.Printf("%d\n", b)
+        }
+        panic("out of range")
+}
+	`,
+	}, 0, gosec.NewConfig()},
+	{[]string{
+		`
+package main
+
+import (
+        "fmt"
+        "math"
+        "math/rand"
+)
+
+func main() {
+        a := rand.Int63()
+        if !(a >= math.MinInt32) && a > math.MaxInt32 {
+            b := int32(a)
+            fmt.Printf("%d\n", b)
+        }
+        panic("out of range")
+}
+	`,
+	}, 0, gosec.NewConfig()},
+	{[]string{
+		`
+package main
+
+import (
+        "fmt"
+        "math"
+        "math/rand"
+)
+
+func main() {
+        a := rand.Int63()
+        if !(a >= math.MinInt32) || a > math.MaxInt32 {
+            panic("out of range")
+        }
+        b := int32(a)
+        fmt.Printf("%d\n", b)
+}
+	`,
+	}, 0, gosec.NewConfig()},
+	{[]string{
+		`
+package main
+
+import (
+        "fmt"
+        "math"
+        "math/rand"
+)
+
+func main() {
+        a := rand.Int63()
+        if math.MinInt32 <= a && math.MaxInt32 >= a {
+            b := int32(a)
+            fmt.Printf("%d\n", b)
+        }
+        panic("out of range")
+}
+	`,
+	}, 0, gosec.NewConfig()},
 }

--- a/testutils/g115_samples.go
+++ b/testutils/g115_samples.go
@@ -287,10 +287,34 @@ package main
 import (
         "fmt"
         "math"
+        "math/rand"
 )
 
 func main() {
-        var a int64 = 13
+        a := rand.Int63()
+        if a < math.MinInt32 {
+            panic("out of range")
+        }
+        if a > math.MaxInt32 {
+            panic("out of range")
+        }
+        b := int32(a)
+        fmt.Printf("%d\n", b)
+}
+	`,
+	}, 0, gosec.NewConfig()},
+	{[]string{
+		`
+package main
+
+import (
+        "fmt"
+        "math"
+        "math/rand"
+)
+
+func main() {
+        a := rand.Int63()
         if a < math.MinInt32 || a > math.MaxInt32 {
             panic("out of range")
         }
@@ -390,4 +414,65 @@ func main() {
 }
 	`,
 	}, 1, gosec.NewConfig()},
+	{[]string{
+		`
+package main
+
+import (
+        "fmt"
+        "math"
+        "math/rand"
+)
+
+func main() {
+        a := rand.Int63()
+        if a < 0 {
+            panic("out of range")
+        }
+        if a > math.MaxUint32 {
+            panic("out of range")
+        }
+        b := uint32(a)
+        fmt.Printf("%d\n", b)
+}
+`,
+	}, 0, gosec.NewConfig()},
+	{[]string{
+		`
+package main
+
+import (
+        "fmt"
+        "math/rand"
+)
+
+func main() {
+        a := rand.Int63()
+        if a < 0 {
+            panic("out of range")
+        }
+        b := uint32(a)
+        fmt.Printf("%d\n", b)
+}
+`,
+	}, 1, gosec.NewConfig()},
+	{[]string{
+		`
+package main
+
+import (
+        "math"
+)
+
+func foo(x int) uint32 {
+        if x < 0 {
+            return 0
+        }
+        if x > math.MaxUint32 {
+            return math.MaxUint32
+        }
+        return uint32(x)
+}
+`,
+	}, 0, gosec.NewConfig()},
 }

--- a/testutils/g115_samples.go
+++ b/testutils/g115_samples.go
@@ -697,4 +697,23 @@ func main() {
 }
 	`,
 	}, 0, gosec.NewConfig()},
+	{[]string{
+		`
+        package main
+
+        import (
+            "fmt"
+            "math/rand"
+        )
+
+        func main() {
+            a := rand.Int63()
+            if a >= 0 {
+                panic("no positivity allowed")
+            }
+            b := uint64(-a)
+            fmt.Printf("%d\n", b)
+        }
+            `,
+	}, 0, gosec.NewConfig()},
 }

--- a/testutils/g115_samples.go
+++ b/testutils/g115_samples.go
@@ -684,4 +684,17 @@ func main() {
 }
 	`,
 	}, 0, gosec.NewConfig()},
+	{[]string{
+		`
+package main
+
+import "unsafe"
+
+func main() {
+	i := uintptr(123)
+	p := unsafe.Pointer(i)
+	_ = p
+}
+	`,
+	}, 0, gosec.NewConfig()},
 }

--- a/testutils/g115_samples.go
+++ b/testutils/g115_samples.go
@@ -315,7 +315,7 @@ import (
 
 func main() {
         a := rand.Int63()
-        if a < math.MinInt32 || a > math.MaxInt32 {
+        if a < math.MinInt32 && a > math.MaxInt32 {
             panic("out of range")
         }
         b := int32(a)
@@ -335,7 +335,27 @@ import (
 
 func main() {
         a := rand.Int63()
-        if a < math.MinInt64 || a > math.MaxInt32 {
+        if a < math.MinInt32 || a > math.MaxInt32 {
+            panic("out of range")
+        }
+        b := int32(a)
+        fmt.Printf("%d\n", b)
+}
+	`,
+	}, 1, gosec.NewConfig()},
+	{[]string{
+		`
+package main
+
+import (
+        "fmt"
+        "math"
+        "math/rand"
+)
+
+func main() {
+        a := rand.Int63()
+        if a < math.MinInt64 && a > math.MaxInt32 {
             panic("out of range")
         }
         b := int32(a)
@@ -354,7 +374,7 @@ import (
 
 func main() {
         var a int32 = math.MaxInt32
-        if a < math.MinInt32 || a > math.MaxInt32 {
+        if a < math.MinInt32 && a > math.MaxInt32 {
             panic("out of range")
         }
         var b int64 = int64(a) * 2

--- a/testutils/g115_samples.go
+++ b/testutils/g115_samples.go
@@ -521,6 +521,23 @@ import (
 )
 
 func foo(items []string) uint32 {
+        x := cap(items)
+        if x > math.MaxUint32 {
+            return math.MaxUint32
+        }
+        return uint32(x)
+}
+`,
+	}, 0, gosec.NewConfig()},
+	{[]string{
+		`
+package main
+
+import (
+        "math"
+)
+
+func foo(items []string) uint32 {
         x := len(items)
         if x < math.MaxUint32 {
             return uint32(x)

--- a/testutils/g115_samples.go
+++ b/testutils/g115_samples.go
@@ -646,4 +646,42 @@ func main() {
 }
 	`,
 	}, 0, gosec.NewConfig()},
+	{[]string{
+		`
+package main
+
+import (
+        "fmt"
+        "math/rand"
+)
+
+func main() {
+        a := rand.Int63()
+        if a == 3 || a == 4 {
+            b := int32(a)
+            fmt.Printf("%d\n", b)
+        }
+        panic("out of range")
+}
+	`,
+	}, 0, gosec.NewConfig()},
+	{[]string{
+		`
+package main
+
+import (
+        "fmt"
+        "math/rand"
+)
+
+func main() {
+        a := rand.Int63()
+        if a != 3 || a != 4 {
+            panic("out of range")
+        }
+        b := int32(a)
+        fmt.Printf("%d\n", b)
+}
+	`,
+	}, 0, gosec.NewConfig()},
 }


### PR DESCRIPTION
As per discussion in #1187, the implementation was lacking. This PR extends the bounds check logic to validate that the integer size is checked within the bounds of the destination type. 

I'd like to hear @rittneje's opinion on the changes as they reported the issues with it and @ben-krieger's too since he is already looking into it as well.

fixes #1187 
fixes #1202