### PR TITLE
(docs) fix justification format

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ As with all automated detection tools, there will be cases of false positives.
 In cases where gosec reports a failure that has been manually verified as being safe,
 it is possible to annotate the code with a comment that starts with `#nosec`.
 
-The `#nosec` comment should have the format `#nosec [RuleList] [-- Justification]`.
+The `#nosec` comment should have the format `#nosec [RuleList] [- Justification]`.
 
 The `#nosec` comment needs to be placed on the line where the warning is reported.
 


### PR DESCRIPTION
In my testing I had to use one dash instead of two.