### PR TITLE
chore(go): update supported Go versions to 1.25.10 and 1.26.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
     strategy:
       matrix:
         version:
-          - go-version: "1.25.9"
+          - go-version: "1.25.10"
             golangci: "latest"
-          - go-version: "1.26.2"
+          - go-version: "1.26.3"
             golangci: "latest"
     runs-on: ubuntu-latest
     permissions:
@@ -67,7 +67,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
       - name: Checkout Source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -123,7 +123,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
       - name: Checkout Source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
           cache: false
       - name: Install Cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1


### PR DESCRIPTION
## Summary

- Bump CI/release workflow Go versions to the latest patch releases of the supported 1.25 and 1.26 series.
- `.github/workflows/ci.yml`: matrix `1.25.9` → `1.25.10`, `1.26.2` → `1.26.3` (matrix, taint-perf-guard, coverage jobs).
- `.github/workflows/release.yml`: `1.26.2` → `1.26.3`.

Source: https://go.dev/doc/devel/release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

fixes #1667