### PR TITLE
chore(prompts): add skill and prompt to update action gosec version

### DIFF
--- a/.github/prompts/update-gosec-action-version.prompt.md
+++ b/.github/prompts/update-gosec-action-version.prompt.md
@@ -1,0 +1,14 @@
+---
+name: Update Gosec Action Version
+mode: agent
+description: Update action.yml to use a provided gosec version and open a pull request using the reusable gosec skill.
+---
+
+Use the skill Update Gosec Action Version from .github/skills/gosec-update-action-version/SKILL.md.
+
+The skill updates `action.yml`, creates a branch and commit, and opens a pull request.
+
+Use this input:
+
+### gosec version
+{{gosec_version}}

--- a/.github/skills/gosec-update-action-version/SKILL.md
+++ b/.github/skills/gosec-update-action-version/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: Update Gosec Action Version
+description: Update the gosec Docker image version in action.yml using a provided gosec version.
+---
+
+# Update gosec version in GitHub Action metadata
+
+Use this skill when you want to update the gosec version used by this repository's GitHub Action.
+
+## Required input
+
+### gosec version
+<gosec version, for example 2.24.1>
+
+## Execution workflow
+
+1. Read `action.yml`.
+2. Locate `runs.image` with format `docker://securego/gosec:<version>`.
+3. Replace only the version segment after the colon with the provided gosec version.
+4. Do not change unrelated fields or formatting in `action.yml`.
+5. Validate that the resulting image value is exactly `docker://securego/gosec:<provided_version>`.
+6. Create a branch named `chore/update-action-gosec-<provided_version>`.
+7. Commit the change with message `chore(action): bump gosec to <provided_version>`.
+8. Push the branch to origin.
+9. Open a pull request to `master` with:
+	- Title: `chore(action): bump gosec to <provided_version>`
+	- Body: concise summary that this updates `action.yml` Docker image version.
+
+## Output requirements
+
+- Report old version and new version.
+- Confirm that only `action.yml` was modified for the version bump.
+- Report the created branch name, commit SHA, pull request title, and pull request URL.


### PR DESCRIPTION
## Summary
- add reusable skill to update the gosec Docker image version in action.yml
- add a /prompts-callable prompt that takes gosec_version input
- extend skill workflow to create branch, commit, push, and open PR after update

## Notes
- no runtime code changes; prompt/skill metadata only