### PR TITLE
Refactor error position parsing to support path with colon.

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -762,7 +762,7 @@ func ParseErrors(pkg *packages.Package) (map[string][]Error, error) {
 		return nil, nil
 	}
 	errs := make(map[string][]Error)
-	var posRegexp = regexp.MustCompile(`^(.*?)(?::(\w+))?(?::(\w+))?$`)
+	posRegexp := regexp.MustCompile(`^(.*?)(?::(\w+))?(?::(\w+))?$`)
 	for _, pkgErr := range pkg.Errors {
 		matches := posRegexp.FindStringSubmatch(pkgErr.Pos)
 		file := pkgErr.Pos

--- a/analyzer.go
+++ b/analyzer.go
@@ -29,6 +29,7 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"runtime/debug"
 	"strconv"
 	"strings"
@@ -761,20 +762,24 @@ func ParseErrors(pkg *packages.Package) (map[string][]Error, error) {
 		return nil, nil
 	}
 	errs := make(map[string][]Error)
+	var posRegexp = regexp.MustCompile(`^(.*?)(?::(\w+))?(?::(\w+))?$`)
 	for _, pkgErr := range pkg.Errors {
-		parts := strings.Split(pkgErr.Pos, ":")
-		file := parts[0]
+		matches := posRegexp.FindStringSubmatch(pkgErr.Pos)
+		file := pkgErr.Pos
 		var err error
-		var line int
-		if len(parts) > 1 {
-			if line, err = strconv.Atoi(parts[1]); err != nil {
-				return nil, fmt.Errorf("parsing line: %w", err)
+		var line, column int
+		if len(matches) > 0 {
+			file = matches[1]
+			file = strings.TrimSuffix(file, ":")
+			if matches[2] != "" {
+				if line, err = strconv.Atoi(matches[2]); err != nil {
+					return nil, fmt.Errorf("parsing line: %w", err)
+				}
 			}
-		}
-		var column int
-		if len(parts) > 2 {
-			if column, err = strconv.Atoi(parts[2]); err != nil {
-				return nil, fmt.Errorf("parsing column: %w", err)
+			if matches[3] != "" {
+				if column, err = strconv.Atoi(matches[3]); err != nil {
+					return nil, fmt.Errorf("parsing column: %w", err)
+				}
 			}
 		}
 		msg := strings.TrimSpace(pkgErr.Msg)

--- a/analyzer.go
+++ b/analyzer.go
@@ -771,12 +771,12 @@ func ParseErrors(pkg *packages.Package) (map[string][]Error, error) {
 		if len(matches) > 0 {
 			file = matches[1]
 			file = strings.TrimSuffix(file, ":")
-			if matches[2] != "" {
+			if len(matches) > 2 && matches[2] != "" {
 				if line, err = strconv.Atoi(matches[2]); err != nil {
 					return nil, fmt.Errorf("parsing line: %w", err)
 				}
 			}
-			if matches[3] != "" {
+			if len(matches) > 3 && matches[3] != "" {
 				if column, err = strconv.Atoi(matches[3]); err != nil {
 					return nil, fmt.Errorf("parsing column: %w", err)
 				}

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -1803,6 +1803,26 @@ func main() {
 			Expect(err).Should(HaveOccurred())
 		})
 
+		It("should properly parse the errors with colons in path", func() {
+			pkg := &packages.Package{
+				Errors: []packages.Error{
+					{
+						Pos: "C:\\file:1:2",
+						Msg: "build error",
+					},
+				},
+			}
+			errors, err := gosec.ParseErrors(pkg)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(errors).To(HaveLen(1))
+			for _, ferr := range errors {
+				Expect(ferr).To(HaveLen(1))
+				Expect(ferr[0].Line).To(Equal(1))
+				Expect(ferr[0].Column).To(Equal(2))
+				Expect(ferr[0].Err).Should(MatchRegexp(`build error`))
+			}
+		})
+
 		It("should append  error to the same file", func() {
 			pkg := &packages.Package{
 				Errors: []packages.Error{

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -85,12 +85,17 @@ var _ = Describe("Analyzer", func() {
 				func bar(){
 					println("package has two files!")
 				}`)
+			pkg.AddFile("foo:bar.go", `
+				package main
+				func fooBar(){
+					println("package has another file!")
+				}`)
 			err := pkg.Build()
 			Expect(err).ShouldNot(HaveOccurred())
 			err = analyzer.Process(buildTags, pkg.Path)
 			Expect(err).ShouldNot(HaveOccurred())
 			_, metrics, _ := analyzer.Report()
-			Expect(metrics.NumFiles).To(Equal(2))
+			Expect(metrics.NumFiles).To(Equal(3))
 		})
 
 		It("should be able to analyze multiple Go files concurrently", func() {
@@ -1810,11 +1815,15 @@ func main() {
 						Pos: "C:\\file:1:2",
 						Msg: "build error",
 					},
+					{
+						Pos: "file:100:1:2",
+						Msg: "build error",
+					},
 				},
 			}
 			errors, err := gosec.ParseErrors(pkg)
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(errors).To(HaveLen(1))
+			Expect(errors).To(HaveLen(2))
 			for _, ferr := range errors {
 				Expect(ferr).To(HaveLen(1))
 				Expect(ferr[0].Line).To(Equal(1))


### PR DESCRIPTION
Refactor error position parsing with regex to support path with colon.

This is my attempt to solve https://github.com/securego/gosec/issues/327. To reproduce the issue, run **gosec** with a Go file with invalid syntax either on Windows, or on Linux but in a path with colons (such as `~/home/test:code`)