### PR TITLE
Refactor AppendError to use strings.Contains

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -543,8 +543,7 @@ func (gosec *Analyzer) ParseErrors(pkg *packages.Package) error {
 // AppendError appends an error to the file errors
 func (gosec *Analyzer) AppendError(file string, err error) {
 	// Do not report the error for empty packages (e.g. files excluded from build with a tag)
-	r := regexp.MustCompile(`no buildable Go source files in`)
-	if r.MatchString(err.Error()) {
+	if strings.Contains(err.Error(), "no buildable Go source files in") {
 		return
 	}
 	errors := make([]Error, 0)


### PR DESCRIPTION
The PR replaces `regexp.MustCompile` with `strings.Contains` to simplify and performance.

These simple benchmark show, that version with `strings.Contains` is more performant.

<details>
<summary>Benchmark</summary>

```go
func BenchmarkAppendError(b *testing.B) {
	analyzer := gosec.NewAnalyzer(nil, false, false, false, 1, nil)

	file := "test.go"
	err := errors.New("test error")

	for i := 0; i < b.N; i++ {
		analyzer.AppendError(file, err)
	}
}
```

</details>

Before (`regexp.MustCompile`):
```
-test.shuffle 1734344546323474000
goos: darwin
goarch: arm64
pkg: github.com/securego/gosec/v2
cpu: Apple M1 Pro
BenchmarkAppendError
BenchmarkAppendError-8   	   33993	     35043 ns/op	    3927 B/op	      23 allocs/op
PASS
coverage: 3.7% of statements
ok  	github.com/securego/gosec/v2	3.471s
```

After (`strings.Contains`):
```
Running tool: /opt/homebrew/bin/go test -benchmem -run=^$ -coverprofile=/var/folders/pk/5dzf3qsj6l18s2b3zfw194840000gn/T/vscode-goN80OyX/go-code-cover -bench ^BenchmarkAppendError$ github.com/securego/gosec/v2 -v -race -shuffle=on -parallel=8 -failfast

-test.shuffle 1734344511315519000
goos: darwin
goarch: arm64
pkg: github.com/securego/gosec/v2
cpu: Apple M1 Pro
BenchmarkAppendError
BenchmarkAppendError-8   	 1341718	       874.3 ns/op	     160 B/op	       0 allocs/op
PASS
coverage: 3.6% of statements
ok  	github.com/securego/gosec/v2	4.038s
```
