### PR TITLE
chore: migrate gosec container image publishing and references to GHCR

### DIFF
--- a/.github/prompts/update-gosec-action-version.prompt.md
+++ b/.github/prompts/update-gosec-action-version.prompt.md
@@ -1,7 +1,7 @@
 ---
 name: Update Gosec Action Version
 mode: agent
-description: Update action.yml to use a provided gosec version and open a pull request using the reusable gosec skill.
+description: Update action.yml to use a provided gosec GHCR image version and open a pull request using the reusable gosec skill.
 ---
 
 Use the skill Update Gosec Action Version from .github/skills/gosec-update-action-version/SKILL.md.

--- a/.github/skills/gosec-update-action-version/SKILL.md
+++ b/.github/skills/gosec-update-action-version/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Update Gosec Action Version
-description: Update the gosec Docker image version in action.yml using a provided gosec version.
+description: Update the gosec GHCR image version in action.yml using a provided gosec version.
 ---
 
 # Update gosec version in GitHub Action metadata
@@ -15,16 +15,16 @@ Use this skill when you want to update the gosec version used by this repository
 ## Execution workflow
 
 1. Read `action.yml`.
-2. Locate `runs.image` with format `docker://securego/gosec:<version>`.
+2. Locate `runs.image` with format `docker://ghcr.io/securego/gosec:<version>`.
 3. Replace only the version segment after the colon with the provided gosec version.
 4. Do not change unrelated fields or formatting in `action.yml`.
-5. Validate that the resulting image value is exactly `docker://securego/gosec:<provided_version>`.
+5. Validate that the resulting image value is exactly `docker://ghcr.io/securego/gosec:<provided_version>`.
 6. Create a branch named `chore/update-action-gosec-<provided_version>`.
 7. Commit the change with message `chore(action): bump gosec to <provided_version>`.
 8. Push the branch to origin.
 9. Open a pull request to `master` with:
 	- Title: `chore(action): bump gosec to <provided_version>`
-	- Body: concise summary that this updates `action.yml` Docker image version.
+	- Body: concise summary that this updates `action.yml` GHCR image version.
 
 ## Output requirements
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,11 +34,6 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -55,7 +50,6 @@ jobs:
         id: meta
         with:
           images: |
-            securego/gosec
             ghcr.io/securego/gosec
           flavor: |
             latest=true

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -414,7 +414,7 @@ The release workflow builds binaries and Docker images, then signs artifacts.
 Verify signatures:
 
 ```bash
-cosign verify --key cosign.pub securego/gosec:<TAG>
+cosign verify --key cosign.pub ghcr.io/securego/gosec:<TAG>
 cosign verify-blob --key cosign.pub --signature gosec_<VERSION>_darwin_amd64.tar.gz.sig gosec_<VERSION>_darwin_amd64.tar.gz
 ```
 
@@ -429,7 +429,7 @@ make image
 Run against a local project:
 
 ```bash
-docker run --rm -it -w /<PROJECT>/ -v <YOUR_PROJECT_PATH>/<PROJECT>:/<PROJECT> securego/gosec /<PROJECT>/...
+docker run --rm -it -w /<PROJECT>/ -v <YOUR_PROJECT_PATH>/<PROJECT>:/<PROJECT> ghcr.io/securego/gosec:latest /<PROJECT>/...
 ```
 
 Set `-w` so module dependencies resolve from the mounted project root.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 
 Inspects source code for security problems by scanning the Go AST and SSA code representation.
 
+> ⚠️ Container image migration notice: `gosec` images have been migrated from Docker Hub to `ghcr.io/securego/gosec`.
+> Starting with the next release, Docker Hub images will no longer be published.
+
 <img src="https://securego.io/img/gosec.png" width="320">
 
 ## Quick links
@@ -35,7 +38,7 @@ You may obtain a copy of the License [here](http://www.apache.org/licenses/LICEN
 [![GoDoc](https://pkg.go.dev/badge/github.com/securego/gosec/v2)](https://pkg.go.dev/github.com/securego/gosec/v2)
 [![Docs](https://readthedocs.org/projects/docs/badge/?version=latest)](https://securego.io/)
 [![Downloads](https://img.shields.io/github/downloads/securego/gosec/total.svg)](https://github.com/securego/gosec/releases)
-[![Docker Pulls](https://img.shields.io/docker/pulls/securego/gosec.svg)](https://hub.docker.com/r/securego/gosec/tags)
+[![GHCR](https://img.shields.io/badge/ghcr.io-securego%2Fgosec-blue)](https://github.com/orgs/securego/packages/container/package/gosec)
 [![Slack](https://img.shields.io/badge/Slack-4A154B?style=for-the-badge&logo=slack&logoColor=white)](http://securego.slack.com)
 [![go-recipes](https://raw.githubusercontent.com/nikolaydubina/go-recipes/main/badge.svg?raw=true)](https://github.com/nikolaydubina/go-recipes)
 

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
 
 runs:
   using: "docker"
-  image: "docker://securego/gosec:2.24.0"
+  image: "docker://ghcr.io/securego/gosec:2.24.6"
   args:
     - ${{ inputs.args }}
 


### PR DESCRIPTION
## Summary
- migrate GitHub Action runtime image to GHCR (ghcr.io/securego/gosec)
- pin action image tag to v2.24.6
- remove Docker Hub publishing from release workflow
- update docs, skills, and prompt text to reference GHCR
- add README notice that Docker Hub images will stop in the next release

## Testing
- verified workflow/image references with repository searches