### PR TITLE
fix: revive.redefines-builtin-id lint warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,6 +44,7 @@ linters-settings:
     rules:
       - name: dot-imports
         disabled: true
+      - name: redefines-builtin-id
 
 run:
   timeout: 5m

--- a/analyzers/conversion_overflow.go
+++ b/analyzers/conversion_overflow.go
@@ -451,7 +451,7 @@ func walkBranchForConvert(block *ssa.BasicBlock, instr *ssa.Convert, visitedIfs 
 			if result.isRangeCheck {
 				bounds.minValue = toPtr(maxWithPtr(result.minValue, bounds.minValue))
 				bounds.maxValue = toPtr(minWithPtr(result.maxValue, bounds.maxValue))
-				bounds.explixitPositiveVals = append(bounds.explixitPositiveVals, result.explicitPositiveVals...)
+				bounds.explicitPositiveVals = append(bounds.explicitPositiveVals, result.explicitPositiveVals...)
 				bounds.explicitNegativeVals = append(bounds.explicitNegativeVals, result.explicitNegativeVals...)
 			}
 		case *ssa.Call:

--- a/analyzers/conversion_overflow.go
+++ b/analyzers/conversion_overflow.go
@@ -15,6 +15,7 @@
 package analyzers
 
 import (
+	"cmp"
 	"fmt"
 	"go/token"
 	"math"
@@ -22,7 +23,6 @@ import (
 	"strconv"
 	"strings"
 
-	"golang.org/x/exp/constraints"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/buildssa"
 	"golang.org/x/tools/go/ssa"
@@ -141,8 +141,8 @@ func parseIntType(intType string) (integer, error) {
 		return integer{}, fmt.Errorf("invalid bit size: %d", intSize)
 	}
 
-	var min int
-	var max uint
+	var minVal int
+	var maxVal uint
 
 	if signed {
 		shiftAmount := intSize - 1
@@ -152,19 +152,19 @@ func parseIntType(intType string) (integer, error) {
 			return integer{}, fmt.Errorf("invalid shift amount: %d", shiftAmount)
 		}
 
-		max = (1 << uint(shiftAmount)) - 1
-		min = -1 << (intSize - 1)
+		maxVal = (1 << uint(shiftAmount)) - 1
+		minVal = -1 << (intSize - 1)
 
 	} else {
-		max = (1 << uint(intSize)) - 1
-		min = 0
+		maxVal = (1 << uint(intSize)) - 1
+		minVal = 0
 	}
 
 	return integer{
 		signed: signed,
 		size:   intSize,
-		min:    min,
-		max:    max,
+		min:    minVal,
+		max:    maxVal,
 	}, nil
 }
 
@@ -274,8 +274,8 @@ func hasExplicitRangeCheck(instr *ssa.Convert, dstType string) bool {
 			case *ssa.If:
 				result := getResultRange(v, instr, visitedIfs)
 				if result.isRangeCheck {
-					minValue = max(minValue, &result.minValue)
-					maxValue = min(maxValue, &result.maxValue)
+					minValue = max(minValue, result.minValue)
+					maxValue = min(maxValue, result.maxValue)
 					explicitPositiveVals = append(explicitPositiveVals, result.explicitPositiveVals...)
 					explicitNegativeVals = append(explicitNegativeVals, result.explicitNegativeVals...)
 				}
@@ -328,12 +328,12 @@ func getResultRange(ifInstr *ssa.If, instr *ssa.Convert, visitedIfs map[*ssa.If]
 
 	if thenBounds.convertFound {
 		result.convertFound = true
-		result.minValue = max(result.minValue, thenBounds.minValue)
-		result.maxValue = min(result.maxValue, thenBounds.maxValue)
+		result.minValue = maxWithPtr(result.minValue, thenBounds.minValue)
+		result.maxValue = minWithPtr(result.maxValue, thenBounds.maxValue)
 	} else if elseBounds.convertFound {
 		result.convertFound = true
-		result.minValue = max(result.minValue, elseBounds.minValue)
-		result.maxValue = min(result.maxValue, elseBounds.maxValue)
+		result.minValue = maxWithPtr(result.minValue, elseBounds.minValue)
+		result.maxValue = minWithPtr(result.maxValue, elseBounds.maxValue)
 	}
 
 	result.explicitPositiveVals = append(result.explicitPositiveVals, thenBounds.explixitPositiveVals...)
@@ -388,14 +388,14 @@ func updateResultFromBinOp(result *rangeResult, binOp *ssa.BinOp, instr *ssa.Con
 	}
 
 	if op == "neg" {
-		min := result.minValue
-		max := result.maxValue
+		minVal := result.minValue
+		maxVal := result.maxValue
 
-		if min >= 0 {
-			result.maxValue = uint(min)
+		if minVal >= 0 {
+			result.maxValue = uint(minVal)
 		}
-		if max <= math.MaxInt {
-			result.minValue = int(max)
+		if maxVal <= math.MaxInt {
+			result.minValue = int(maxVal)
 		}
 	}
 }
@@ -449,8 +449,8 @@ func walkBranchForConvert(block *ssa.BasicBlock, instr *ssa.Convert, visitedIfs 
 			bounds.convertFound = bounds.convertFound || result.convertFound
 
 			if result.isRangeCheck {
-				bounds.minValue = toPtr(max(result.minValue, bounds.minValue))
-				bounds.maxValue = toPtr(min(result.maxValue, bounds.maxValue))
+				bounds.minValue = toPtr(maxWithPtr(result.minValue, bounds.minValue))
+				bounds.maxValue = toPtr(minWithPtr(result.maxValue, bounds.maxValue))
 				bounds.explixitPositiveVals = append(bounds.explixitPositiveVals, result.explicitPositiveVals...)
 				bounds.explicitNegativeVals = append(bounds.explicitNegativeVals, result.explicitNegativeVals...)
 			}
@@ -540,24 +540,18 @@ func explicitValsInRange(explicitPosVals []uint, explicitNegVals []int, dstInt i
 	return true
 }
 
-func min[T constraints.Integer](a T, b *T) T {
+func minWithPtr[T cmp.Ordered](a T, b *T) T {
 	if b == nil {
 		return a
 	}
-	if a < *b {
-		return a
-	}
-	return *b
+	return min(a, *b)
 }
 
-func max[T constraints.Integer](a T, b *T) T {
+func maxWithPtr[T cmp.Ordered](a T, b *T) T {
 	if b == nil {
 		return a
 	}
-	if a > *b {
-		return a
-	}
-	return *b
+	return max(a, *b)
 }
 
 func toPtr[T any](a T) *T {

--- a/analyzers/conversion_overflow.go
+++ b/analyzers/conversion_overflow.go
@@ -452,6 +452,7 @@ func walkBranchForConvert(block *ssa.BasicBlock, instr *ssa.Convert, visitedIfs 
 				bounds.minValue = toPtr(maxWithPtr(result.minValue, bounds.minValue))
 				bounds.maxValue = toPtr(minWithPtr(result.maxValue, bounds.maxValue))
 				bounds.explixitPositiveVals = append(bounds.explixitPositiveVals, result.explicitPositiveVals...)
+				bounds.explicitNegativeVals = append(bounds.explicitNegativeVals, result.explicitNegativeVals...)
 			}
 		case *ssa.Call:
 			if v == instr.X {

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/onsi/gomega v1.35.1
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/crypto v0.29.0
-	golang.org/x/exp v0.0.0-20241108190413-2d47ceb2692f
 	golang.org/x/lint v0.0.0-20241112194109-818c5a804067
 	golang.org/x/text v0.20.0
 	golang.org/x/tools v0.27.0

--- a/go.sum
+++ b/go.sum
@@ -428,8 +428,6 @@ golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20200331195152-e8c3332aa8e5/go.mod h1:4M0jN8W1tt0AVLNr8HDosyJCDCDuyL9N9+3m7wDWgKw=
-golang.org/x/exp v0.0.0-20241108190413-2d47ceb2692f h1:XdNn9LlyWAhLVp6P/i8QYBW+hlyhrhei9uErw2B5GJo=
-golang.org/x/exp v0.0.0-20241108190413-2d47ceb2692f/go.mod h1:D5SMRVC3C2/4+F/DB1wZsLRnSNimn2Sp/NPsCrsv8ak=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=


### PR DESCRIPTION
The PR fixes `revive.redefines-builtin-id` lint warnings:

```sh
❯ golangci-lint run
analyzers/conversion_overflow.go:144:2: redefines-builtin-id: redefinition of the built-in function min (revive)
        var min int
        ^
analyzers/conversion_overflow.go:145:2: redefines-builtin-id: redefinition of the built-in function max (revive)
        var max uint
        ^
analyzers/conversion_overflow.go:155:3: redefines-builtin-id: redefinition of the built-in function max (revive)
                max = (1 << uint(shiftAmount)) - 1
                ^
analyzers/conversion_overflow.go:156:3: redefines-builtin-id: redefinition of the built-in function min (revive)
                min = -1 << (intSize - 1)
                ^
analyzers/conversion_overflow.go:159:3: redefines-builtin-id: redefinition of the built-in function max (revive)
                max = (1 << uint(intSize)) - 1
                ^
analyzers/conversion_overflow.go:160:3: redefines-builtin-id: redefinition of the built-in function min (revive)
                min = 0
                ^
```

This is because Go 1.22 has the following built-ins:
- https://pkg.go.dev/builtin@go1.22.0#min
- https://pkg.go.dev/builtin@go1.22.0#max