### PR TITLE
Improve capitalization in AI API flags descriptions

### DIFF
--- a/cmd/gosec/main.go
+++ b/cmd/gosec/main.go
@@ -157,10 +157,10 @@ var (
 	flagAiApiProvider = flag.String("ai-api-provider", "", "AI API provider to generate auto fixes to issues.\nValid options are: gemini")
 
 	// key to implementing AI provider services
-	flagAiApiKey = flag.String("ai-api-key", "", "key to access the AI API")
+	flagAiApiKey = flag.String("ai-api-key", "", "Key to access the AI API")
 
 	// endpoint to the AI provider
-	flagAiEndpoint = flag.String("ai-endpoint", "", "endpoint AI API.\nThis is optional, the default API endpoint will be used when not provided.")
+	flagAiEndpoint = flag.String("ai-endpoint", "", "Endpoint AI API.\nThis is optional, the default API endpoint will be used when not provided.")
 
 	// exclude the folders from scan
 	flagDirsExclude arrayFlags


### PR DESCRIPTION
This is for consistency with other flags.

`gosec -v` before:

```
OPTIONS:

  -ai-api-key string
        key to access the AI API
  -ai-api-provider string
        AI API provider to generate auto fixes to issues.
        Valid options are: gemini
  -ai-endpoint string
        endpoint AI API.
        This is optional, the default API endpoint will be used when not provided.
  -color
        Prints the text format report with colorization when it goes in the stdout (default true)
```


`go run ./cmd/gosec -v` after:

```
OPTIONS:

  -ai-api-key string
        Key to access the AI API
  -ai-api-provider string
        AI API provider to generate auto fixes to issues.
        Valid options are: gemini
  -ai-endpoint string
        Endpoint AI API.
        This is optional, the default API endpoint will be used when not provided.
  -color
        Prints the text format report with colorization when it goes in the stdout (default true)
```

