### PR TITLE
Update version in 'action.yml' to 2.22.3 (anticipating next version)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
 
 runs:
     using: 'docker'
-    image: 'docker://securego/gosec:2.22.1'
+    image: 'docker://securego/gosec:2.22.3'
     args:
       - ${{ inputs.args }}
 


### PR DESCRIPTION
Hello! 👋 

This change is needed for GitHub Actions to pull the correct version. Ideally this would get merged before the release is created, so Dependabot pulls the right version when updating GitHub Actions.