### PR TITLE
Refactor AppendError to check for build.NoGoError

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -16,6 +16,7 @@
 package gosec
 
 import (
+	"errors"
 	"fmt"
 	"go/ast"
 	"go/build"
@@ -543,7 +544,8 @@ func (gosec *Analyzer) ParseErrors(pkg *packages.Package) error {
 // AppendError appends an error to the file errors
 func (gosec *Analyzer) AppendError(file string, err error) {
 	// Do not report the error for empty packages (e.g. files excluded from build with a tag)
-	if strings.Contains(err.Error(), "no buildable Go source files in") {
+	var noGoErr *build.NoGoError
+	if errors.As(err, &noGoErr) {
 		return
 	}
 	errors := make([]Error, 0)

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -16,6 +16,7 @@ package gosec_test
 
 import (
 	"errors"
+	"go/build"
 	"log"
 	"regexp"
 	"strings"
@@ -1311,7 +1312,10 @@ var _ = Describe("Analyzer", func() {
 
 	Context("when appending errors", func() {
 		It("should skip error for non-buildable packages", func() {
-			analyzer.AppendError("test", errors.New(`loading file from package "pkg/test": no buildable Go source files in pkg/test`))
+			err := &build.NoGoError{
+				Dir: "pkg/test",
+			}
+			analyzer.AppendError("test", err)
 			_, _, errors := analyzer.Report()
 			Expect(errors).To(BeEmpty())
 		})


### PR DESCRIPTION
This PR refactors `Analyzer.AppendError` to handle [`build.NoGoError`](https://pkg.go.dev/go/build#NoGoError) for non-buildable packages. It's better to check for specific error instead of string.

