### PR TITLE
fix(analyzer): per-package rule instantiation eliminates concurrent map crash

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -194,8 +194,18 @@ func (m *Metrics) Merge(other *Metrics) {
 // Analyzer object is the main object of gosec. It has methods to load and analyze
 // packages, traverse ASTs, and invoke the correct checking rules on each node as required.
 type Analyzer struct {
-	ignoreNosec       bool
-	ruleset           RuleSet
+	ignoreNosec bool
+	ruleset     RuleSet
+	// ruleBuilders and ruleSuppressed store the original arguments passed to
+	// LoadRules so that checkRules can call buildPackageRuleset to produce a
+	// goroutine-local RuleSet for every concurrent package walk. Each walk
+	// therefore owns its own freshly allocated rule instances, which means
+	// rules are free to keep per-package mutable state (e.g. maps tracking
+	// cleaned or joined variables) without any synchronisation. The shared
+	// gosec.ruleset is kept for callers that use the public CheckRules API
+	// directly (backward-compatible path).
+	ruleBuilders      map[string]RuleBuilder
+	ruleSuppressed    map[string]bool
 	context           *Context
 	config            Config
 	logger            *log.Logger
@@ -254,10 +264,30 @@ func (gosec *Analyzer) Config() Config {
 // LoadRules instantiates all the rules to be used when analyzing source
 // packages
 func (gosec *Analyzer) LoadRules(ruleDefinitions map[string]RuleBuilder, ruleSuppressed map[string]bool) {
+	// Persist the builders so checkRules can produce per-package rule
+	// instances via buildPackageRuleset, eliminating shared mutable state
+	// across concurrent goroutines without requiring locks inside rules.
+	gosec.ruleBuilders = ruleDefinitions
+	gosec.ruleSuppressed = ruleSuppressed
+
 	for id, def := range ruleDefinitions {
 		r, nodes := def(id, gosec.config)
 		gosec.ruleset.Register(r, ruleSuppressed[id], nodes...)
 	}
+}
+
+// buildPackageRuleset constructs a brand-new RuleSet by re-invoking every
+// stored RuleBuilder. The returned ruleset is intended to be used for a single
+// package walk: because each concurrent worker calls buildPackageRuleset
+// independently, every goroutine gets its own rule instances with their own
+// internal state (maps, caches, etc.), so rules require no synchronisation.
+func (gosec *Analyzer) buildPackageRuleset() RuleSet {
+	rs := NewRuleSet()
+	for id, def := range gosec.ruleBuilders {
+		r, nodes := def(id, gosec.config)
+		rs.Register(r, gosec.ruleSuppressed[id], nodes...)
+	}
+	return rs
 }
 
 // LoadAnalyzers instantiates all the analyzers to be used when analyzing source
@@ -460,8 +490,20 @@ func (gosec *Analyzer) checkRules(pkg *packages.Package) ([]*issue.Issue, *Metri
 		callCachePool.Put(callCache)
 	}()
 
+	// Build a goroutine-local RuleSet so this package walk owns its own fresh
+	// rule instances. Rules with internal maps (e.g. readfile.cleanedVar,
+	// joinedVar) are therefore safe to use without any synchronisation: each
+	// concurrent worker has completely independent rule objects. Falls back to
+	// the shared ruleset when builders are unavailable (direct CheckRules path).
+	var pkgRuleset *RuleSet
+	if len(gosec.ruleBuilders) > 0 {
+		rs := gosec.buildPackageRuleset()
+		pkgRuleset = &rs
+	}
+
 	visitor := &astVisitor{
 		gosec:             gosec,
+		ruleset:           pkgRuleset,
 		issues:            make([]*issue.Issue, 0, 16),
 		stats:             stats,
 		ignoreNosec:       gosec.ignoreNosec,
@@ -502,7 +544,7 @@ func (gosec *Analyzer) checkRules(pkg *packages.Package) ([]*issue.Issue, *Metri
 
 		visitor.context = ctx
 		visitor.updateIgnores()
-		if len(gosec.ruleset.Rules) > 0 {
+		if len(visitor.activeRuleset().Rules) > 0 {
 			ast.Walk(visitor, file)
 		}
 		stats.NumFiles++
@@ -811,7 +853,12 @@ func findNoSecTag(text, tag string) (bool, string) {
 
 // astVisitor implements ast.Visitor for per-file rule checking and issue collection.
 type astVisitor struct {
-	gosec             *Analyzer
+	gosec *Analyzer
+	// ruleset is a package-local RuleSet built fresh by buildPackageRuleset
+	// for each concurrent package walk. It is non-nil when invoked through
+	// the normal Process → checkRules path and nil when the public CheckRules
+	// API is called directly (falling back to the shared gosec.ruleset).
+	ruleset           *RuleSet
 	context           *Context
 	issues            []*issue.Issue
 	stats             *Metrics
@@ -820,13 +867,22 @@ type astVisitor struct {
 	trackSuppressions bool
 }
 
+// activeRuleset returns the package-local ruleset when available, falling back
+// to the shared analyzer ruleset for direct CheckRules callers.
+func (v *astVisitor) activeRuleset() *RuleSet {
+	if v.ruleset != nil {
+		return v.ruleset
+	}
+	return &v.gosec.ruleset
+}
+
 func (v *astVisitor) Visit(n ast.Node) ast.Visitor {
 	switch i := n.(type) {
 	case *ast.File:
 		v.context.Imports.TrackFile(i)
 	}
 
-	for _, rule := range v.gosec.ruleset.RegisteredFor(n) {
+	for _, rule := range v.activeRuleset().RegisteredFor(n) {
 		issue, err := rule.Match(n, v.context)
 		if err != nil {
 			file, line := GetLocation(n, v.context)
@@ -1012,5 +1068,7 @@ func (gosec *Analyzer) Reset() {
 	gosec.issues = make([]*issue.Issue, 0, 16)
 	gosec.stats = &Metrics{}
 	gosec.ruleset = NewRuleSet()
+	gosec.ruleBuilders = nil
+	gosec.ruleSuppressed = nil
 	gosec.analyzerSet = analyzers.NewAnalyzerSet()
 }

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -115,6 +115,51 @@ var _ = Describe("Analyzer", func() {
 			Expect(metrics.NumFiles).To(Equal(2))
 		})
 
+		It("should not race when analyzing G304 patterns across many packages concurrently (issue #1586)", func() {
+			const numPackages = 20
+			const concurrency = 16
+
+			// Source that exercises both cleanedVar and joinedVar maps in the
+			// readfile rule: one assignment via filepath.Clean (tracked in
+			// cleanedVar), one via filepath.Join with a variable argument
+			// (tracked in joinedVar), plus an os.Open call that triggers Match.
+			g304Source := `package main
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func main() {
+	name := "input"
+	cleaned := filepath.Clean(name)
+	_, _ = os.Open(cleaned)
+	joined := filepath.Join("/base", name)
+	_, _ = os.Open(joined)
+}
+`
+			concurrentAnalyzer := gosec.NewAnalyzer(nil, false, false, false, concurrency, logger)
+			concurrentAnalyzer.LoadRules(rules.Generate(false, rules.NewRuleFilter(false, "G304")).RulesInfo())
+
+			pkgs := make([]*testutils.TestPackage, numPackages)
+			paths := make([]string, numPackages)
+			for i := range numPackages {
+				pkgs[i] = testutils.NewTestPackage()
+				pkgs[i].AddFile("main.go", g304Source)
+				err := pkgs[i].Build()
+				Expect(err).ShouldNot(HaveOccurred())
+				paths[i] = pkgs[i].Path
+			}
+			defer func() {
+				for _, p := range pkgs {
+					p.Close()
+				}
+			}()
+
+			err := concurrentAnalyzer.Process(buildTags, paths...)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
 		It("should be able to analyze multiple Go packages", func() {
 			analyzer.LoadRules(rules.Generate(false).RulesInfo())
 			pkg1 := testutils.NewTestPackage()


### PR DESCRIPTION

### Problem

`Analyzer.Process` fans out to `gosec.concurrency` goroutines. Each goroutine calls `checkRules(pkg)` → `ast.Walk` → `rule.Match` on **the same shared rule instances** registered once in `LoadRules`. Rules that maintain per-package state in struct fields — specifically `readfile` (G304) with its `cleanedVar` and `joinedVar` maps — are written and read concurrently across goroutines, producing a fatal map race:

```
fatal error: concurrent map read and map write
goroutine N: rules.(*readfile).Match → trackCleanAssign → r.cleanedVar[v] = …  (WRITE)
goroutine M: rules.(*readfile).Match → isFilepathClean  → _, ok := r.cleanedVar[v] (READ)
```

There is also a pre-existing secondary bug: the maps are never cleared between packages, so a variable resolved as "cleaned" in package `foo` remains in `cleanedVar` when package `bar` is later analysed, silently suppressing findings.

### Approach

This fix is a direct elaboration of **Option C** from issue #1586 — creating a fresh rule instance per invocation of `checkRules` - with two refinements:

1. **Granularity is per package walk, not per goroutine.** A single goroutine processes multiple packages sequentially; per-goroutine instances would still share state across those packages.
2. **Mechanism reuses existing `RuleBuilder` functions.** `LoadRules` already receives `map[string]RuleBuilder`. Storing these and re-invoking them in `checkRules` produces a complete, fresh `RuleSet` without duplicating any constructor logic and without modifying any rule file.

### Changes (`analyzer.go` only — no rule files modified)

| Location | Change |
|---|---|
| `Analyzer` struct | Add `ruleBuilders map[string]RuleBuilder` and `ruleSuppressed map[string]bool` |
| `LoadRules()` | Save the incoming arguments before the existing registration loop (loop unchanged) |
| `buildPackageRuleset()` | New private method — re-invokes every stored builder, returns a fresh `RuleSet` |
| `checkRules()` | Calls `buildPackageRuleset()`, passes result into `astVisitor` via new `ruleset *RuleSet` field |
| `astVisitor` struct | Add `ruleset *RuleSet` field |
| `activeRuleset()` | New helper on `astVisitor` — returns the package-local ruleset, falls back to shared `gosec.ruleset` for direct `CheckRules` callers (backward-compatible) |
| `Visit()` | Uses `activeRuleset()` instead of `gosec.ruleset` directly |
| `Reset()` | Nils out `ruleBuilders` and `ruleSuppressed` |

### Properties

- **No public API changes.** `CheckRules`, `LoadRules`, `Process`, `Report`, `Reset` all have identical signatures.
- **Backward compatible.** Direct callers of the public `CheckRules` method (without going through `Process`) continue to use the shared `gosec.ruleset` via the `activeRuleset()` fallback.
- **No synchronisation inside rules.** Each concurrent worker owns completely independent rule instances — no mutex, no `sync.Map`, no coordination needed now or in the future.
- **Fixes cross-package contamination as a side-effect.** Each package walk starts with fresh maps, so state from one package cannot suppress findings in another.
- **Future-proof.** Any rule that needs per-package mutable state is automatically isolated with no extra work required from the rule author.