### PR TITLE
Add support for go 1.26.x and remove support for go 1.24.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     strategy:
       matrix:
         version:
-          - go-version: "1.24.13"
-            golangci: "latest"
           - go-version: "1.25.7"
+            golangci: "latest"
+          - go-version: "1.26.0"
             golangci: "latest"
     runs-on: ubuntu-latest
     env:
@@ -52,7 +52,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.7"
+          go-version: "1.26.0"
       - name: Checkout Source
         uses: actions/checkout@v6
       - uses: actions/cache@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.7"
+          go-version: "1.26.0"
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3
         with:
@@ -67,7 +67,7 @@ jobs:
           tags: ${{steps.meta.outputs.tags}}
           labels: ${{steps.meta.outputs.labels}}
           push: true
-          build-args: GO_VERSION=1.25
+          build-args: GO_VERSION=1.26
       - name: Sign Docker Image
         run: cosign sign --yes --key /tmp/cosign.key ${DIGEST} --registry-username="$secrets.DOCKER_USERNAME" --registry-password="::add-mask::$secrets.DOCKER_PASSWORD"
         env:

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ GOBIN ?= $(GOPATH)/bin
 GOSEC ?= $(GOBIN)/gosec
 GO_MINOR_VERSION = $(shell $(GO) version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f2)
 GOVULN_MIN_VERSION = 17
-GO_VERSION = 1.25
+GO_VERSION = 1.26
 LDFLAGS = -ldflags "\
 	-X 'main.Version=$(shell git describe --tags --always)' \
 	-X 'main.GitTag=$(shell git describe --tags --abbrev=0)' \

--- a/analyzers/bench_test.go
+++ b/analyzers/bench_test.go
@@ -36,7 +36,7 @@ func benchmarkAnalyzerStress(b *testing.B, analyzerID string, generator func() s
 
 	// Create a dummy go.mod to ensure we are in a module
 	goMod := filepath.Join(tmpDir, "go.mod")
-	if err := os.WriteFile(goMod, []byte("module bench\n\ngo 1.24\n"), 0o600); err != nil {
+	if err := os.WriteFile(goMod, []byte("module bench\n\ngo 1.25\n"), 0o600); err != nil {
 		b.Fatalf("failed to write go.mod: %v", err)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -57,4 +57,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.24.0
+go 1.25.0


### PR DESCRIPTION
Add support for go 1.26.x and remove support for go 1.24.x. Only the last two major versions are suported.