### PR TITLE
G115: Enhance RangeAnalyzer with constant propagation and chained arithmetic support

### DIFF
--- a/analyzers/util.go
+++ b/analyzers/util.go
@@ -520,38 +520,44 @@ type operationInfo struct {
 	flipped bool
 }
 
-// minBounds computes the minimum of two uint64 values, treating them as signed if !isSrcUnsigned.
-func minBounds(a, b uint64, isSrcUnsigned bool) uint64 {
+// minBounds computes the minimum of two uint64 values, considering whether they are set and treating them as signed if !isSrcUnsigned.
+func minBounds(aVal uint64, aSet bool, bVal uint64, bSet bool, isSrcUnsigned bool) uint64 {
+	if !aSet {
+		return bVal
+	}
+	if !bSet {
+		return aVal
+	}
 	if !isSrcUnsigned {
-		if toInt64(a) < toInt64(b) {
-			return a
+		if toInt64(aVal) < toInt64(bVal) {
+			return aVal
 		}
-		return b
+		return bVal
 	}
-	if a < b {
-		return a
+	if aVal < bVal {
+		return aVal
 	}
-	return b
+	return bVal
 }
 
-// maxBounds computes the maximum of two uint64 values, treating them as signed if !isSrcUnsigned.
-func maxBounds(a, b uint64, isSrcUnsigned bool) uint64 {
-	if a == toUint64(minInt64) { // Using MinInt64 as "not set" for signed-capable minValue
-		return b
+// maxBounds computes the maximum of two uint64 values, considering whether they are set and treating them as signed if !isSrcUnsigned.
+func maxBounds(aVal uint64, aSet bool, bVal uint64, bSet bool, isSrcUnsigned bool) uint64 {
+	if !aSet {
+		return bVal
 	}
-	if b == toUint64(minInt64) {
-		return a
+	if !bSet {
+		return aVal
 	}
 	if !isSrcUnsigned {
-		if toInt64(a) > toInt64(b) {
-			return a
+		if toInt64(aVal) > toInt64(bVal) {
+			return aVal
 		}
-		return b
+		return bVal
 	}
-	if a > b {
-		return a
+	if aVal > bVal {
+		return aVal
 	}
-	return b
+	return bVal
 }
 
 // isUint checks if the value's type is an unsigned integer.

--- a/testutils/g115_samples.go
+++ b/testutils/g115_samples.go
@@ -1729,6 +1729,49 @@ import (
 )
 func main() {
 	val := rand.Int()
+	val8 := -val
+	if val8 >= -129 && val8 < -1 { // -129 is not representable in int8
+		v := int8(val8)
+		fmt.Println(uint(-v))
+	}
+}
+`}, 1, gosec.NewConfig()},
+	{[]string{`
+package main
+import (
+	"fmt"
+	"math/rand"
+)
+func main() {
+	val8 := rand.Int()
+	if val8 < 128 && val8 >= 0 {
+		v := int8(val8)
+		fmt.Println(uint(v))
+	}
+}
+`}, 0, gosec.NewConfig()},
+	{[]string{`
+package main
+import (
+	"fmt"
+	"math/rand"
+)
+func main() {
+	val8 := rand.Int()
+	if val8 < 129 && val8 >= 0 { // 128 is not representable in int8
+		v := int8(val8)
+		fmt.Println(uint(v))
+	}
+}
+`}, 1, gosec.NewConfig()},
+	{[]string{`
+package main
+import (
+	"fmt"
+	"math/rand"
+)
+func main() {
+	val := rand.Int()
 	val16 := -val
 	if val16 > -10 && val16 < -1 {
 		v := int16(val16)


### PR DESCRIPTION
While fixing the `#nosec` detection I  noticed that it shouldn't trigger in the first place since the value is known, but we have to track it properly.

https://github.com/securego/gosec/issues/1240
https://github.com/securego/gosec/pull/1467

This fixes it.