### PR TITLE
Update gosec to v1.21.4 in GitHub action

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,5 @@
 ---
+version: 2
 project_name: gosec
 
 release:

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
 
 runs:
     using: 'docker'
-    image: 'docker://securego/gosec:2.21.3'
+    image: 'docker://securego/gosec:2.21.4'
     args:
       - ${{ inputs.args }}
 


### PR DESCRIPTION
- Add the version into goreleaser config
- Update the gosec to v2.21.4 in the Github action**
