### PR TITLE
fix: text must be supplied when markdown is used

### DIFF
--- a/report/sarif/builder.go
+++ b/report/sarif/builder.go
@@ -91,6 +91,8 @@ func NewResult(ruleID string, ruleIndex int, level Level, message string, suppre
 		result.Fixes = []*Fix{
 			{
 				Description: &Message{
+					// Note: Text SHALL be supplied when Markdown is used: https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790720
+					Text:     autofix, // TODO: ensure this is plain text
 					Markdown: autofix,
 				},
 			},


### PR DESCRIPTION
as noted in #1393 and stated in the schema https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790720 (considering this is the right version) Text SHALL be present when Markdown is used. This PR just uses the autofix for text right now. A further issue can be opened if the autofix is indeed markdown but for now this PR should at least enable SRAIF upload again

Fixes https://github.com/securego/gosec/issues/1393