### PR TITLE
fix(G602): avoid false positives for range-over-array indexing

### DIFF
--- a/testutils/g602_samples.go
+++ b/testutils/g602_samples.go
@@ -696,4 +696,23 @@ func main() {
 	_ = arr[4]
 }
 `}, 0, gosec.NewConfig()},
+	// Issue #1525: G602 false positive for array index in range-over-array loops
+	{[]string{`
+package main
+func main() {
+	var arr [8]int
+	for i := range arr {
+		arr[i] = i
+	}
+}
+`}, 0, gosec.NewConfig()},
+	{[]string{`
+package main
+func main() {
+	var arr [8]int
+	for i := range arr {
+		_ = arr[i+1]
+	}
+}
+`}, 1, gosec.NewConfig()},
 }


### PR DESCRIPTION
This change fixes a false positive in G602 when iterating over fixed-size arrays with range and indexing using the loop variable.

* Corrects loop bound normalization in SSA-based index analysis so offsets are not applied twice.
* Preserves true-positive detection for real out-of-bounds patterns (for example index + 1 at upper edge).
* Adds regression samples covering both:valid range-over-array indexing (no issue expected)invalid shifted indexing inside the same loop (issue expected)

fixes #1525