### PR TITLE
Simplify tests by using GinkgoT().TempDir()

### DIFF
--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -17,7 +17,6 @@ package gosec_test
 import (
 	"errors"
 	"log"
-	"os"
 	"regexp"
 	"strings"
 
@@ -45,10 +44,8 @@ var _ = Describe("Analyzer", func() {
 	Context("when processing a package", func() {
 		It("should not report an error if the package contains no Go files", func() {
 			analyzer.LoadRules(rules.Generate(false).RulesInfo())
-			dir, err := os.MkdirTemp("", "empty")
-			defer os.RemoveAll(dir)
-			Expect(err).ShouldNot(HaveOccurred())
-			err = analyzer.Process(buildTags, dir)
+			dir := GinkgoT().TempDir()
+			err := analyzer.Process(buildTags, dir)
 			Expect(err).ShouldNot(HaveOccurred())
 			_, _, errors := analyzer.Report()
 			Expect(errors).To(BeEmpty())

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -17,14 +17,8 @@ var _ = Describe("Helpers", func() {
 	Context("when listing package paths", func() {
 		var dir string
 		JustBeforeEach(func() {
-			var err error
-			dir, err = os.MkdirTemp("", "gosec")
-			Expect(err).ShouldNot(HaveOccurred())
-			_, err = os.MkdirTemp(dir, "test*.go")
-			Expect(err).ShouldNot(HaveOccurred())
-		})
-		AfterEach(func() {
-			err := os.RemoveAll(dir)
+			dir = GinkgoT().TempDir()
+			_, err := os.MkdirTemp(dir, "test*.go")
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 		It("should return the root directory as package path", func() {


### PR DESCRIPTION
The PR refactors tests by replacing `os.MkdirTemp` with `GinkgoT().TempDir()`.

[`T.TempDir`](https://pkg.go.dev/testing#T.TempDir) returns a temporary directory for the test to use. The directory is automatically removed when the test and all its subtests complete.