### PR TITLE
G201/G202: add checks for injection into sql.Conn methods

### DIFF
--- a/rules/sql.go
+++ b/rules/sql.go
@@ -32,6 +32,12 @@ type sqlStatement struct {
 }
 
 var sqlCallIdents = map[string]map[string]int{
+	"*database/sql.Conn": {
+		"ExecContext":     1,
+		"QueryContext":    1,
+		"QueryRowContext": 1,
+		"PrepareContext":  1,
+	},
 	"*database/sql.DB": {
 		"Exec":            0,
 		"ExecContext":     1,

--- a/testutils/g201_samples.go
+++ b/testutils/g201_samples.go
@@ -105,6 +105,36 @@ func main(){
 }
 `}, 1, gosec.NewConfig()},
 	{[]string{`
+// Format string without proper quoting with connection
+package main
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+)
+
+func main(){
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		panic(err)
+	}
+	conn, err := db.Conn(context.Background())
+	if err != nil {
+		panic(err)
+	}
+	q := fmt.Sprintf("select * from foo where name = '%s'", os.Args[1])
+	rows, err := conn.QueryContext(context.Background(), q)
+	if err != nil {
+		panic(err)
+	}
+	defer rows.Close()
+	if err := conn.Close(); err != nil {
+		panic(err)
+	}
+}
+`}, 1, gosec.NewConfig()},
+	{[]string{`
 // Format string false positive, safe string spec.
 package main
 

--- a/testutils/g202_samples.go
+++ b/testutils/g202_samples.go
@@ -121,6 +121,35 @@ func main(){
 }
 `}, 1, gosec.NewConfig()},
 	{[]string{`
+// DB connection check
+package main
+
+import (
+    "context"
+	"database/sql"
+	"os"
+)
+
+func main(){
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		panic(err)
+	}
+	conn, err := db.Conn(context.Background())
+	if err != nil {
+		panic(err)
+	}
+	rows, err := conn.QueryContext(context.Background(), "select * from foo where name = " + os.Args[1])
+	if err != nil {
+		panic(err)
+	}
+	defer rows.Close()
+	if err := conn.Close(); err != nil {
+		panic(err)
+	}
+}
+`}, 1, gosec.NewConfig()},
+	{[]string{`
 // multiple string concatenation
 package main
 


### PR DESCRIPTION
We check sql.DB and sql.Tx, but sql.Conn appears to have been missed. It carries the same issues as DB/Tx in terms of injection.