### PR TITLE
Fix G118 false positive on cancel called inside goroutine closure

### DIFF
--- a/analyzers/context_propagation.go
+++ b/analyzers/context_propagation.go
@@ -725,6 +725,17 @@ func isCancelCalled(cancelValue ssa.Value, allFuncs []*ssa.Function) bool {
 				if r.X == current {
 					queue = append(queue, r)
 				}
+			case *ssa.MakeClosure:
+				// The cancel value is captured as a free variable in a closure.
+				// Find the corresponding FreeVar inside the closure body and
+				// follow it so that calls within the closure are detected.
+				if fn, ok := r.Fn.(*ssa.Function); ok {
+					for i, binding := range r.Bindings {
+						if binding == current && i < len(fn.FreeVars) {
+							queue = append(queue, fn.FreeVars[i])
+						}
+					}
+				}
 			case *ssa.Return:
 				// Cancel function is returned to the caller — responsibility
 				// is transferred; treat as "called".

--- a/testutils/g118_samples.go
+++ b/testutils/g118_samples.go
@@ -1552,4 +1552,20 @@ func initDatabase(ctx context.Context) (*sql.DB, func(), error) {
 	return db, cancelFunc, nil
 }
 `}, 0, gosec.NewConfig()},
+
+	// Safe: cancel called inside goroutine closure (issue #1590)
+	{[]string{`
+package main
+
+import (
+	"context"
+)
+
+func main() {
+	_, cancel := context.WithCancel(context.Background())
+	go func() {
+		cancel()
+	}()
+}
+`}, 0, gosec.NewConfig()},
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/securego/gosec/issues/1590

The G118 analyzer (`detectLostCancel`) reported a false positive when `cancel` was called inside a goroutine closure:

```go
_, cancel := context.WithCancel(context.Background())
go func() {
    cancel()
}()
```

### Root cause

`isCancelCalled` traces the cancel value through various SSA types but did not handle `*ssa.MakeClosure`. When Go captures `cancel` in a closure, the SSA creates a `MakeClosure` instruction binding the cancel as a free variable. Since the tracer never followed this binding, it could not see the call inside the closure body.

### Fix

Added a `*ssa.MakeClosure` case to `isCancelCalled` that maps each binding back to the corresponding `FreeVar` in the closure function, then continues tracing from there. This lets the existing `CallInstruction` case detect the invocation.

### Testing

- Added a test sample matching the exact pattern from the issue (expected 0 issues)
- All existing G118 tests continue to pass
- Verified manually that genuinely lost cancels are still detected
