### PR TITLE
Fix URL regexp and remove redundant Google regex patterns

### DIFF
--- a/rules/hardcoded_credentials.go
+++ b/rules/hardcoded_credentials.go
@@ -84,49 +84,25 @@ var secretsPatterns = [...]secretPattern{
 		regexp: regexp.MustCompile(`ghs_[a-zA-Z0-9]{36}`),
 	},
 	{
-		name:   "Google API Key",
+		name:   "Google API Key", // Also Google Cloud Platform, Gmail, Drive, YouTube, etc.
 		regexp: regexp.MustCompile(`AIza[0-9A-Za-z\-_]{35}`),
 	},
+
 	{
-		name:   "Google Cloud Platform API Key",
-		regexp: regexp.MustCompile(`AIza[0-9A-Za-z\-_]{35}`),
-	},
-	{
-		name:   "Google Cloud Platform OAuth",
+		name:   "Google Cloud Platform OAuth", // Also Gmail, Drive, YouTube, etc.
 		regexp: regexp.MustCompile(`[0-9]+-[0-9A-Za-z_]{32}\.apps\.googleusercontent\.com`),
 	},
-	{
-		name:   "Google Drive API Key",
-		regexp: regexp.MustCompile(`AIza[0-9A-Za-z\-_]{35}`),
-	},
-	{
-		name:   "Google Drive OAuth",
-		regexp: regexp.MustCompile(`[0-9]+-[0-9A-Za-z_]{32}\.apps\.googleusercontent\.com`),
-	},
+
 	{
 		name:   "Google (GCP) Service-account",
 		regexp: regexp.MustCompile(`"type": "service_account"`),
 	},
-	{
-		name:   "Google Gmail API Key",
-		regexp: regexp.MustCompile(`AIza[0-9A-Za-z\-_]{35}`),
-	},
-	{
-		name:   "Google Gmail OAuth",
-		regexp: regexp.MustCompile(`[0-9]+-[0-9A-Za-z_]{32}\.apps\.googleusercontent\.com`),
-	},
+
 	{
 		name:   "Google OAuth Access Token",
 		regexp: regexp.MustCompile(`ya29\.[0-9A-Za-z\-_]+`),
 	},
-	{
-		name:   "Google YouTube API Key",
-		regexp: regexp.MustCompile(`AIza[0-9A-Za-z\-_]{35}`),
-	},
-	{
-		name:   "Google YouTube OAuth",
-		regexp: regexp.MustCompile(`[0-9]+-[0-9A-Za-z_]{32}\.apps\.googleusercontent\.com`),
-	},
+
 	{
 		name:   "Generic API Key",
 		regexp: regexp.MustCompile(`[aA][pP][iI]_?[kK][eE][yY].*[''|"][0-9a-zA-Z]{32,45}[''|"]`),
@@ -149,7 +125,7 @@ var secretsPatterns = [...]secretPattern{
 	},
 	{
 		name:   "Password in URL",
-		regexp: regexp.MustCompile(`[a-zA-Z]{3,10}://[^/\\s:@]{3,20}:[^/\\s:@]{3,20}@.{1,100}["'\\s]`),
+		regexp: regexp.MustCompile(`[a-zA-Z]{3,10}://[a-zA-Z0-9\.\-\_\+]{1,64}:[a-zA-Z0-9\.\-\_\!\$\%\&\*\+\=\^\(\)]{1,128}@[a-zA-Z0-9\.\-\_]+(:[0-9]+)?(/[^"'\s]*)?(["'\s]|$)`),
 	},
 	{
 		name:   "Slack Webhook",

--- a/testutils/g101_samples.go
+++ b/testutils/g101_samples.go
@@ -512,8 +512,8 @@ package main
 import "fmt"
 
 func main() {
-	urlSecret := "https://username:abcdef0123456789abcdef0123456789abcdef01@contoso.com/"
-	fmt.Println(urlSecret)
+	url := "https://username:abcdef0123456789abcdef0123456789abcdef01@contoso.com/"
+	fmt.Println(url)
 }
 `}, 1, gosec.NewConfig()},
 		{[]string{`


### PR DESCRIPTION
The URL regex was previously broken but the test passed because "Secret" matched from the key and the Zxcvbn entropy was high enough. If the default truncate length would have been increased from 16 to something higher the test wouldn't have  passed since Zxcvbn would have detected the repeated pattern.