### PR TITLE
chore(action): bump gosec to 2.24.7

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
 
 runs:
   using: "docker"
-  image: "docker://ghcr.io/securego/gosec:2.24.6"
+  image: "docker://ghcr.io/securego/gosec:2.24.7"
   args:
     - ${{ inputs.args }}
 


### PR DESCRIPTION
Updates action.yml to use ghcr.io/securego/gosec:2.24.7 for the Docker-based GitHub Action image.