### PR TITLE
Remove the decryption funtions/methods from G407 check

### DIFF
--- a/analyzers/hardcoded_nonce.go
+++ b/analyzers/hardcoded_nonce.go
@@ -48,10 +48,7 @@ func runHardCodedNonce(pass *analysis.Pass) (interface{}, error) {
 	// Example "Test" 3, 1 -- means the function "Test" which accepts 3 arguments, and has the nonce arg as second argument
 	calls := map[string][]int{
 		"(crypto/cipher.AEAD).Seal":     {4, 1},
-		"(crypto/cipher.AEAD).Open":     {4, 1},
-		"crypto/cipher.NewCBCDecrypter": {2, 1},
 		"crypto/cipher.NewCBCEncrypter": {2, 1},
-		"crypto/cipher.NewCFBDecrypter": {2, 1},
 		"crypto/cipher.NewCFBEncrypter": {2, 1},
 		"crypto/cipher.NewCTR":          {2, 1},
 		"crypto/cipher.NewOFB":          {2, 1},

--- a/testutils/g407_samples.go
+++ b/testutils/g407_samples.go
@@ -173,7 +173,7 @@ func main() {
 	cipherText, _ = aesGCM.Open(nil, []byte("ILoveMyNonce"), cipherText, nil)
 	fmt.Println(string(cipherText))
 }
-`}, 2, gosec.NewConfig()},
+`}, 1, gosec.NewConfig()},
 
 	{[]string{`package main
 
@@ -193,7 +193,7 @@ func main() {
 	cipherText, _ = aesGCM.Open(nil, []byte{}, cipherText, nil)
 	fmt.Println(string(cipherText))
 }
-`}, 2, gosec.NewConfig()},
+`}, 1, gosec.NewConfig()},
 
 	{[]string{`package main
 
@@ -214,7 +214,7 @@ func main() {
 	cipherText, _ = aesGCM.Open(nil, []byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, cipherText, nil)
 	fmt.Println(string(cipherText))
 }
-`}, 2, gosec.NewConfig()},
+`}, 1, gosec.NewConfig()},
 
 	{[]string{`package main
 
@@ -248,7 +248,7 @@ func main() {
 
 	fmt.Println(string(cipherText))
 }
-`}, 2, gosec.NewConfig()},
+`}, 1, gosec.NewConfig()},
 
 	{[]string{`package main
 
@@ -281,7 +281,7 @@ func main() {
 	}(), cipherText, nil)
 	fmt.Println(string(cipherText))
 }
-`}, 2, gosec.NewConfig()},
+`}, 1, gosec.NewConfig()},
 
 	{[]string{`package main
 
@@ -301,7 +301,7 @@ func main() {
 	fmt.Println(string(cipheredText))
 
 }
-`}, 2, gosec.NewConfig()},
+`}, 1, gosec.NewConfig()},
 
 	{[]string{`package main
 
@@ -321,7 +321,7 @@ func main() {
 	fmt.Println(string(cipheredText))
 
 }
-`}, 2, gosec.NewConfig()},
+`}, 1, gosec.NewConfig()},
 
 	{[]string{`package main
 
@@ -342,7 +342,7 @@ func main() {
 	aesCFB.XORKeyStream(output, output)
 	fmt.Println(string(output))
 
-}`}, 2, gosec.NewConfig()},
+}`}, 1, gosec.NewConfig()},
 
 	{[]string{`package main
 
@@ -363,7 +363,7 @@ func main() {
 	aesCFB.XORKeyStream(output, output)
 	fmt.Println(string(output))
 
-}`}, 2, gosec.NewConfig()},
+}`}, 1, gosec.NewConfig()},
 
 	{[]string{`package main
 
@@ -386,7 +386,7 @@ func main() {
 	aesCBC.CryptBlocks(output, output)
 	fmt.Println(string(output))
 
-}`}, 2, gosec.NewConfig()},
+}`}, 1, gosec.NewConfig()},
 
 	{[]string{`package main
 
@@ -410,7 +410,7 @@ func main() {
 	fmt.Println(string(output))
 
 }
-`}, 2, gosec.NewConfig()},
+`}, 1, gosec.NewConfig()},
 
 	{[]string{`package main
 


### PR DESCRIPTION
The nonce in the decryption functions/methods is typically provided and it should not be randomly generated.

fixes #1209 