### PR TITLE
minor: add G701-G706 rule-to-CWE mappings and CWE-117, CWE-918 entries

### DIFF
--- a/cwe/data.go
+++ b/cwe/data.go
@@ -168,6 +168,11 @@ var idWeaknesses = map[string]*Weakness{
 		Description: "The product uses a cryptographic primitive that uses an Initialization Vector (IV), but the product does not generate IVs that are sufficiently unpredictable or unique according to the expected cryptographic requirements for that primitive.",
 		Name:        "Generation of Weak Initialization Vector (IV)",
 	},
+	"117": {
+		ID:          "117",
+		Description: "The software does not neutralize or incorrectly neutralizes output that is written to logs.",
+		Name:        "Improper Output Neutralization for Logs",
+	},
 	"502": {
 		ID:          "502",
 		Description: "The application deserializes untrusted data without sufficiently verifying that the resulting data will be valid.",
@@ -177,6 +182,11 @@ var idWeaknesses = map[string]*Weakness{
 		ID:          "614",
 		Description: "The Secure attribute for a sensitive cookie is not set, which could cause the user agent to send that cookie in plaintext over an HTTP session.",
 		Name:        "Sensitive Cookie in HTTPS Session Without 'Secure' Attribute",
+	},
+	"918": {
+		ID:          "918",
+		Description: "The web server receives a URL or similar request from an upstream component and retrieves the contents of this URL, but it does not sufficiently ensure that the request is being sent to the expected destination.",
+		Name:        "Server-Side Request Forgery (SSRF)",
 	},
 }
 

--- a/issue/issue.go
+++ b/issue/issue.go
@@ -106,6 +106,12 @@ var ruleToCWE = map[string]string{
 	"G507": "327",
 	"G601": "118",
 	"G602": "118",
+	"G701": "89",
+	"G702": "78",
+	"G703": "22",
+	"G704": "918",
+	"G705": "79",
+	"G706": "117",
 }
 
 // Issue is returned by a gosec rule if it discovers an issue with the scanned code.

--- a/issue/issue_test.go
+++ b/issue/issue_test.go
@@ -156,6 +156,38 @@ func main() {
 			Expect(cwe.ID).Should(Equal("22"))
 		})
 
+		It("should return correct CWE for taint analysis rules", func() {
+			// G701: SQL Injection via taint analysis
+			cweResult := issue.GetCweByRule("G701")
+			Expect(cweResult).ShouldNot(BeNil())
+			Expect(cweResult.ID).Should(Equal("89"))
+
+			// G702: Command Injection via taint analysis
+			cweResult = issue.GetCweByRule("G702")
+			Expect(cweResult).ShouldNot(BeNil())
+			Expect(cweResult.ID).Should(Equal("78"))
+
+			// G703: Path Traversal via taint analysis
+			cweResult = issue.GetCweByRule("G703")
+			Expect(cweResult).ShouldNot(BeNil())
+			Expect(cweResult.ID).Should(Equal("22"))
+
+			// G704: SSRF via taint analysis
+			cweResult = issue.GetCweByRule("G704")
+			Expect(cweResult).ShouldNot(BeNil())
+			Expect(cweResult.ID).Should(Equal("918"))
+
+			// G705: XSS via taint analysis
+			cweResult = issue.GetCweByRule("G705")
+			Expect(cweResult).ShouldNot(BeNil())
+			Expect(cweResult.ID).Should(Equal("79"))
+
+			// G706: Log Injection via taint analysis
+			cweResult = issue.GetCweByRule("G706")
+			Expect(cweResult).ShouldNot(BeNil())
+			Expect(cweResult.ID).Should(Equal("117"))
+		})
+
 		It("should return nil for unknown rule IDs", func() {
 			cwe := issue.GetCweByRule("G999")
 			Expect(cwe).Should(BeNil())


### PR DESCRIPTION
Extends the `ruleToCWE` map to include the taint analysis rules introduced in #1486.

- **`issue/issue.go`**: Added G701→CWE-89, G702→CWE-78, G703→CWE-22, G704→CWE-918, G705→CWE-79, G706→CWE-117
- **`cwe/data.go`**: Added missing CWE-117 (Log Injection) and CWE-918 (SSRF) weakness definitions
- **`issue/issue_test.go`**: Test coverage for all six new mappings