### PR TITLE
Fix: Bump go-version: 1.25.8 to 1.25.9 in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - go-version: "1.25.8"
+          - go-version: "1.25.9"
             golangci: "latest"
           - go-version: "1.26.1"
             golangci: "latest"


### PR DESCRIPTION
Bump the go version entry from 1.25.8 to 1.25.9 to resolve 4 stdlib vulnerabilities flagged by `govulncheck` in CI.

| CVE | Package | Fix |
|---|---|---|
| GO-2026-4947 | `crypto/x509` | Chain building DoS |
| GO-2026-4946 | `crypto/x509` | Policy validation DoS |
| GO-2026-4870 | `crypto/tls` | TLS 1.3 KeyUpdate DoS |
| GO-2026-4865 | `html/template` | JsBraceDepth XSS |