### PR TITLE
Fix G602 regression coverage for issue #1545 and stabilize G117 TOML test dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	cloud.google.com/go v0.121.2 // indirect
 	cloud.google.com/go/auth v0.16.5 // indirect
 	cloud.google.com/go/compute/metadata v0.8.0 // indirect
+	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,7 @@ cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RX
 contrib.go.opencensus.io/exporter/stackdriver v0.13.4/go.mod h1:aXENhDJ1Y4lIg4EUaVTwzvYETVNZk10Pu26tevFKLUc=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=

--- a/testutils/g602_samples.go
+++ b/testutils/g602_samples.go
@@ -715,4 +715,29 @@ func main() {
 	}
 }
 `}, 1, gosec.NewConfig()},
+	// Issue #1545: G602 false positive on range-over-array indexing into same-size array
+	{[]string{`
+package main
+
+func main() {
+	ranged := [1]int{1}
+	var accessed [1]*int
+
+	for i, r := range ranged {
+		accessed[i] = &r
+	}
+}
+`}, 0, gosec.NewConfig()},
+	{[]string{`
+package main
+
+func main() {
+	ranged := [2]int{1, 2}
+	var accessed [1]*int
+
+	for i, r := range ranged {
+		accessed[i] = &r
+	}
+}
+`}, 1, gosec.NewConfig()},
 }


### PR DESCRIPTION
This PR adds regression coverage for the G602 false-positive reported in issue #1545 by introducing two sample cases: one valid range-over-array indexing pattern that should not trigger, and one true out-of-bounds variant that should still be detected.It also fixes test instability in the rules suite by adding the missing BurntSushi TOML module metadata required by G117 sample compilation in the test harness.

fixes #1545