### PR TITLE
Fix G115 false positives and negatives (Issue #1501)

### DIFF
--- a/analyzers/util.go
+++ b/analyzers/util.go
@@ -643,6 +643,11 @@ func isSameOrRelated(a, b ssa.Value) bool {
 			return aField.Field == bField.Field && isSameOrRelated(aField.X, bField.X)
 		}
 	}
+	if aIndex, ok := aVal.(*ssa.IndexAddr); ok {
+		if bIndex, ok := bVal.(*ssa.IndexAddr); ok {
+			return isSameOrRelated(aIndex.X, bIndex.X) && isSameOrRelated(aIndex.Index, bIndex.Index)
+		}
+	}
 	if aUnOp, ok := aVal.(*ssa.UnOp); ok {
 		if aUnOp.Op == token.MUL {
 			if bUnOp, ok := bVal.(*ssa.UnOp); ok && bUnOp.Op == token.MUL {


### PR DESCRIPTION
fixes https://github.com/securego/gosec/issues/1501

Fixes false positives for guarded conversions in loops by excluding back-edge dominators from reachability check. Fixes false negatives for array/slice element conversions by preventing recursive range resolution through IndexAddr. Also fixes isNonNegative check for range loops.