### PR TITLE
reduce false positives: improve hardcoded credential detection

### DIFF
--- a/testutils/g101_samples.go
+++ b/testutils/g101_samples.go
@@ -482,6 +482,73 @@ func main() {
 	_ = []string{"f62e5bcda4fae4f82370da0c6f20697b8f8447ef"} // unkeyed – no trigger
 }
 `}, 0, gosec.NewConfig()},
+		{[]string{`
+package main
+
+func main() {
+	secret := "dXNlcjpwYXNzd29yZDEh" // base64 encoded user:password1!
+	_ = secret
+}
+`}, 1, gosec.NewConfig()},
+		{[]string{`
+package main
+
+func main() {
+	secret := "Päs5wörd!" // non-ascii
+	_ = secret
+}
+`}, 1, gosec.NewConfig()},
+		{[]string{`
+package main
+
+func main() {
+	setSqlPasswordStmt := "ALTER USER 'root' IDENTIFIED BY 'f62e5bcda4fae4f82370da0c6f20697b8f8447ef'"
+	_ = setSqlPasswordStmt
+}
+`}, 1, gosec.NewConfig()},
+		{[]string{`
+package main
+
+func main() {
+	urlWithCredentials := "http://example.com/path/to/resource?secret=c9d386ea-fa95-4a7d-9c9a-ce9ff35396b3"
+	_ = urlWithCredentials
+}
+`}, 1, gosec.NewConfig()},
+		{[]string{`
+package main
+
+func main() {
+	urlWithoutCredentials := "http://example.com/path/to/resource"
+	_ = urlWithoutCredentials
+}
+`}, 0, gosec.NewConfig()},
+		{[]string{`
+package main
+
+func main() {
+	envPostgreSQLPassword := "POSTGRESQL_PASSWORD"
+	envPostgreSQLPasswordDesc := "The password for the postgresql user"
+	_ = envPostgreSQLPassword
+	_ = envPostgreSQLPasswordDesc
+}
+`}, 0, gosec.NewConfig()},
+
+		{[]string{`
+package main
+
+func main() {
+	setSqlPasswordStmt := "ALTER USER 'root' IDENTIFIED BY ?"
+	_ = setSqlPasswordStmt
+}
+`}, 0, gosec.NewConfig()},
+		{[]string{`
+package main
+
+func main() {
+	setSqlPasswordStmt := "SET PASSWORD FOR 'root'@'localhost' = ?"
+	_ = setSqlPasswordStmt
+}
+`}, 0, gosec.NewConfig()},
 	}
 
 	// SampleCodeG101Values code snippets for hardcoded credentials


### PR DESCRIPTION
I'll set this to draft as there's some pretty weird stuff going on and you guys might want to test it yourself against some code bases you know well.

Summary of how this was done

0. Slight refactor of `rules/hardcoded_credentials.go`. After that all the match functions call wrapper `isCredential()` instead of implementing the test logic individually. The only real change is a call to `isFalsePositive()` that just returned `false` at first (no real change in functionality this far).
1. `./gosec -nosec -include G101 -quiet -fmt json /path/to/sources/...` to gather results from popular Go projects with decently large code bases.
2. Manually sort results to `rules/testdata/hardcoded_credentials/false_positives` and `rules/testdata/hardcoded_credentials/true_positives`.
3. Run the `clean_json.py` against all the gathered JSON-files.
4. Add some custom false positives and true positives so the LLMs don't just hard code random words to be always ignored and so on. For example custom true positive: `"code": "\tprodEnvCredential = \"dXNlcjpwYXNzd29yZDEh\" // base64 encoded user:password1!"` because the real code bases had false positives like `"code": "\tenvGithubToken  = \"GITHUB_TOKEN\""` -> do not blindly ignore if key has "env"
5. Tell Claude Opus 4.5 (thinking) and Gemini 3 Pro (high) agents to run `go test -v ./rules -run TestHardcodedCredentials` and figure out patterns to filter out false positives only by modifying `isFalsePositive()` function.
6. Every now and then manually remove slop and tell the agents which changes looked promising. Repeat step 5. until all the tests pass.
7. Final cleanup. For example
 - Extracting code (repeated or just making isFalsePositive a bit more readable) to own functions
 - Adding `analyzeToken()` function to remove around 20 full scans with `strings.Contains()` in the hot path.
 - Shannon entropy calculation is used in complex structures due to it's speed. More advanced Zxcvbn has already detected high entropy and Shannon entropy basically provides an upper limit and filters out non-interesting strings fast. 
 
Having a custom fast test function was pretty helpful since the relatively heavy ./testutils/ could be used as a sanity check quite rarely. I don't know if the other tests are as noisy with false positives as hardcoded credentials / G101, but this method can probably used elsewhere. Maybe G104 (unhandled errors) still has a lot of calls that are deemed safe and you don't have to manually check returned errors?

Especially Kubernetes has some pretty wild stuff going on within the its code base like the following. Basically all the weird stuff you see in this change are because of Kubernetes :)

kubernetes/staging/src/k8s.io/api/core/v1/generated.pb.go:
```go
       repeatedStringForImagePullSecrets := "[]LocalObjectReference{"
```

Here's the full list of projects used to build this change.
```
cockroach
etcd
gitea
kubernetes
mattermost-server
minio
moby
terraform
vitess
```

clean_json.py - it extracts the important parts from the JSON and also tries to fix some minor copy & paste errors
```python
#!/usr/bin/env python3
import json
import re
import sys
import os

def parse_line_range(line_str):
    line_str = str(line_str).strip()
    if "-" in line_str:
        start, end = line_str.split("-")
        return int(start), int(end)
    else:
        val = int(line_str)
        return val, val

def clean_code(code_snippet, target_range):
    lines = code_snippet.split("\n")
    cleaned_lines = []
    start_target, end_target = target_range
    
    for line in lines:
        # Regex to match optional whitespace, digits, colon, and capturing the rest
        # matches "41: content" or " 41: content"
        m = re.match(r"^\s*(\d+):\s?(.*)", line)
        if m:
            line_num = int(m.group(1))
            content = m.group(2)
            
            # The user wants ONLY the lines specified in the range. 
            if start_target <= line_num <= end_target:
                cleaned_lines.append(content)
            
    return "\n".join(cleaned_lines)

def process_file(fpath):
    try:
        with open(fpath, "r") as f:
            content = f.read().strip()
        
        # 1. Basic formatting fixes for copied content
        # Remove trailing dot if present (artifact from copy-paste)
        content = content.rstrip(".")

        # 2. Heuristic wrappers if it's just a fragment
        if content.startswith("\"Issues\":") or content.startswith("Issues:"):
             content = "{" + content + "}"
        elif content.lstrip().startswith("\"Issues\":"): 
             content = "{" + content + "}"
        
        # 3. Handle Trailing Commas (common in manual JSON edits)
        # Regex to remove trailing commas before closing braces/brackets
        # formatting: , }  -> }   and , ] -> ]
        content = re.sub(r",\s*([\]}])", r"\1", content)

        # 4. Wrap in object if it looks like a list but contains "Issues" key implied? 
        # Actually proper Gosec output is {"Issues": [...]}. 
        # Sometimes users paste just [ ... ] which is also fine if we treat it as the list.
        if not content.startswith("{") and not content.startswith("[") and "Issues" in content:
             content = "{" + content + "}"

        data = json.loads(content)
        
        # Extract issues list
        issues = []
        if isinstance(data, dict):
             # Case-insensitive key lookup for "Issues" or "issues"
             for k, v in data.items():
                 if k.lower() == "issues":
                     issues = v
                     break
        elif isinstance(data, list):
            issues = data
        
        cleaned_issues = []
        for i in issues:
            if "code" in i:
                cleaned = ""
                if "line" in i:
                    try:
                        target = parse_line_range(i["line"])
                        cleaned = clean_code(i["code"], target)
                    except Exception as e:
                        print(f"[{fpath}] Warning parsing line range '{i['line']}': {e}")
                        # Attempt to clean line numbers at least:
                        cleaned = "\n".join([re.sub(r"^\s*\d+:\s?", "", l) for l in i["code"].split("\n")])
                else:
                    # If 'line' is missing, strip line numbers from all lines
                    cleaned = "\n".join([re.sub(r"^\s*\d+:\s?", "", l) for l in i["code"].split("\n")])

                if cleaned:
                    cleaned_issues.append({"code": cleaned})
        
        with open(fpath, "w") as f:
            json.dump(cleaned_issues, f, indent=4)
            
        print(f"Successfully processed {fpath}")
        
    except json.JSONDecodeError as e:
        print(f"JSON Error in {fpath}: {e}")
    except Exception as e:
        print(f"Error processing {fpath}: {e}")

if __name__ == "__main__":
    if len(sys.argv) < 2:
        print("Usage: python3 clean_json.py <file1> <file2> ...")
        sys.exit(1)

    files = sys.argv[1:]

    for f in files:
        if os.path.exists(f):
            process_file(f)
        else:
            print(f"File not found: {f}")

```

rules/hardcoded_credentials_test.go
```go
package rules

import (
	"encoding/json"
	"fmt"
	"go/ast"
	"go/parser"
	"go/token"
	"os"
	"path/filepath"
	"testing"

	"github.com/securego/gosec/v2"
)

type testCase struct {
	Code string `json:"code"`
}

type credentialCandidate struct {
	name  string
	value string
}

func parseCode(code string) ([]credentialCandidate, error) {
	var candidates []credentialCandidate

	extract := func(node ast.Node) bool {
		switch node := node.(type) {
		case *ast.AssignStmt:
			for _, i := range node.Lhs {
				if ident, ok := i.(*ast.Ident); ok {
					for _, e := range node.Rhs {
						if val, err := gosec.GetString(e); err == nil {
							candidates = append(candidates, credentialCandidate{ident.Name, val})
						}
					}
				}
			}
		case *ast.ValueSpec:
			for index, ident := range node.Names {
				if node.Values != nil {
					idx := index
					if len(node.Values) <= idx {
						idx = len(node.Values) - 1
					}
					if val, err := gosec.GetString(node.Values[idx]); err == nil {
						candidates = append(candidates, credentialCandidate{ident.Name, val})
					}
				}
			}
		case *ast.CompositeLit:
			for _, elt := range node.Elts {
				if kv, ok := elt.(*ast.KeyValueExpr); ok {
					varName := ""
					if ident, ok := kv.Key.(*ast.Ident); ok {
						varName = ident.Name
					} else if keyStr, err := gosec.GetString(kv.Key); err == nil {
						varName = keyStr
					}

					if val, err := gosec.GetString(kv.Value); err == nil {
						candidates = append(candidates, credentialCandidate{varName, val})
					}
				}
			}
		case *ast.BinaryExpr:
			if node.Op == token.EQL || node.Op == token.NEQ {
				ident, ok := node.X.(*ast.Ident)
				if !ok {
					ident, _ = node.Y.(*ast.Ident)
				}

				var valueNode ast.Node
				if _, ok := node.X.(*ast.BasicLit); ok {
					valueNode = node.X
				} else if _, ok := node.Y.(*ast.BasicLit); ok {
					valueNode = node.Y
				}

				if valueNode != nil {
					if val, err := gosec.GetString(valueNode); err == nil {
						varName := ""
						if ident != nil {
							varName = ident.Name
						}
						candidates = append(candidates, credentialCandidate{varName, val})
					}
				}
			}
		}
		return true
	}

	attempts := []string{
		fmt.Sprintf("package main\nfunc function() {\n%s\n}", code),
		fmt.Sprintf("package main\n%s", code),
		fmt.Sprintf("package main\nvar (\n%s\n)", code),
		fmt.Sprintf("package main\nconst (\n%s\n)", code),
		fmt.Sprintf("package main\nvar _ = map[string]interface{}{\n%s\n}", code),
	}

	for _, src := range attempts {
		fset := token.NewFileSet()
		f, err := parser.ParseFile(fset, "", src, parser.ParseComments)
		if err == nil {
			ast.Inspect(f, extract)
			return candidates, nil
		}
	}
	return nil, fmt.Errorf("failed to parse code")
}

func TestHardcodedCredentials(t *testing.T) {
	rule, _ := NewHardcodedCredentials("G101", gosec.Config{})
	credRule, ok := rule.(*credentials)
	if !ok {
		t.Fatal("Rule is not of type *credentials")
	}

	loadCases := func(dir string) ([]testCase, error) {
		var cases []testCase
		files, err := filepath.Glob(filepath.Join("testdata/hardcoded_credentials", dir, "*.json"))
		if err != nil {
			return nil, err
		}
		for _, file := range files {
			data, err := os.ReadFile(file)
			if err != nil {
				return nil, err
			}
			var fileCases []testCase
			if err := json.Unmarshal(data, &fileCases); err != nil {
				return nil, fmt.Errorf("failed to parse %s: %w", file, err)
			}
			cases = append(cases, fileCases...)
		}
		return cases, nil
	}

	t.Run("TruePositives", func(t *testing.T) {
		cases, err := loadCases("true_positives")
		if err != nil {
			t.Fatal(err)
		}
		for _, c := range cases {
			candidates, err := parseCode(c.Code)
			if err != nil {
				t.Errorf("Failed to parse code: %s, error: %v", c.Code, err)
				continue
			}
			found := false
			for _, cand := range candidates {
				if _, ok := credRule.isCredential(cand.name, cand.value); ok {
					found = true
					break
				}
			}
			if !found {
				t.Errorf("Expected credential to be detected in: %s", c.Code)
			}
		}
	})

	t.Run("FalsePositives", func(t *testing.T) {
		cases, err := loadCases("false_positives")
		if err != nil {
			t.Fatal(err)
		}
		for _, c := range cases {
			candidates, err := parseCode(c.Code)
			if err != nil {
				// Don't fail hard on parse error for all, but maybe log it?
				// Some snippets might be genuinely partial/broken.
				// For now let's log and fail the test case to see what's wrong.
				t.Errorf("Failed to parse code: %s, error: %v", c.Code, err)
				continue
			}
			for _, cand := range candidates {
				if match, ok := credRule.isCredential(cand.name, cand.value); ok {
					t.Errorf("False positive detected: %s (match: %s) in code: %s. Value: %q", cand.name, match, c.Code, cand.value)
				}
			}
		}
	})
}

```