### PR TITLE
Fix/g704 false positive const url

### DIFF
--- a/taint/taint.go
+++ b/taint/taint.go
@@ -521,6 +521,12 @@ func (a *Analyzer) isTainted(v ssa.Value, fn *ssa.Function, visited map[ssa.Valu
 	}
 	visited[v] = true
 
+	// Constants are compile-time literals and can never carry attacker-controlled
+	// data. Short-circuit immediately — no taint possible.
+	if _, ok := v.(*ssa.Const); ok {
+		return false
+	}
+
 	// Trace back through SSA instructions
 	switch val := v.(type) {
 	case *ssa.Parameter:

--- a/testutils/g704_samples.go
+++ b/testutils/g704_samples.go
@@ -65,4 +65,40 @@ func GetPublicIP() (string, error) {
 	return "", nil
 }
 `}, 0, gosec.NewConfig()},
+	// Constant URL string must NOT trigger G704.
+	{[]string{`
+package main
+
+import (
+	"context"
+	"net/http"
+)
+
+const url = "https://go.dev/"
+
+func main() {
+	ctx := context.Background()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		panic(err)
+	}
+	_, err = new(http.Client).Do(req)
+	if err != nil {
+		panic(err)
+	}
+}
+`}, 0, gosec.NewConfig()},
+	// Sanity check: variable URL from request still fires.
+	{[]string{`
+package main
+
+import (
+	"net/http"
+)
+
+func handler(r *http.Request) {
+	target := r.URL.Query().Get("url")
+	http.Get(target) //nolint:errcheck
+}
+`}, 1, gosec.NewConfig()},
 }


### PR DESCRIPTION
## Problem
G704 (SSRF) fires when a `const` URL string is passed to `http.Client.Do` via an intermediate `*http.Request`. The taint engine was not short-circuiting on `*ssa.Const` values, so compile-time literals were being treated as potentially attacker-controlled.

## Solution
Adds a single early-exit guard in the taint propagation walk: if the SSA value is an `*ssa.Const`, return clean immediately. Constants are compile-time literals and can never carry user input by definition.

This also prevents the same class of false positive across all other G70x rules (G701 SQLi, G703 path traversal, etc.) wherever a constant-valued argument reaches a sink.

Fixes: #1549