### PR TITLE
feat: add G118 rule to detect insecure HTTP cookies missing Secure/HttpOnly flags

### DIFF
--- a/rules/cookie.go
+++ b/rules/cookie.go
@@ -1,0 +1,67 @@
+package rules
+
+import (
+	"go/ast"
+
+	"github.com/securego/gosec/v2"
+	"github.com/securego/gosec/v2/issue"
+)
+
+type insecureCookie struct {
+	issue.MetaData
+}
+
+func (r *insecureCookie) Match(n ast.Node, c *gosec.Context) (*issue.Issue, error) {
+	comp, ok := n.(*ast.CompositeLit)
+	if !ok {
+		return nil, nil
+	}
+	sel, ok := comp.Type.(*ast.SelectorExpr)
+	if !ok {
+		return nil, nil
+	}
+	ident, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return nil, nil
+	}
+	if ident.Name != "http" || sel.Sel.Name != "Cookie" {
+		return nil, nil
+	}
+	secureSet := false
+	httpOnlySet := false
+	for _, elt := range comp.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		key, ok := kv.Key.(*ast.Ident)
+		if !ok {
+			continue
+		}
+		val, ok := kv.Value.(*ast.Ident)
+		if !ok {
+			continue
+		}
+		if key.Name == "Secure" && val.Name == "true" {
+			secureSet = true
+		}
+		if key.Name == "HttpOnly" && val.Name == "true" {
+			httpOnlySet = true
+		}
+	}
+	if !secureSet || !httpOnlySet {
+		return c.NewIssue(n, r.ID(), r.What, r.Severity, r.Confidence), nil
+	}
+	return nil, nil
+}
+
+func NewInsecureCookie(id string, _ gosec.Config) (gosec.Rule, []ast.Node) {
+	return &insecureCookie{
+		MetaData: issue.NewMetaData(
+			id,
+			"Cookie does not have Secure and HttpOnly flags set to true.",
+			issue.Medium,
+			issue.High,
+		),
+	}, []ast.Node{(*ast.CompositeLit)(nil)}
+}

--- a/rules/rulelist.go
+++ b/rules/rulelist.go
@@ -78,6 +78,7 @@ func Generate(trackSuppressions bool, filters ...RuleFilter) RuleList {
 		{"G114", "Use of net/http serve function that has no support for setting timeouts", NewHTTPServeWithoutTimeouts},
 		{"G116", "Detect Trojan Source attacks using bidirectional Unicode characters", NewTrojanSource},
 		{"G117", "Potential exposure of secrets via JSON/YAML/XML/TOML marshaling", NewSecretSerialization},
+		{"G118", "Cookie missing Secure or HttpOnly flag", NewInsecureCookie},
 
 		// injection
 		{"G201", "SQL query construction using format string", NewSQLStrFormat},

--- a/testutils/source/cookie.go
+++ b/testutils/source/cookie.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"net/http"
+)
+
+func main() {
+	// G118: missing both Secure and HttpOnly
+	_ = http.Cookie{
+		Name:  "session",
+		Value: "abc123",
+	}
+
+	// G118: missing Secure
+	_ = http.Cookie{
+		Name:     "session",
+		Value:    "abc123",
+		HttpOnly: true,
+	}
+
+	// G118: missing HttpOnly
+	_ = http.Cookie{
+		Name:   "session",
+		Value:  "abc123",
+		Secure: true,
+	}
+
+	// OK: both flags set
+	_ = http.Cookie{
+		Name:     "session",
+		Value:    "abc123",
+		Secure:   true,
+		HttpOnly: true,
+	}
+}


### PR DESCRIPTION
## Summary

Adds a new gosec rule G118 to detect `http.Cookie` struct literals that are
missing the `Secure` and/or `HttpOnly` flags.

## Motivation

- Missing `Secure` flag allows cookie transmission over plain HTTP,
  exposing session tokens to network interception (CWE-614)
- Missing `HttpOnly` flag exposes cookies to JavaScript access,
  enabling theft via XSS attacks (CWE-1004)

This is a common misconfiguration in Go web applications and has no
existing gosec rule covering it.

## What this detects

- `http.Cookie{}` with no flags set — Severity: MEDIUM
- `http.Cookie{HttpOnly: true}` missing Secure — Severity: MEDIUM
- `http.Cookie{Secure: true}` missing HttpOnly — Severity: MEDIUM

## What this does NOT flag

- `http.Cookie{Secure: true, HttpOnly: true}` — correctly ignored

## Test results

3 issues detected, 1 safe cookie correctly ignored.

## References

- https://cwe.mitre.org/data/definitions/614.html
- https://cwe.mitre.org/data/definitions/1004.html
- https://owasp.org/www-community/controls/SecureCookieAttribute