### PR TITLE
Fix G118 false positive when cancel is stored in returned struct field

### DIFF
--- a/analyzers/context_propagation.go
+++ b/analyzers/context_propagation.go
@@ -705,6 +705,11 @@ func isCancelCalled(cancelValue ssa.Value, allFuncs []*ssa.Function) bool {
 					if isCancelCalledViaStructField(fa, allFuncs) {
 						return true
 					}
+					// Check if the struct containing this field is returned,
+					// transferring cancel responsibility to the caller.
+					if isStructFieldReturnedFromFunc(fa) {
+						return true
+					}
 				}
 				queue = append(queue, r.Addr)
 			case *ssa.UnOp:
@@ -744,6 +749,33 @@ func isCancelCalled(cancelValue ssa.Value, allFuncs []*ssa.Function) bool {
 						return true
 					}
 				}
+			}
+		}
+	}
+
+	return false
+}
+
+// isStructFieldReturnedFromFunc checks whether the struct that owns a FieldAddr
+// is loaded and returned from the enclosing function. When a cancel is stored in
+// a struct field and the struct is returned, responsibility for calling the
+// cancel is transferred to the caller.
+func isStructFieldReturnedFromFunc(fa *ssa.FieldAddr) bool {
+	structBase := fa.X
+	if structBase == nil {
+		return false
+	}
+
+	// Follow referrers of the struct base pointer to find loads (*struct)
+	// that are then returned.
+	for _, ref := range safeReferrers(structBase) {
+		load, ok := ref.(*ssa.UnOp)
+		if !ok || load.Op != token.MUL {
+			continue
+		}
+		for _, loadRef := range safeReferrers(load) {
+			if _, ok := loadRef.(*ssa.Return); ok {
+				return true
 			}
 		}
 	}

--- a/testutils/g118_samples.go
+++ b/testutils/g118_samples.go
@@ -1568,4 +1568,28 @@ func main() {
 	}()
 }
 `}, 0, gosec.NewConfig()},
+
+	// Safe: cancel stored in struct field, struct returned, caller invokes it (issue #1591)
+	{[]string{`
+package main
+
+import (
+	"context"
+)
+
+type Foo struct {
+	Cancel func()
+}
+
+func NewFoo() Foo {
+	_, cancel := context.WithCancel(context.Background())
+	foo := Foo{Cancel: cancel}
+	return foo
+}
+
+func main() {
+	foo := NewFoo()
+	foo.Cancel()
+}
+`}, 0, gosec.NewConfig()},
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/securego/gosec/issues/1591

The G118 analyzer (`detectLostCancel`) reported a false positive when a cancel function was stored in a struct field and the struct was returned to the caller:

```go
type Foo struct{ Cancel func() }

func NewFoo() Foo {
    _, cancel := context.WithCancel(context.Background())
    foo := Foo{Cancel: cancel}
    return foo
}

func main() {
    foo := NewFoo()
    foo.Cancel()
}
```

### Root cause

In `isCancelCalled`, when the cancel value is stored into a struct field via a `Store` to a `FieldAddr`, the trace adds the `FieldAddr` address to the queue. But that `FieldAddr`'s only referrer is the Store itself — dead end. The struct is subsequently loaded and returned, transferring responsibility to the caller, but this link was never followed.

The existing `isCancelCalledViaStructField` only checks methods on the same receiver type, which doesn't apply when the struct has no methods and the cancel is consumed by a plain caller.

### Fix

Added `isStructFieldReturnedFromFunc` that checks whether the struct base pointer from a `FieldAddr` is loaded and returned from the enclosing function. Called from the `Store`+`FieldAddr` branch in `isCancelCalled` — if the struct is returned, treat the cancel as transferred (same as a direct cancel return).

### Testing

- Added a test sample matching the exact pattern from the issue (expected 0 issues)
- All existing G118 tests continue to pass
- Verified manually that genuinely lost cancels (struct not returned) are still detected
