### PR TITLE
Update Docker GO_VERSION Build Args

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
           tags: ${{steps.meta.outputs.tags}}
           labels: ${{steps.meta.outputs.labels}}
           push: true
-          build-args: GO_VERSION=1.24
+          build-args: GO_VERSION=1.24.1
       - name: Sign Docker Image
         run: cosign sign --yes --key /tmp/cosign.key ${DIGEST} --registry-username="$secrets.DOCKER_USERNAME" --registry-password="::add-mask::$secrets.DOCKER_PASSWORD"
         env:


### PR DESCRIPTION
# Overview
This PR updates the `GO_VERSION` build argument in the `release.yml` workflow to `1.24.1`.

## Context
The `securego/gosec@v2.22.2` action uses a Docker image with Go `1.24` by default. This causes an error in projects requiring Go `1.24.1`:
```
stderr: go: go.mod requires go >= 1.24.1 (running go 1.24.0; GOTOOLCHAIN=local)
```
Ref: #1313 