### PR TITLE
fix: optimize nosec directive parsing to avoid allocations

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -29,7 +29,6 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
-	"regexp"
 	"runtime/debug"
 	"strconv"
 	"strings"
@@ -45,6 +44,11 @@ import (
 	"github.com/securego/gosec/v2/issue"
 )
 
+var (
+	ErrNoPackageTypeInfo = errors.New("package has no type information")
+	ErrNilPackage        = errors.New("nil package provided")
+)
+
 // LoadMode controls the amount of details to return when loading the packages
 const LoadMode = packages.NeedName |
 	packages.NeedFiles |
@@ -58,11 +62,11 @@ const LoadMode = packages.NeedName |
 	packages.NeedEmbedFiles |
 	packages.NeedEmbedPatterns
 
-const externalSuppressionJustification = "Globally suppressed."
-
-const aliasOfAllRules = "*"
-
-var directiveRegexp = regexp.MustCompile("^//gosec:disable(?: (.+))?$")
+const (
+	externalSuppressionJustification = "Globally suppressed."
+	aliasOfAllRules                  = "*"
+	directivePrefix                  = "//gosec:disable"
+)
 
 type ignore struct {
 	start        int
@@ -144,7 +148,6 @@ func (i ignores) get(file string, line string) map[string][]issue.SuppressionInf
 type Context struct {
 	FileSet      *token.FileSet
 	Comments     ast.CommentMap
-	AllComments  []*ast.CommentGroup // All comments in the file for line-based nosec lookup (fix for #1240)
 	Info         *types.Info
 	Pkg          *types.Package
 	PkgFiles     []*ast.File
@@ -153,6 +156,7 @@ type Context struct {
 	Config       Config
 	Ignores      ignores
 	PassedValues map[string]any
+	callCache    map[ast.Node]callInfo
 }
 
 // GetFileAtNodePos returns the file at the node position in the file set available in the context.
@@ -445,6 +449,12 @@ func (gosec *Analyzer) checkRules(pkg *packages.Package) ([]*issue.Issue, *Metri
 	stats := &Metrics{}
 	allIgnores := newIgnores()
 
+	callCache := callCachePool.Get().(map[ast.Node]callInfo)
+	defer func() {
+		clear(callCache)
+		callCachePool.Put(callCache)
+	}()
+
 	visitor := &astVisitor{
 		gosec:             gosec,
 		issues:            make([]*issue.Issue, 0, 16),
@@ -476,13 +486,13 @@ func (gosec *Analyzer) checkRules(pkg *packages.Package) ([]*issue.Issue, *Metri
 			FileSet:      pkg.Fset,
 			Config:       gosec.config,
 			Comments:     ast.NewCommentMap(pkg.Fset, file, file.Comments),
-			AllComments:  file.Comments, // Store all comments for line-based lookup (fix for #1240)
 			Root:         file,
 			Info:         pkg.TypesInfo,
 			Pkg:          pkg.Types,
 			PkgFiles:     pkg.Syntax,
 			Imports:      NewImportTracker(),
 			PassedValues: make(map[string]any),
+			callCache:    callCache,
 		}
 
 		visitor.context = ctx
@@ -624,13 +634,13 @@ func (gosec *Analyzer) buildSSA(pkg *packages.Package) (*buildssa.SSA, error) {
 		}
 	}()
 	if pkg == nil {
-		return nil, errors.New("nil package provided")
+		return nil, ErrNilPackage
 	}
 	if pkg.Types == nil {
 		return nil, fmt.Errorf("package %s has no type information (compilation failed?)", pkg.Name)
 	}
 	if pkg.TypesInfo == nil {
-		return nil, fmt.Errorf("package %s has no type information", pkg.Name)
+		return nil, fmt.Errorf("%w: %s", ErrNoPackageTypeInfo, pkg.Name)
 	}
 	pass := &analysis.Pass{
 		Fset:             pkg.Fset,
@@ -721,30 +731,52 @@ func (gosec *Analyzer) AppendError(file string, err error) {
 // findNoSecDirective checks if the comment group contains `#nosec` or `//gosec:disable` directive.
 // If found, it returns true and the directive's arguments.
 func findNoSecDirective(group *ast.CommentGroup, noSecDefaultTag, noSecAlternativeTag string) (bool, string) {
-	// Check if the comment grounp has a nosec comment.
+	if group == nil {
+		return false, ""
+	}
+
+	// Join all comments in the group once to support multi-line nosec tags
+	text := group.Text()
+
+	// Check for nosec tags
 	for _, tag := range []string{noSecDefaultTag, noSecAlternativeTag} {
-		if found, args := findNoSecTag(group, tag); found {
+		if found, args := findNoSecTag(text, tag); found {
 			return true, args
 		}
 	}
 
-	// Check if the comment group has a directive comment.
+	// Check for directive comments individually
 	for _, c := range group.List {
-		match := directiveRegexp.FindStringSubmatch(c.Text)
-		if len(match) > 0 {
-			return true, match[0]
+		if after, ok := strings.CutPrefix(c.Text, directivePrefix); ok {
+			if len(after) == 0 || after[0] == ' ' {
+				return true, strings.TrimSpace(after)
+			}
 		}
 	}
 
 	return false, ""
 }
 
-func findNoSecTag(group *ast.CommentGroup, tag string) (bool, string) {
-	comment := strings.TrimSpace(group.Text())
+func findNoSecTag(text, tag string) (bool, string) {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return false, ""
+	}
 
-	if strings.HasPrefix(comment, tag) || regexp.MustCompile("\n *"+tag).MatchString(comment) {
-		// Discard what's in front of the nosec tag.
-		return true, strings.SplitN(comment, tag, 2)[1]
+	if strings.HasPrefix(text, tag) {
+		return true, text[len(tag):]
+	}
+
+	if idx := strings.Index(text, tag); idx > 0 {
+		// Check if it's at the beginning of a line (possibly with space)
+		for i := idx - 1; i >= 0; i-- {
+			if text[i] == '\n' {
+				return true, text[idx+len(tag):]
+			}
+			if text[i] != ' ' && text[i] != '\t' {
+				break
+			}
+		}
 	}
 
 	return false, ""
@@ -788,52 +820,48 @@ func (v *astVisitor) updateIgnores() {
 
 // updateIgnoredRulesForNode parses comments for a specific node and updates ignored rules.
 func (v *astVisitor) updateIgnoredRulesForNode(n ast.Node) {
-	ignoredRules := v.ignore(n)
+	ignoredRules, group := v.ignore(n)
 	if len(ignoredRules) > 0 {
 		if v.context.Ignores == nil {
 			v.context.Ignores = newIgnores()
 		}
-		line := issue.GetLine(v.context.FileSet.File(n.Pos()), n)
+
+		// Calculate the range to include both the node and the comment group
+		// This handles cases where the comment is associated with a subsequent node
+		// but we still want to ignore the line where the comment is located.
+		startPos := n.Pos()
+		endPos := n.End()
+		if group != nil {
+			if group.Pos() < startPos {
+				startPos = group.Pos()
+			}
+			if group.End() > endPos {
+				endPos = group.End()
+			}
+		}
+
+		startLine := v.context.FileSet.File(startPos).Line(startPos)
+		endLine := v.context.FileSet.File(endPos).Line(endPos)
+		line := strconv.Itoa(startLine)
+		if startLine != endLine {
+			line = fmt.Sprintf("%d-%d", startLine, endLine)
+		}
 		v.context.Ignores.add(
-			v.context.FileSet.File(n.Pos()).Name(),
+			v.context.FileSet.File(startPos).Name(),
 			line,
 			ignoredRules,
 		)
 	}
 }
 
-// parseNoSecDirective extracts rules and justification from nosec directive arguments
-func parseNoSecDirective(args string) map[string]issue.SuppressionInfo {
-	justification := ""
-	commentParts := regexp.MustCompile(`-{2,}`).Split(args, 2)
-	directive := commentParts[0]
-	if len(commentParts) > 1 {
-		justification = strings.TrimSpace(strings.TrimRight(commentParts[1], "\n"))
-	}
-
-	re := regexp.MustCompile(`(G\d{3})`)
-	matches := re.FindAllStringSubmatch(directive, -1)
-
-	suppression := issue.SuppressionInfo{
-		Kind:          "inSource",
-		Justification: justification,
-	}
-
-	ignores := make(map[string]issue.SuppressionInfo)
-	if len(matches) == 0 {
-		ignores[aliasOfAllRules] = suppression
-	} else {
-		for _, v := range matches {
-			ignores[v[1]] = suppression
-		}
-	}
-	return ignores
-}
-
 // ignore checks if a node is tagged with a nosec comment and returns the suppressed rules.
-func (v *astVisitor) ignore(n ast.Node) map[string]issue.SuppressionInfo {
+func (v *astVisitor) ignore(n ast.Node) (map[string]issue.SuppressionInfo, *ast.CommentGroup) {
 	if v.ignoreNosec {
-		return nil
+		return nil, nil
+	}
+	groups, ok := v.context.Comments[n]
+	if !ok {
+		return nil, nil
 	}
 
 	noSecDefaultTag, err := v.gosec.config.GetGlobal(Nosec)
@@ -849,57 +877,62 @@ func (v *astVisitor) ignore(n ast.Node) map[string]issue.SuppressionInfo {
 		noSecAlternativeTag = NoSecTag(noSecAlternativeTag)
 	}
 
-	// First, try the existing AST CommentMap lookup
-	groups, ok := v.context.Comments[n]
-	if ok {
-		for _, group := range groups {
-			found, args := findNoSecDirective(group, noSecDefaultTag, noSecAlternativeTag)
-			if !found {
-				continue
-			}
-			v.stats.NumNosec++
-			return parseNoSecDirective(args)
+	for _, group := range groups {
+		found, args := findNoSecDirective(group, noSecDefaultTag, noSecAlternativeTag)
+		if !found {
+			continue
 		}
-	}
+		v.stats.NumNosec++
 
-	// FIX FOR ISSUE #1240:
-	// If not found in CommentMap, check all comments on the same line.
-	// This handles the case where the comment is associated with a parent node
-	// (like IfStmt or BlockStmt) instead of the specific expression that
-	// triggers the rule (like a type conversion CallExpr).
-	//
-	// Go's ast.CommentMap associates comments with the "largest" node on the
-	// same line. For example:
-	//     if len(x) <= int(y) { // #nosec G115
-	// The comment gets associated with the IfStmt, not the int(y) CallExpr.
-	// This fallback ensures the nosec still applies to the conversion.
-	if v.context.FileSet != nil && n != nil && v.context.AllComments != nil {
-		nodePos := v.context.FileSet.Position(n.Pos())
-		nodeEndPos := v.context.FileSet.Position(n.End())
+		justification := ""
+		if idx := strings.Index(args, "--"); idx > -1 {
+			justification = strings.TrimSpace(strings.TrimLeft(args[idx+2:], "-"))
+			args = args[:idx]
+		}
 
-		for _, group := range v.context.AllComments {
-			if group == nil {
-				continue
-			}
+		directive := strings.TrimSpace(args)
+		// If the directive is empty or contains "block" (legacy), ignore all rules
+		if len(directive) == 0 || directive == "block" {
+			return map[string]issue.SuppressionInfo{
+				aliasOfAllRules: {
+					Kind:          "inSource",
+					Justification: justification,
+				},
+			}, group
+		}
 
-			for _, comment := range group.List {
-				commentPos := v.context.FileSet.Position(comment.Pos())
+		ignores := make(map[string]issue.SuppressionInfo)
+		suppression := issue.SuppressionInfo{
+			Kind:          "inSource",
+			Justification: justification,
+		}
 
-				// Check if the comment is on the same line as the node
-				// (either where it starts or ends, to handle multi-line nodes)
-				if commentPos.Line == nodePos.Line || commentPos.Line == nodeEndPos.Line {
-					found, args := findNoSecDirective(group, noSecDefaultTag, noSecAlternativeTag)
-					if !found {
-						continue
+		// Manually parse identifiers starting with 'G' followed by 3 digits
+		for i := 0; i < len(directive); {
+			if directive[i] == 'G' && i+4 <= len(directive) {
+				ruleID := directive[i : i+4]
+				valid := true
+				for j := 1; j < 4; j++ {
+					if directive[i+j] < '0' || directive[i+j] > '9' {
+						valid = false
+						break
 					}
-					v.stats.NumNosec++
-					return parseNoSecDirective(args)
+				}
+				if valid {
+					ignores[ruleID] = suppression
+					i += 4
+					continue
 				}
 			}
+			i++
 		}
-	}
 
-	return nil
+		if len(ignores) == 0 {
+			ignores[aliasOfAllRules] = suppression
+		}
+		return ignores, group
+	}
+	return nil, nil
 }
 
 // updateIssues updates the issues list with the given issue, handling suppressions.

--- a/analyzers/util.go
+++ b/analyzers/util.go
@@ -15,6 +15,7 @@
 package analyzers
 
 import (
+	"errors"
 	"fmt"
 	"go/constant"
 	"go/token"
@@ -60,6 +61,11 @@ type BaseAnalyzerState struct {
 	ClosureCache map[ssa.Value]bool
 	Depth        int
 }
+
+var (
+	ErrNoSSAResult    = errors.New("no SSA result found in the analysis pass")
+	ErrInvalidSSAType = errors.New("the analysis pass result is not of type SSA")
+)
 
 var (
 	visitedPool = sync.Pool{
@@ -199,11 +205,11 @@ func BuildDefaultAnalyzers() []*analysis.Analyzer {
 func getSSAResult(pass *analysis.Pass) (*SSAAnalyzerResult, error) {
 	result, ok := pass.ResultOf[buildssa.Analyzer]
 	if !ok {
-		return nil, fmt.Errorf("no SSA result found in the analysis pass")
+		return nil, ErrNoSSAResult
 	}
 	ssaResult, ok := result.(*SSAAnalyzerResult)
 	if !ok {
-		return nil, fmt.Errorf("the analysis pass result is not of type SSA")
+		return nil, ErrInvalidSSAType
 	}
 	return ssaResult, nil
 }

--- a/helpers.go
+++ b/helpers.go
@@ -33,6 +33,12 @@ import (
 	"sync"
 )
 
+var (
+	ErrUnexpectedASTNode     = errors.New("unexpected AST node type")
+	ErrNoProjectRelativePath = errors.New("no project relative path found")
+	ErrNoProjectAbsolutePath = errors.New("no project absolute path found")
+)
+
 // envGoModVersion overrides the Go version detection.
 const envGoModVersion = "GOSECGOVERSION"
 
@@ -84,7 +90,7 @@ func GetInt(n ast.Node) (int64, error) {
 	if node, ok := n.(*ast.BasicLit); ok && node.Kind == token.INT {
 		return strconv.ParseInt(node.Value, 0, 64)
 	}
-	return 0, fmt.Errorf("unexpected AST node type: %T", n)
+	return 0, fmt.Errorf("%w: %T", ErrUnexpectedASTNode, n)
 }
 
 // GetFloat will read and return a float value from an ast.BasicLit
@@ -92,7 +98,7 @@ func GetFloat(n ast.Node) (float64, error) {
 	if node, ok := n.(*ast.BasicLit); ok && node.Kind == token.FLOAT {
 		return strconv.ParseFloat(node.Value, 64)
 	}
-	return 0.0, fmt.Errorf("unexpected AST node type: %T", n)
+	return 0.0, fmt.Errorf("%w: %T", ErrUnexpectedASTNode, n)
 }
 
 // GetChar will read and return a char value from an ast.BasicLit
@@ -100,7 +106,7 @@ func GetChar(n ast.Node) (byte, error) {
 	if node, ok := n.(*ast.BasicLit); ok && node.Kind == token.CHAR {
 		return node.Value[0], nil
 	}
-	return 0, fmt.Errorf("unexpected AST node type: %T", n)
+	return 0, fmt.Errorf("%w: %T", ErrUnexpectedASTNode, n)
 }
 
 // GetStringRecursive will recursively walk down a tree of *ast.BinaryExpr. It will then concat the results, and return.
@@ -143,7 +149,7 @@ func GetString(n ast.Node) (string, error) {
 		return strconv.Unquote(node.Value)
 	}
 
-	return "", fmt.Errorf("unexpected AST node type: %T", n)
+	return "", fmt.Errorf("%w: %T", ErrUnexpectedASTNode, n)
 }
 
 // GetCallObject returns the object and call expression and associated
@@ -162,9 +168,35 @@ func GetCallObject(n ast.Node, ctx *Context) (*ast.CallExpr, types.Object) {
 	return nil, nil
 }
 
+type callInfo struct {
+	packageName string
+	funcName    string
+	err         error
+}
+
+var callCachePool = sync.Pool{
+	New: func() any {
+		return make(map[ast.Node]callInfo)
+	},
+}
+
 // GetCallInfo returns the package or type and name  associated with a
 // call expression.
 func GetCallInfo(n ast.Node, ctx *Context) (string, string, error) {
+	if ctx.callCache != nil {
+		if res, ok := ctx.callCache[n]; ok {
+			return res.packageName, res.funcName, res.err
+		}
+	}
+
+	packageName, funcName, err := getCallInfo(n, ctx)
+	if ctx.callCache != nil {
+		ctx.callCache[n] = callInfo{packageName, funcName, err}
+	}
+	return packageName, funcName, err
+}
+
+func getCallInfo(n ast.Node, ctx *Context) (string, string, error) {
 	switch node := n.(type) {
 	case *ast.CallExpr:
 		switch fn := node.Fun.(type) {
@@ -370,7 +402,7 @@ func GetPkgRelativePath(path string) (string, error) {
 			return strings.TrimPrefix(abspath, projectRoot), nil
 		}
 	}
-	return "", errors.New("no project relative path found")
+	return "", ErrNoProjectRelativePath
 }
 
 // GetPkgAbsPath returns the Go package absolute path derived from
@@ -381,7 +413,7 @@ func GetPkgAbsPath(pkgPath string) (string, error) {
 		return "", err
 	}
 	if _, err := os.Stat(absPath); os.IsNotExist(err) {
-		return "", errors.New("no project absolute path found")
+		return "", ErrNoProjectAbsolutePath
 	}
 	return absPath, nil
 }


### PR DESCRIPTION
Fixes https://github.com/securego/gosec/issues/1240
Split out from https://github.com/securego/gosec/pull/1467