### PR TITLE
Add G710 rule for open redirect via taint analysis

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -101,6 +101,7 @@
 - G707 — SMTP command/header injection via taint analysis (**Taint**)
 - G708 — Server-side template injection via `text/template` (**Taint**)
 - G709 — Unsafe deserialization of untrusted data (**Taint**)
+- G710 — Open redirect via taint analysis (**Taint**)
 
 _Note: Implementation types used in this document:_
 - **AST**: rule implemented in `rules/` and evaluated on AST patterns

--- a/analyzers/analyzers_test.go
+++ b/analyzers/analyzers_test.go
@@ -134,5 +134,9 @@ var _ = Describe("gosec analyzers", func() {
 		It("should detect unsafe deserialization via taint analysis", func() {
 			runner("G709", testutils.SampleCodeG709)
 		})
+
+		It("should detect open redirect via taint analysis", func() {
+			runner("G710", testutils.SampleCodeG710)
+		})
 	})
 })

--- a/analyzers/analyzerslist.go
+++ b/analyzers/analyzerslist.go
@@ -96,6 +96,13 @@ var (
 		CWE:         "CWE-502",
 	}
 
+	OpenRedirectRule = taint.RuleInfo{
+		ID:          "G710",
+		Description: "Open redirect: user-controlled URL flows into http.Redirect",
+		Severity:    "MEDIUM",
+		CWE:         "CWE-601",
+	}
+
 	FormParsingLimitRule = taint.RuleInfo{
 		ID:          "G120",
 		Description: "Unbounded multipart form parsing can cause memory exhaustion",
@@ -162,6 +169,7 @@ var defaultAnalyzers = []AnalyzerDefinition{
 	{"G707", "SMTP command/header injection via taint analysis", newSMTPInjectionAnalyzer},
 	{"G708", "Server-side template injection via taint analysis", newSSTIAnalyzer},
 	{"G709", "Unsafe deserialization of untrusted data via taint analysis", newUnsafeDeserializationAnalyzer},
+	{"G710", "Open redirect via taint analysis", newOpenRedirectAnalyzer},
 }
 
 // Generate the list of analyzers to use
@@ -199,6 +207,7 @@ func DefaultTaintAnalyzers() []*analysis.Analyzer {
 	sstiConfig := SSTI()
 	deserConfig := UnsafeDeserialization()
 	formConfig := FormParsingLimits()
+	openRedirectConfig := OpenRedirect()
 
 	return []*analysis.Analyzer{
 		taint.NewGosecAnalyzer(&SQLInjectionRule, &sqlConfig),
@@ -211,5 +220,6 @@ func DefaultTaintAnalyzers() []*analysis.Analyzer {
 		taint.NewGosecAnalyzer(&SSTIRule, &sstiConfig),
 		taint.NewGosecAnalyzer(&UnsafeDeserializationRule, &deserConfig),
 		taint.NewGosecAnalyzer(&FormParsingLimitRule, &formConfig),
+		taint.NewGosecAnalyzer(&OpenRedirectRule, &openRedirectConfig),
 	}
 }

--- a/analyzers/analyzerslist_test.go
+++ b/analyzers/analyzerslist_test.go
@@ -81,6 +81,12 @@ func TestTaintAnalyzerConstructors(t *testing.T) {
 			description: "Unsafe deserialization of untrusted data via taint analysis",
 		},
 		{
+			name:        "OpenRedirect",
+			constructor: newOpenRedirectAnalyzer,
+			id:          "G710",
+			description: "Open redirect via taint analysis",
+		},
+		{
 			name:        "FormParsingLimit",
 			constructor: newFormParsingLimitAnalyzer,
 			id:          "G120",
@@ -119,7 +125,7 @@ func TestTaintAnalyzerConstructors(t *testing.T) {
 
 // TestDefaultAnalyzersIncludeTaint tests that default analyzers include taint rules.
 func TestDefaultAnalyzersIncludeTaint(t *testing.T) {
-	expectedTaintIDs := []string{"G701", "G702", "G703", "G704", "G705", "G706", "G707", "G708", "G709"}
+	expectedTaintIDs := []string{"G701", "G702", "G703", "G704", "G705", "G706", "G707", "G708", "G709", "G710"}
 
 	found := make(map[string]bool)
 	for _, def := range defaultAnalyzers {
@@ -137,7 +143,7 @@ func TestDefaultAnalyzersIncludeTaint(t *testing.T) {
 func TestGenerateIncludesTaintAnalyzers(t *testing.T) {
 	analyzerList := Generate(false)
 
-	expectedTaintIDs := []string{"G701", "G702", "G703", "G704", "G705", "G706", "G707", "G708", "G709"}
+	expectedTaintIDs := []string{"G701", "G702", "G703", "G704", "G705", "G706", "G707", "G708", "G709", "G710"}
 
 	for _, id := range expectedTaintIDs {
 		if _, ok := analyzerList.Analyzers[id]; !ok {
@@ -302,7 +308,7 @@ func TestAnalyzerList_AnalyzersInfo(t *testing.T) {
 func TestDefaultTaintAnalyzers(t *testing.T) {
 	analyzers := DefaultTaintAnalyzers()
 
-	expectedCount := 10 // SQL, Command, Path, SSRF, XSS, Log, SMTP, SSTI, Deserialization, FormParsing
+	expectedCount := 11 // SQL, Command, Path, SSRF, XSS, Log, SMTP, SSTI, Deserialization, FormParsing, OpenRedirect
 	if len(analyzers) != expectedCount {
 		t.Errorf("Expected %d taint analyzers, got %d", expectedCount, len(analyzers))
 	}
@@ -317,6 +323,7 @@ func TestDefaultTaintAnalyzers(t *testing.T) {
 		"G707": false,
 		"G708": false,
 		"G709": false,
+		"G710": false,
 		"G120": false,
 	}
 

--- a/analyzers/openredirect.go
+++ b/analyzers/openredirect.go
@@ -1,0 +1,67 @@
+// (c) Copyright gosec's authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analyzers
+
+import (
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/securego/gosec/v2/taint"
+)
+
+// OpenRedirect returns a configuration for detecting open-redirect vulnerabilities
+// where user-controlled data flows into the URL argument of net/http.Redirect.
+// See CWE-601.
+func OpenRedirect() taint.Config {
+	return taint.Config{
+		Sources: []taint.Source{
+			// Type sources: tainted when received as parameters from external callers.
+			// Any read from a *http.Request (FormValue, URL.Query().Get, Cookie, etc.)
+			// propagates taint through the existing receiver-based logic in isTainted.
+			{Package: "net/http", Name: "Request", Pointer: true},
+			{Package: "net/url", Name: "URL", Pointer: true},
+			{Package: "net/url", Name: "Values"},
+		},
+		Sinks: []taint.Sink{
+			// http.Redirect(w, r, url, code): only the URL string (arg index 2)
+			// is the redirect target. Skipping arg 1 (*http.Request) prevents the
+			// receiver itself from being treated as a tainted sink argument.
+			{Package: "net/http", Method: "Redirect", CheckArgs: []int{2}},
+		},
+		Sanitizers: []taint.Sanitizer{
+			// url.PathEscape / QueryEscape neutralize untrusted path or query
+			// fragments embedded into a hard-coded base URL.
+			{Package: "net/url", Method: "PathEscape"},
+			{Package: "net/url", Method: "QueryEscape"},
+
+			// Numeric conversions cannot produce a URL host or scheme.
+			{Package: "strconv", Method: "Atoi"},
+			{Package: "strconv", Method: "Itoa"},
+			{Package: "strconv", Method: "ParseInt"},
+			{Package: "strconv", Method: "ParseUint"},
+			{Package: "strconv", Method: "FormatInt"},
+			{Package: "strconv", Method: "FormatUint"},
+		},
+	}
+}
+
+// newOpenRedirectAnalyzer creates an analyzer for detecting open-redirect
+// vulnerabilities via taint analysis (G710).
+func newOpenRedirectAnalyzer(id string, description string) *analysis.Analyzer {
+	config := OpenRedirect()
+	rule := OpenRedirectRule
+	rule.ID = id
+	rule.Description = description
+	return taint.NewGosecAnalyzer(&rule, &config)
+}

--- a/issue/issue.go
+++ b/issue/issue.go
@@ -112,6 +112,7 @@ var ruleToCWE = map[string]string{
 	"G704": "918",
 	"G705": "79",
 	"G706": "117",
+	"G710": "601",
 }
 
 // Issue is returned by a gosec rule if it discovers an issue with the scanned code.

--- a/testutils/g710_samples.go
+++ b/testutils/g710_samples.go
@@ -1,0 +1,68 @@
+package testutils
+
+import "github.com/securego/gosec/v2"
+
+// SampleCodeG710 - Open redirect via taint analysis
+var SampleCodeG710 = []CodeSample{
+	// Positive: query parameter flows directly into http.Redirect URL.
+	{[]string{`
+package main
+
+import (
+	"net/http"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	target := r.URL.Query().Get("next")
+	http.Redirect(w, r, target, http.StatusFound)
+}
+`}, 1, gosec.NewConfig()},
+
+	// Positive: form value concatenated into a redirect target.
+	{[]string{`
+package main
+
+import (
+	"net/http"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	dest := r.FormValue("redirect")
+	http.Redirect(w, r, "/proxy?to="+dest, http.StatusSeeOther)
+}
+`}, 1, gosec.NewConfig()},
+
+	// Negative: redirect to a constant URL — never tainted.
+	{[]string{`
+package main
+
+import (
+	"net/http"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	http.Redirect(w, r, "/dashboard", http.StatusFound)
+}
+`}, 0, gosec.NewConfig()},
+
+	// Negative: redirect target derived from numeric conversion of user input
+	// (strconv.Atoi sanitizer strips any redirect payload from the string).
+	{[]string{`
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.Atoi(r.URL.Query().Get("id"))
+	if err != nil {
+		http.Error(w, "bad id", http.StatusBadRequest)
+		return
+	}
+	http.Redirect(w, r, fmt.Sprintf("/users/%d", id), http.StatusFound)
+}
+`}, 0, gosec.NewConfig()},
+}


### PR DESCRIPTION
## Summary

Adds **G710** — an open-redirect detector that uses the existing taint engine to flag user-controlled data flowing into the URL argument of `net/http.Redirect` (CWE-601, severity MEDIUM).

Closes [#1652](https://github.com/securego/gosec/issues/1652).

## Why

`http.Redirect(w, r, userControlledURL, code)` lets attackers craft links that bounce victims to attacker-controlled hosts (phishing, OAuth/SAML relay). 
gosec currently has no rule for this pattern - `G119` covers redirect *header* propagation, not the redirect target itself.

## Approach

Reuses the existing taint infrastructure (`taint.Config` + `taint.NewGosecAnalyzer`) - same shape as G705 (XSS) and G706 (log injection). No changes to the `taint` package were needed:

- **Sources:** `*http.Request`, `*url.URL`, `url.Values` — taint propagates through any method call on a tainted receiver, so `r.FormValue`, `r.URL.Query().Get`, `r.Cookie`, etc. are all covered automatically.
- **Sink:** `net/http.Redirect` with `CheckArgs: []int{2}` to scope the check to the URL string and skip the `*http.Request` argument.
- **Sanitizers:** `url.PathEscape`, `url.QueryEscape`, and numeric `strconv` conversions (which cannot produce a host or scheme).

Constant URLs (e.g. `http.Redirect(w, r, "/dashboard", 302)`) never fire because `*ssa.Const` short-circuits in the taint engine.

## Test plan

- [x] `go build ./analyzers/... ./taint/... ./testutils/... ./issue/... ./cmd/...` — clean
- [x] `go test ./analyzers/ ./taint/ ./issue/` — all pass
- [x] G710 ginkgo spec passes all 4 sample cases (query param → redirect, concat → redirect, constant URL safe, `strconv.Atoi`-sanitized safe)
