### PR TITLE
Sync taint rule docs and add missing CWE mappings for G113/G307

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -97,7 +97,7 @@ func runMyAnalyzer(pass *analysis.Pass) (interface{}, error) {
 ### Creating taint analysis rules
 
 gosec taint analyzers track data flow from untrusted sources to dangerous sinks.
-Current taint rules include SQL injection, command injection, path traversal, SSRF, XSS, log injection, and SMTP injection.
+Current taint rules include SQL injection, command injection, path traversal, SSRF, XSS, log injection, SMTP injection, server-side template injection, unsafe deserialization, and open redirect.
 
 #### Steps
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ and SSA code representation.
   and crypto issues
 - **Taint analysis** for tracking data flow from user input to
   dangerous functions (SQL injection, command injection, path
-  traversal, SSRF, XSS, log injection)
+  traversal, SSRF, XSS, log injection, SMTP injection, SSTI,
+  unsafe deserialization, open redirect)
 
 ## License
 
@@ -226,7 +227,7 @@ gosec includes rules across these categories:
   range aliasing and slice bounds)
 - `G7xx`: taint analysis rules (SQL injection, command
   injection, path traversal, SSRF, XSS, log, SMTP injection,
-  SSTI and unsafe deserialization)
+  SSTI, unsafe deserialization, and open redirect)
 
 For the full list, rule descriptions, and per-rule
 configuration, see [RULES.md](RULES.md).

--- a/flag_test.go
+++ b/flag_test.go
@@ -16,7 +16,7 @@ var _ = Describe("Cli", func() {
 			os.Args = []string{"gosec", "-flag1=-incorrect"}
 			f := vflag.ValidatedFlag{}
 			flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
-			flag.Var(&f, "falg1", "")
+			flag.Var(&f, "flag1", "")
 			flag.CommandLine.Init("flag1", flag.ContinueOnError)
 			flag.Parse()
 			Expect(flag.Parsed()).Should(BeTrue())

--- a/issue/issue.go
+++ b/issue/issue.go
@@ -52,7 +52,9 @@ func GetCweByRule(id string) *cwe.Weakness {
 	return nil
 }
 
-// ruleToCWE maps gosec rules to CWEs
+// ruleToCWE maps gosec rules to CWEs. The key is the rule ID
+// and the value is the CWE ID. If a rule does not have a CWE,
+// it will not be included in this map.
 var ruleToCWE = map[string]string{
 	"G101": "798",
 	"G102": "200",
@@ -65,6 +67,7 @@ var ruleToCWE = map[string]string{
 	"G110": "409",
 	"G111": "22",
 	"G112": "400",
+	"G113": "444",
 	"G707": "93",
 	"G708": "94",
 	"G709": "502",
@@ -89,6 +92,7 @@ var ruleToCWE = map[string]string{
 	"G304": "22",
 	"G305": "22",
 	"G306": "276",
+	"G307": "276",
 	"G401": "328",
 	"G402": "295",
 	"G403": "310",


### PR DESCRIPTION
- Update README and DEVELOPMENT to list G707-G710 alongside the existing taint rules. 
- Add `CWE-444` for `G113` (HTTP request smuggling) and `CWE-276` for `G307` (`os.Create` permissions) so issues from those rules carry a CWE weakness instead of nil. 
- Fix a `falg1` typo in `flag_test` that prevented the validated-flag test from binding the flag it was meant to exercise.