### PR TITLE
Enable testifylint and fix up lint issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,6 +23,7 @@ linters:
     - nolintlint
     - revive
     - staticcheck
+    - testifylint
     - typecheck
     - unconvert
     - unparam
@@ -39,6 +40,9 @@ linters-settings:
     checks:
      - all
      - '-SA1019'
+
+  testifylint:
+    enable-all: true
 
   revive:
     rules:


### PR DESCRIPTION
This PR improves the tests in `autofix/ai_test.go`.

Changes:

- Added `testifylint` to the list of linters.
- Replaced `assert.Error` and `assert.Equal` with `require.ErrorEqual` as suggested by `testifylint`.
- Updated mock expectations to use `.Once()`.
- Changed to use `mock.AssertExpectationsForObjects`.