### PR TITLE
fix: panic on float constants in overflow analyzer

### DIFF
--- a/analyzers/util.go
+++ b/analyzers/util.go
@@ -284,7 +284,7 @@ func GetIntTypeInfo(t types.Type) (IntTypeInfo, error) {
 // GetConstantInt64 extracts a constant int64 value from an ssa.Value
 func GetConstantInt64(v ssa.Value) (int64, bool) {
 	if c, ok := v.(*ssa.Const); ok {
-		if c.Value != nil {
+		if c.Value != nil && c.Value.Kind() == constant.Int {
 			if val, ok := constant.Int64Val(c.Value); ok {
 				return val, true
 			}
@@ -301,7 +301,7 @@ func GetConstantInt64(v ssa.Value) (int64, bool) {
 // GetConstantUint64 extracts a constant uint64 value from an ssa.Value
 func GetConstantUint64(v ssa.Value) (uint64, bool) {
 	if c, ok := v.(*ssa.Const); ok {
-		if c.Value != nil {
+		if c.Value != nil && c.Value.Kind() == constant.Int {
 			if val, ok := constant.Uint64Val(c.Value); ok {
 				return val, true
 			}
@@ -458,7 +458,7 @@ func GetDominators(block *ssa.BasicBlock) []*ssa.BasicBlock {
 
 // isConstantInRange checks if a constant value fits within the range of the destination type.
 func IsConstantInTypeRange(constVal *ssa.Const, dstInt IntTypeInfo) bool {
-	if constVal.Value == nil {
+	if constVal.Value == nil || constVal.Value.Kind() != constant.Int {
 		return false
 	}
 	if dstInt.Signed {

--- a/analyzers/util_test.go
+++ b/analyzers/util_test.go
@@ -1,0 +1,22 @@
+package analyzers
+
+import (
+	"go/constant"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"golang.org/x/tools/go/ssa"
+)
+
+var _ = Describe("GetConstantInt64", func() {
+	It("should not panic on float constants", func() {
+		// Create a float constant (simulates float64(-1))
+		floatVal := constant.MakeFloat64(-1.0)
+		c := &ssa.Const{Value: floatVal}
+
+		// Should return (0, false) without panicking
+		val, ok := GetConstantInt64(c)
+		Expect(ok).To(BeFalse())
+		Expect(val).To(Equal(int64(0)))
+	})
+})


### PR DESCRIPTION
fix: prevent panic on float constants in conversion overflow analyzer

The issue is that gosec v2.23.0 panics with "-1 not an Int" when analyzing code with float-to-int conversions because `constant.Int64Val()` panics when called on non-Int constants. 

Fixes #1502

Note: As part of this, we can also improve code coverage for utility, beyond the scope of this PR but we can detect upfront when any future panics happen.