### PR TITLE
fix(G118): treat returned cancel func as called (fixes #1584)

### DIFF
--- a/analyzers/context_propagation.go
+++ b/analyzers/context_propagation.go
@@ -725,6 +725,14 @@ func isCancelCalled(cancelValue ssa.Value, allFuncs []*ssa.Function) bool {
 				if r.X == current {
 					queue = append(queue, r)
 				}
+			case *ssa.Return:
+				// Cancel function is returned to the caller — responsibility
+				// is transferred; treat as "called".
+				for _, result := range r.Results {
+					if result == current {
+						return true
+					}
+				}
 			}
 		}
 	}

--- a/testutils/g118_samples.go
+++ b/testutils/g118_samples.go
@@ -324,7 +324,7 @@ func multiContext(ctx context.Context) {
 }
 `}, 1, gosec.NewConfig()},
 
-	// Vulnerable: cancel returned to caller (analyzer cannot verify caller will use it)
+	// Safe: cancel returned to caller — responsibility is transferred
 	{[]string{`
 package main
 
@@ -333,7 +333,7 @@ import "context"
 func createContext(ctx context.Context) (context.Context, context.CancelFunc) {
 	return context.WithCancel(ctx)
 }
-`}, 1, gosec.NewConfig()},
+`}, 0, gosec.NewConfig()},
 
 	// Note: simple goroutines with Background() not detected when request param unused
 	{[]string{`
@@ -1509,4 +1509,47 @@ func multipleViolations(ctx context.Context) {
 	_, _, _ = cancel1, cancel2, cancel3
 }
 `}, 3, gosec.NewConfig()},
+
+	// Safe: cancel returned as func() and called by caller (issue #1584)
+	{[]string{`
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+type Env struct {
+	DB       *sql.DB
+	Shutdown func()
+}
+
+func withContext(ctx context.Context, env *Env) error {
+	db, closeFn, err := initDatabase(ctx)
+	if err != nil {
+		return fmt.Errorf("creating database: %w", err)
+	}
+
+	prev := env.Shutdown
+	env.Shutdown = func() {
+		prev()
+		closeFn()
+	}
+
+	env.DB = db
+	return nil
+}
+
+func initDatabase(ctx context.Context) (*sql.DB, func(), error) {
+	ctx, cancelFunc := context.WithCancel(ctx)
+	_ = ctx
+
+	db, err := sql.Open("sqlite", "testing")
+	if err != nil {
+		return nil, cancelFunc, fmt.Errorf("opening database: %%w", err)
+	}
+	return db, cancelFunc, nil
+}
+`}, 0, gosec.NewConfig()},
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/securego/gosec/issues/1584

The `isCancelCalled` BFS in the G118 (context propagation) analyzer did not handle `*ssa.Return`, so a cancel function returned from a helper was flagged as "lost" even though responsibility was transferred to the caller.

## Root Cause

When a function like `initDatabase` calls `context.WithCancel(ctx)` and returns the cancel func to its caller, the SSA representation produces a `Return` instruction referencing the cancel value. The BFS in `isCancelCalled` had no `case *ssa.Return:` branch, so it dead-ended and concluded the cancel was never called.

## Changes

- **`analyzers/context_propagation.go`**: Add a `*ssa.Return` case to the `isCancelCalled` BFS — when the cancel value appears among the return operands, treat it as called (responsibility transferred to caller).
- **`testutils/g118_samples.go`**: Update the existing "cancel returned to caller" test to expect 0 issues. Add a new test case matching the exact issue #1584 pattern (cancel returned as `func()` and invoked by caller through a shutdown chain).

## Validation

- Build: clean
- All 156 analyzer specs pass
- Reproduction case from issue #1584: 0 issues (was 1)
- Genuinely lost cancel functions: still correctly detected
