### PR TITLE
docs: add G116 rule description to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ directory you can supply `./...` as the input argument.
 - G112: Potential slowloris attack
 - G114: Use of net/http serve function that has no support for setting timeouts
 - G115: Potential integer overflow when converting between integer types
+- G116: Detect Trojan Source attacks using bidirectional Unicode control characters
 - G201: SQL query construction using format string
 - G202: SQL query construction using string concatenation
 - G203: Use of unescaped data in HTML templates


### PR DESCRIPTION
### Description
Add missing G116 rule description to README's Available rules section.
The G116 rule was added in #1431 but the README was not updated.

Sorry for forgetting to include this in #1431.