### PR TITLE
refactor: simplify report functions in main.go

### DIFF
--- a/cmd/gosec/main.go
+++ b/cmd/gosec/main.go
@@ -294,11 +294,7 @@ func getPrintedFormat(format string, verbose string) string {
 }
 
 func printReport(format string, color bool, rootPaths []string, reportInfo *gosec.ReportInfo) error {
-	err := report.CreateReport(os.Stdout, format, color, rootPaths, reportInfo)
-	if err != nil {
-		return err
-	}
-	return nil
+	return report.CreateReport(os.Stdout, format, color, rootPaths, reportInfo)
 }
 
 func saveReport(filename, format string, rootPaths []string, reportInfo *gosec.ReportInfo) error {
@@ -307,11 +303,7 @@ func saveReport(filename, format string, rootPaths []string, reportInfo *gosec.R
 		return err
 	}
 	defer outfile.Close() // #nosec G307
-	err = report.CreateReport(outfile, format, false, rootPaths, reportInfo)
-	if err != nil {
-		return err
-	}
-	return nil
+	return report.CreateReport(outfile, format, false, rootPaths, reportInfo)
 }
 
 func convertToScore(value string) (issue.Score, error) {


### PR DESCRIPTION
- Remove redundant error handling patterns in printReport and saveReport
- Directly return report.CreateReport results instead of if-else blocks
- Maintain functionality while improving code readability