### PR TITLE
fix(G120): prevent hang-like analysis blowup in wrapper protection checks

### DIFF
--- a/analyzers/form_parsing_limits_internal_test.go
+++ b/analyzers/form_parsing_limits_internal_test.go
@@ -1,0 +1,45 @@
+package analyzers
+
+import (
+	"go/constant"
+	"go/types"
+	"testing"
+
+	"golang.org/x/tools/go/ssa"
+)
+
+func TestDependencyCheckerHandlesPhiCycleWithoutTarget(t *testing.T) {
+	t.Parallel()
+
+	checker := newDependencyChecker()
+	target := ssa.NewConst(constant.MakeInt64(42), types.Typ[types.Int])
+
+	phiA := &ssa.Phi{}
+	phiB := &ssa.Phi{}
+	phiA.Edges = []ssa.Value{phiB}
+	phiB.Edges = []ssa.Value{phiA}
+
+	if checker.dependsOn(phiA, target) {
+		t.Fatal("expected false for cycle without target dependency")
+	}
+}
+
+func TestDependencyCheckerFindsTargetInPhiCycle(t *testing.T) {
+	t.Parallel()
+
+	checker := newDependencyChecker()
+	target := ssa.NewConst(constant.MakeInt64(7), types.Typ[types.Int])
+
+	phiA := &ssa.Phi{}
+	phiB := &ssa.Phi{}
+	phiA.Edges = []ssa.Value{phiB, target}
+	phiB.Edges = []ssa.Value{phiA}
+
+	if !checker.dependsOn(phiA, target) {
+		t.Fatal("expected true when cycle has a path to target")
+	}
+
+	if !checker.dependsOn(phiA, target) {
+		t.Fatal("expected stable memoized result on repeated call")
+	}
+}


### PR DESCRIPTION
_Summary:_ 
This change fixes the hang/perceived hang reported in issue #1555 when scanning large codebases with complex SSA graphs. The fix is intentionally scoped to G120 form parsing analysis only.

_Root cause:_ 
G120 wrapper/middleware protection logic repeatedly called value-dependency checks across many function/call combinations. The dependency traversal was depth-limited but not memoized, so cyclic and branch-heavy SSA structures (especially Phi-related paths) caused repeated re-traversal of the same graph regions and severe runtime blowup.

_What changed:_
A cycle-safe, memoized dependency checker was added and used only inside the G120 form parsing analysis flow. Existing G120 logic was kept semantically equivalent while replacing repeated raw dependency traversals with cached checks. Focused regression tests were added for cyclic Phi graphs to verify both cases: no target reachable (false) and target reachable (true), including stable repeated evaluation.