### PR TITLE
chore(go): update supported Go versions to 1.25.9 and 1.26.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         version:
           - go-version: "1.25.9"
             golangci: "latest"
-          - go-version: "1.26.1"
+          - go-version: "1.26.2"
             golangci: "latest"
     runs-on: ubuntu-latest
     env:
@@ -57,7 +57,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
       - name: Checkout Source
         uses: actions/checkout@v6
       - uses: actions/cache@v5
@@ -107,7 +107,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
       - name: Checkout Source
         uses: actions/checkout@v6
       - uses: actions/cache@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
       - name: Install Cosign
         uses: sigstore/cosign-installer@v4.1.1
         with:


### PR DESCRIPTION
## Summary

- Bump Go 1.26.1 → 1.26.2 in CI and release workflows
- Go 1.25.9 was already current — no change needed
- Source: https://go.dev/doc/devel/release

**Files changed:**
- `.github/workflows/ci.yml` (matrix + single-version steps)
- `.github/workflows/release.yml` (setup-go version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)