### PR TITLE
Update what message for G104

### DIFF
--- a/rules/errors.go
+++ b/rules/errors.go
@@ -105,7 +105,7 @@ func NewNoErrorCheck(id string, conf gosec.Config) (gosec.Rule, []ast.Node) {
 			ID:         id,
 			Severity:   issue.Low,
 			Confidence: issue.High,
-			What:       "Errors unhandled.",
+			What:       "Errors unhandled",
 		},
 		whitelist: whitelist,
 	}, []ast.Node{(*ast.AssignStmt)(nil), (*ast.ExprStmt)(nil)}


### PR DESCRIPTION
The PR removes the dot from the "What" message for the G104 rule to make it consistent with the rest of the rule messages.