### PR TITLE
fix: skip SSA analysis on ill-typed packages to prevent panic

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -711,6 +711,9 @@ func (gosec *Analyzer) buildSSA(pkg *packages.Package) (*buildssa.SSA, error) {
 	if pkg.TypesInfo == nil {
 		return nil, fmt.Errorf("%w: %s", ErrNoPackageTypeInfo, pkg.Name)
 	}
+	if pkg.IllTyped {
+		return nil, fmt.Errorf("package %s has type errors, skipping SSA analysis", pkg.Name)
+	}
 	pass := &analysis.Pass{
 		Fset:             pkg.Fset,
 		Files:            pkg.Syntax,

--- a/analyzer_core_internal_test.go
+++ b/analyzer_core_internal_test.go
@@ -107,3 +107,23 @@ func TestBuildSSATypeInfoValidation(t *testing.T) {
 		t.Fatalf("expected error for missing types info")
 	}
 }
+
+func TestBuildSSAIllTypedPackage(t *testing.T) {
+	t.Parallel()
+
+	a := NewAnalyzer(NewConfig(), false, false, false, 1, log.New(io.Discard, "", 0))
+
+	pkg := &packages.Package{
+		Name:      "illtyped",
+		IllTyped:  true,
+		Types:     types.NewPackage("example.com/p", "p"),
+		TypesInfo: &types.Info{},
+	}
+	_, err := a.buildSSA(pkg)
+	if err == nil {
+		t.Fatalf("expected error for ill-typed package")
+	}
+	if got := err.Error(); got != "package illtyped has type errors, skipping SSA analysis" {
+		t.Fatalf("unexpected error message: %s", err)
+	}
+}


### PR DESCRIPTION
## Summary

Packages with type errors (`pkg.IllTyped == true`) have partial type information that can cause nil pointer dereferences inside the SSA builder (`golang.org/x/tools/go/ssa.emitConv`). This results in a panic during `gosec` scans, even though the panic is caught by `defer/recover` — users still see a frightening 50+ line stack trace.

## Root Cause

When `packages.Load` processes a package with compilation errors, it still populates `pkg.Types` and `pkg.TypesInfo` with **partial** data. Some `TypesInfo.Types` entries have nil `Type` fields for expressions the type checker couldn't resolve. The SSA builder doesn't guard against these nil types in `emitConv`, causing a nil pointer dereference.

The existing guards in `buildSSA` check for `pkg.Types == nil` and `pkg.TypesInfo == nil`, but miss the case where these fields are populated with incomplete data.

## Fix

Add a `pkg.IllTyped` check in `buildSSA` (after the existing nil guards) that returns a clean error before attempting SSA construction. AST-based rules continue to run normally on the affected package.

**Before:**
```
[gosec] Panic when running SSA analyzer on package: models. Panic: runtime error: invalid memory address or nil pointer dereference
Stack trace:
goroutine 54 [running]:
runtime/debug.Stack()
... (50+ lines)
```

**After:**
```
[gosec] Error building the SSA representation of the package models: package models has type errors, skipping SSA analysis
```

## Changes

- `analyzer.go`: Add `pkg.IllTyped` guard in `buildSSA`
- `analyzer_core_internal_test.go`: Add `TestBuildSSAIllTypedPackage`

Fixes #1604
