### PR TITLE
update go version to 1.25.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     strategy:
       matrix:
         version:
-          - go-version: "1.24.12"
+          - go-version: "1.24.13"
             golangci: "latest"
-          - go-version: "1.25.6"
+          - go-version: "1.25.7"
             golangci: "latest"
     runs-on: ubuntu-latest
     env:
@@ -52,7 +52,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
       - name: Checkout Source
         uses: actions/checkout@v6
       - uses: actions/cache@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3
         with:


### PR DESCRIPTION
fixes: https://github.com/securego/gosec/issues/1490

**Note:**
Go 1.24.12 has a known crypto/tls vulnerability (CVE-2025-68121 - TLS session resumption authentication bypass via `Config.GetConfigForClient`), which was patched in Go 1.24.13. Hence with this upgrade, we need this change too.