### PR TITLE
Skip flagging the TLS min version for go 1.18+

### DIFF
--- a/rules/tls.go
+++ b/rules/tls.go
@@ -236,22 +236,28 @@ func (t *insecureConfigTLS) findDefinition(obj types.Object, c *gosec.Context) a
 	return initializer
 }
 
+func (t *insecureConfigTLS) isSafeDefault() bool {
+	major, minor, _ := gosec.GoVersion()
+	return major > 1 || (major == 1 && minor >= 18)
+}
+
 func (t *insecureConfigTLS) checkVersion(n ast.Node, c *gosec.Context) *issue.Issue {
-	// Flag explicitly low MinVersion (including explicit 0)
+	// Flag explicitly low MinVersion.
+	// Since Go 1.18+, MinVersion 0 means "use default" which is
+	// TLS 1.2 — safe and not worth flagging.
 	if t.minVersionSet && t.actualMinVersion < t.MinVersion {
+		if t.actualMinVersion == 0 && t.isSafeDefault() {
+			return nil
+		}
 		return c.NewIssue(n, t.ID(), "TLS MinVersion too low.", issue.High, issue.High)
 	}
 
-	// Handle MaxVersion
+	// Handle MaxVersion.
+	// MaxVersion 0 means "use latest" which is always safe.
 	if t.maxVersionSet {
-		// Special case for explicit MaxVersion: 0 (default latest) - suppress warning if MinVersion is securely set
 		if t.actualMaxVersion == 0 {
-			if t.minVersionSet && t.actualMinVersion >= t.MinVersion {
-				return nil
-			}
-			// Otherwise treat explicit 0 as potentially insecure (fall through to flag)
+			return nil
 		}
-		// Flag if explicitly capped too low (non-zero low values always flagged)
 		if t.actualMaxVersion < t.MaxVersion {
 			return c.NewIssue(n, t.ID(), "TLS MaxVersion too low.", issue.High, issue.High)
 		}
@@ -271,6 +277,7 @@ func (t *insecureConfigTLS) Match(n ast.Node, c *gosec.Context) (*issue.Issue, e
 	if complit, ok := n.(*ast.CompositeLit); ok && complit.Type != nil {
 		actualType := c.Info.TypeOf(complit.Type)
 		if actualType != nil && actualType.String() == t.requiredType {
+			defer t.resetVersion()
 			for _, elt := range complit.Elts {
 				if issue := t.processTLSConf(elt, c); issue != nil {
 					return issue, nil
@@ -279,7 +286,6 @@ func (t *insecureConfigTLS) Match(n ast.Node, c *gosec.Context) (*issue.Issue, e
 			if issue := t.checkVersion(complit, c); issue != nil {
 				return issue, nil
 			}
-			t.resetVersion()
 			return nil, nil
 		}
 	}

--- a/testutils/g402_samples.go
+++ b/testutils/g402_samples.go
@@ -40,7 +40,7 @@ func main() {
 }
 `}, 1, gosec.NewConfig()},
 	{[]string{`
-// Insecure minimum version
+// MinVersion 0 is safe on Go 1.18+ (defaults to TLS 1.2)
 package main
 
 import (
@@ -59,7 +59,7 @@ func main() {
 		fmt.Println(err)
 	}
 }
-`}, 1, gosec.NewConfig()},
+`}, 0, gosec.NewConfig()},
 	{[]string{`
 // Insecure minimum version
 package main
@@ -103,14 +103,14 @@ func main() {
 }
 `}, 0, gosec.NewConfig()},
 	{[]string{`
-// Insecure minimum version
+// MinVersion 0 is safe on Go 1.18+ (defaults to TLS 1.2)
 package main
 import (
 	"crypto/tls"
 	"fmt"
 )
 
-func CaseError() *tls.Config {
+func CaseNotError() *tls.Config {
 	var v = &tls.Config{
 		MinVersion: 0,
 	}
@@ -118,12 +118,12 @@ func CaseError() *tls.Config {
 }
 
 func main() {
-    a := CaseError()
+    a := CaseNotError()
 	fmt.Printf("Debug: %v\n", a.MinVersion)
 }
-`}, 1, gosec.NewConfig()},
+`}, 0, gosec.NewConfig()},
 	{[]string{`
-// Insecure minimum version
+// Unresolvable MinVersion from function call — safe on Go 1.18+
 package main
 
 import (
@@ -131,7 +131,7 @@ import (
 	"fmt"
 )
 
-func CaseError() *tls.Config {
+func CaseNotError() *tls.Config {
 	var v = &tls.Config{
 		MinVersion: getVersion(),
 	}
@@ -143,10 +143,10 @@ func getVersion() uint16 {
 }
 
 func main() {
-    a := CaseError()
+    a := CaseNotError()
 	fmt.Printf("Debug: %v\n", a.MinVersion)
 }
-`}, 1, gosec.NewConfig()},
+`}, 0, gosec.NewConfig()},
 	{[]string{`
 // Insecure minimum version
 package main
@@ -171,7 +171,7 @@ func main() {
 }
 `}, 0, gosec.NewConfig()},
 	{[]string{`
-// Insecure max version
+// MaxVersion 0 means "use latest" which is safe
 package main
 
 import (
@@ -190,7 +190,7 @@ func main() {
 		fmt.Println(err)
 	}
 }
-`}, 1, gosec.NewConfig()},
+`}, 0, gosec.NewConfig()},
 	{[]string{`
 // Insecure ciphersuite selection
 package main
@@ -258,7 +258,7 @@ import "crypto/tls"
 func TlsConfig1() *tls.Config {
    return &tls.Config{MinVersion: 0x0304}
 }
-`}, 1, gosec.NewConfig()},
+`}, 0, gosec.NewConfig()},
 	{[]string{`
 package main
 
@@ -379,4 +379,27 @@ func main() {
 	_ = &tls.Config{PreferServerCipherSuites: prefer}
 }
 `}, 1, gosec.NewConfig()},
+	{[]string{`
+// Explicitly insecure MinVersion (TLS 1.0) must still be flagged
+package main
+
+import "crypto/tls"
+
+func main() {
+	_ = &tls.Config{MinVersion: tls.VersionTLS10}
+}
+`}, 1, gosec.NewConfig()},
+	{[]string{`
+// MaxVersion 0 without MinVersion is safe (use latest)
+package main
+
+import "crypto/tls"
+
+func main() {
+	_ = &tls.Config{
+		MaxVersion: 0,
+		ServerName: "example.com",
+	}
+}
+`}, 0, gosec.NewConfig()},
 }


### PR DESCRIPTION
fixes #1627