### PR TITLE
Fix G115 false positive when going from parsed uint to larger int

### DIFF
--- a/analyzers/conversion_overflow.go
+++ b/analyzers/conversion_overflow.go
@@ -226,7 +226,12 @@ func isStringToIntConversion(instr *ssa.Convert, dstType string) bool {
 						if err != nil {
 							return false
 						}
-						isSafe := bitSizeValue <= dstInt.size && signed == dstInt.signed
+
+						// we're good if:
+						// - signs match and bit size is <= than destination
+						// - parsing unsigned and bit size is < than destination
+						isSafe := (bitSizeValue <= dstInt.size && signed == dstInt.signed) ||
+							(bitSizeValue < dstInt.size && !signed)
 						return isSafe
 					}
 				}

--- a/testutils/g115_samples.go
+++ b/testutils/g115_samples.go
@@ -428,6 +428,40 @@ import (
 
 func main() {
         var a string = "13"
+        b, _ := strconv.ParseUint(a, 10, 16)
+        c := int(b)
+        fmt.Printf("%d\n", c)
+}
+	`,
+	}, 0, gosec.NewConfig()},
+	{[]string{
+		`
+package main
+
+import (
+        "fmt"
+        "strconv"
+)
+
+func main() {
+        var a string = "13"
+        b, _ := strconv.ParseUint(a, 10, 31)
+        c := int32(b)
+        fmt.Printf("%d\n", c)
+}
+	`,
+	}, 0, gosec.NewConfig()},
+	{[]string{
+		`
+package main
+
+import (
+        "fmt"
+        "strconv"
+)
+
+func main() {
+        var a string = "13"
         b, _ := strconv.ParseInt(a, 10, 8)
         c := uint8(b)
         fmt.Printf("%d\n", c)


### PR DESCRIPTION
Fixes the issue I recently found in https://github.com/securego/gosec/issues/1212#issuecomment-2499375351.

When converting to an `int*` from a `uint64` created by `strconv.ParseUint` with a specified bit size less than the size of the destination integer, currently G115 is falsely triggered. 

That's because the current check only allows the source and destination sign to match (i.e. from int* to int* or uint* to uint*). This is a useful check when going from `ParseInt` to a uint*, but when going from `ParseUint` to an int* the conversion is safe as long as the bit size is at least one less.

I've added the extra test and documented it since the logic is somewhat complex.

I've also added a few test cases to catch regressions.