### PR TITLE
fix: panic when scanning multi-module repos from root

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -420,11 +420,15 @@ func (gosec *Analyzer) load(pkgPath string, buildTags []string) ([]*packages.Pac
 		}
 	}
 
-	// step 2/2: pass in cli encoded build flags to build correctly.
+	// step 2/2: pass in cli encoded build flags to build correctly,
+	// and set Dir to the module root of the package being loaded.
 	conf := &packages.Config{
 		Mode:       LoadMode,
 		BuildFlags: CLIBuildTags(buildTags),
 		Tests:      gosec.tests,
+	}
+	if modRoot := FindModuleRoot(abspath); modRoot != "" {
+		conf.Dir = modRoot
 	}
 	pkgs, err := packages.Load(conf, packageFiles...)
 	if err != nil {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -369,7 +369,7 @@ var _ = Describe("Helpers", func() {
 		It("should find go.mod in parent directory", func() {
 			tmpDir := GinkgoT().TempDir()
 			gomodPath := filepath.Join(tmpDir, "go.mod")
-			err := os.WriteFile(gomodPath, []byte("module test\n"), 0o644)
+			err := os.WriteFile(gomodPath, []byte("module test\n"), 0o600)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			subDir := filepath.Join(tmpDir, "sub", "pkg")
@@ -383,14 +383,14 @@ var _ = Describe("Helpers", func() {
 		It("should find nearest go.mod in nested module", func() {
 			tmpDir := GinkgoT().TempDir()
 			rootGomod := filepath.Join(tmpDir, "go.mod")
-			err := os.WriteFile(rootGomod, []byte("module example.com/root\n"), 0o644)
+			err := os.WriteFile(rootGomod, []byte("module example.com/root\n"), 0o600)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			nestedMod := filepath.Join(tmpDir, "nested", "mod")
 			err = os.MkdirAll(nestedMod, 0o755)
 			Expect(err).ShouldNot(HaveOccurred())
 			nestedGomod := filepath.Join(nestedMod, "go.mod")
-			err = os.WriteFile(nestedGomod, []byte("module example.com/nested/mod\n"), 0o644)
+			err = os.WriteFile(nestedGomod, []byte("module example.com/nested/mod\n"), 0o600)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			nestedPkg := filepath.Join(nestedMod, "pkg")

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -364,4 +364,41 @@ var _ = Describe("Helpers", func() {
 			Expect(result).To(Equal([]string{"-tags=linux,amd64"}))
 		})
 	})
+
+	Context("when finding module root", func() {
+		It("should find go.mod in parent directory", func() {
+			tmpDir := GinkgoT().TempDir()
+			gomodPath := filepath.Join(tmpDir, "go.mod")
+			err := os.WriteFile(gomodPath, []byte("module test\n"), 0o644)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			subDir := filepath.Join(tmpDir, "sub", "pkg")
+			err = os.MkdirAll(subDir, 0o755)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			result := gosec.FindModuleRoot(subDir)
+			Expect(result).To(Equal(tmpDir))
+		})
+
+		It("should find nearest go.mod in nested module", func() {
+			tmpDir := GinkgoT().TempDir()
+			rootGomod := filepath.Join(tmpDir, "go.mod")
+			err := os.WriteFile(rootGomod, []byte("module example.com/root\n"), 0o644)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			nestedMod := filepath.Join(tmpDir, "nested", "mod")
+			err = os.MkdirAll(nestedMod, 0o755)
+			Expect(err).ShouldNot(HaveOccurred())
+			nestedGomod := filepath.Join(nestedMod, "go.mod")
+			err = os.WriteFile(nestedGomod, []byte("module example.com/nested/mod\n"), 0o644)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			nestedPkg := filepath.Join(nestedMod, "pkg")
+			err = os.MkdirAll(nestedPkg, 0o755)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			result := gosec.FindModuleRoot(nestedPkg)
+			Expect(result).To(Equal(nestedMod))
+		})
+	})
 })


### PR DESCRIPTION
fix: panic when scanning multi-module repositories from root

The issue is that when running gosec from the root of a multi-module repository, the SSA builder panics because packages.Load resolves dependencies using the CWD's  go.mod instead of the nested module's go.mod. This fix adds `FindModuleRoot()` helper method to detect the correct module for each package and sets `packages.Config.Dir` accordingly to prevent SSA panics.

Fixes #1503

