### PR TITLE
Add support for go version 1.25.0 and switch the release build to use go version 1.25.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,11 @@ jobs:
   test:
     strategy:
       matrix:
-        version: [{go-version: '1.23.12', golangci: 'latest'}, {go-version: '1.24.6', golangci: 'latest'}]
+        version:
+        - go-version: '1.24.6'
+          golangci: 'latest'
+        - go-version: '1.25.0'
+          golangci: 'latest'
     runs-on: ubuntu-latest
     env:
       GO111MODULE: on
@@ -48,7 +52,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.6'
+          go-version: '1.25.0'
       - name: Checkout Source
         uses: actions/checkout@v4
       - uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,11 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.6'
+          go-version: '1.25.0'
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3
         with:
-          cosign-release: 'v2.5.0'
+          cosign-release: 'v2.5.3'
       - name: Store Cosign private key in a file
         run: 'echo "$COSIGN_KEY" > /tmp/cosign.key'
         shell: bash
@@ -67,7 +67,7 @@ jobs:
           tags: ${{steps.meta.outputs.tags}}
           labels: ${{steps.meta.outputs.labels}}
           push: true
-          build-args: GO_VERSION=1.24
+          build-args: GO_VERSION=1.25
       - name: Sign Docker Image
         run: cosign sign --yes --key /tmp/cosign.key ${DIGEST} --registry-username="$secrets.DOCKER_USERNAME" --registry-password="::add-mask::$secrets.DOCKER_PASSWORD"
         env:

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ GOSEC ?= $(GOBIN)/gosec
 GINKGO ?= $(GOBIN)/ginkgo
 GO_MINOR_VERSION = $(shell $(GO) version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f2)
 GOVULN_MIN_VERSION = 17
-GO_VERSION = 1.24
+GO_VERSION = 1.25
 LDFLAGS = -ldflags "\
 	-X 'main.Version=$(shell git describe --tags --always)' \
 	-X 'main.GitTag=$(shell git describe --tags --abbrev=0)' \

--- a/go.mod
+++ b/go.mod
@@ -56,4 +56,4 @@ require (
 	google.golang.org/protobuf v1.36.6 // indirect
 )
 
-go 1.23.0
+go 1.24.0


### PR DESCRIPTION
fixes #1375 #1330 