### PR TITLE
Replace old golang.org links with new go.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ func main() {
 	}
 
 	client := &http.Client{Transport: tr}
-	_, err := client.Get("https://golang.org/")
+	_, err := client.Get("https://go.dev/")
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -355,7 +355,7 @@ comment.
 
 ### Build tags
 
-gosec is able to pass your [Go build tags](https://golang.org/pkg/go/build/) to the analyzer.
+gosec is able to pass your [Go build tags](https://pkg.go.dev/go/build/) to the analyzer.
 They can be provided as a comma separated list as follows:
 
 ```bash

--- a/rules/implicit_aliasing.go
+++ b/rules/implicit_aliasing.go
@@ -47,7 +47,7 @@ func doGetIdentExpr(expr ast.Expr, hasSelector bool) (*ast.Ident, bool) {
 }
 
 func (r *implicitAliasing) Match(n ast.Node, c *gosec.Context) (*issue.Issue, error) {
-	// This rule does not apply for Go 1.22, see https://tip.golang.org/doc/go1.22#language.
+	// This rule does not apply for Go 1.22, see https://go.dev/doc/go1.22#language.
 	major, minor, _ := gosec.GoVersion()
 	if major >= 1 && minor >= 22 {
 		return nil, nil

--- a/testutils/g402_samples.go
+++ b/testutils/g402_samples.go
@@ -20,7 +20,7 @@ func main() {
 	}
 
 	client := &http.Client{Transport: tr}
-	_, err := client.Get("https://golang.org/")
+	_, err := client.Get("https://go.dev/")
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -54,7 +54,7 @@ func main() {
 		TLSClientConfig: &tls.Config{MinVersion: 0},
 	}
 	client := &http.Client{Transport: tr}
-	_, err := client.Get("https://golang.org/")
+	_, err := client.Get("https://go.dev/")
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -164,7 +164,7 @@ func main() {
 		TLSClientConfig: &tls.Config{MinVersion: theValue},
 	}
 	client := &http.Client{Transport: tr}
-	_, err := client.Get("https://golang.org/")
+	_, err := client.Get("https://go.dev/")
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -185,7 +185,7 @@ func main() {
 		TLSClientConfig: &tls.Config{MaxVersion: 0},
 	}
 	client := &http.Client{Transport: tr}
-	_, err := client.Get("https://golang.org/")
+	_, err := client.Get("https://go.dev/")
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -211,7 +211,7 @@ func main() {
 		},
 	}
 	client := &http.Client{Transport: tr}
-	_, err := client.Get("https://golang.org/")
+	_, err := client.Get("https://go.dev/")
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -230,12 +230,12 @@ import (
 func main() {
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{
-			MaxVersion: 0, 
+			MaxVersion: 0,
 			MinVersion: tls.VersionTLS13,
 		},
 	}
 	client := &http.Client{Transport: tr}
-	_, err := client.Get("https://golang.org/")
+	_, err := client.Get("https://go.dev/")
 	if err != nil {
 		fmt.Println(err)
 	}


### PR DESCRIPTION
The PR updates the links to `https://go.dev` across the code.