### PR TITLE
fix(G404): flag missing math/rand weak-random functions

### DIFF
--- a/rules/rand.go
+++ b/rules/rand.go
@@ -30,10 +30,10 @@ func NewWeakRandCheck(id string, _ gosec.Config) (gosec.Rule, []ast.Node) {
 	rule := &weakRand{newCallListRule(id,
 		"Use of weak random number generator (math/rand or math/rand/v2 instead of crypto/rand)",
 		issue.High, issue.Medium)}
-	rule.AddAll("math/rand", "New", "Read", "Float32", "Float64", "Int", "Int31", "Int31n",
-		"Int63", "Int63n", "Intn", "NormFloat64", "Uint32", "Uint64")
-	rule.AddAll("math/rand/v2", "New", "Float32", "Float64", "Int", "Int32", "Int32N",
-		"Int64", "Int64N", "IntN", "N", "NormFloat64", "Uint32", "Uint32N", "Uint64", "Uint64N", "UintN")
+	rule.AddAll("math/rand", "New", "Read", "ExpFloat64", "Float32", "Float64", "Int", "Int31", "Int31n",
+		"Int63", "Int63n", "Intn", "NormFloat64", "Perm", "Shuffle", "Uint32", "Uint64")
+	rule.AddAll("math/rand/v2", "New", "ExpFloat64", "Float32", "Float64", "Int", "Int32", "Int32N",
+		"Int64", "Int64N", "IntN", "N", "NormFloat64", "Perm", "Shuffle", "Uint", "Uint32", "Uint32N", "Uint64", "Uint64N", "UintN")
 
 	return rule, []ast.Node{(*ast.CallExpr)(nil)}
 }

--- a/testutils/g404_samples.go
+++ b/testutils/g404_samples.go
@@ -184,4 +184,40 @@ func main() {
 	_ = rand3.IntN(2)  // bad
 }
 `}, 3, gosec.NewConfig()},
+	{[]string{`
+package main
+
+import "math/rand"
+
+func main() {
+	p := rand.Perm(10) // bad
+	println(len(p))
+	f := rand.ExpFloat64() // bad
+	println(f)
+	nums := []int{1, 2, 3}
+	rand.Shuffle(len(nums), func(i, j int) { // bad
+		nums[i], nums[j] = nums[j], nums[i]
+	})
+	println(nums[0])
+}
+`}, 3, gosec.NewConfig()},
+	{[]string{`
+package main
+
+import "math/rand/v2"
+
+func main() {
+	u := rand.Uint() // bad
+	println(u)
+	p := rand.Perm(10) // bad
+	println(len(p))
+	f := rand.ExpFloat64() // bad
+	println(f)
+	nums := []int{1, 2, 3}
+	rand.Shuffle(len(nums), func(i, j int) { // bad
+		nums[i], nums[j] = nums[j], nums[i]
+	})
+	println(nums[0])
+}
+`}, 4, gosec.NewConfig()},
 }


### PR DESCRIPTION
## the problem

G404's call lists for `math/rand` and `math/rand/v2` are missing several package-level functions that emit weak randomness, so calls to them aren't flagged. that's a false negative in a security rule: `rand.Perm`, `rand.Shuffle`, and `rand.ExpFloat64` all return or apply weak randomness but pass G404 clean today, and in v2 `rand.Uint` (added in Go 1.23) was never backfilled into the list either.

`rand.Uint64()` is flagged; sibling `rand.Uint()` is not. `NormFloat64` is in the list but `ExpFloat64` right next to it isn't. these are gaps, not deliberate exclusions.

## the fix

add the missing functions to both `AddAll` lists in `rules/rand.go`:

- `math/rand`: `Perm`, `Shuffle`, `ExpFloat64`
- `math/rand/v2`: `Uint`, `Perm`, `Shuffle`, `ExpFloat64`

same class of gap as issue #486 (`rand.Intn` was missing), which was fixed by extending this exact list.

## scope

after this, the v2 list is a complete superset of the package's weak-random functions. the one `math/rand` package-level function still excluded is `Seed`, on purpose: it consumes a seed and emits no number, so flagging it would be a false positive. seed-source constructors (`NewSource`, `NewPCG`, `NewChaCha8`) stay out for the same reason; `New` itself is already listed and still flagged.

## tests

added two positive samples to `testutils/g404_samples.go` (a `math/rand` case expecting 3 issues, a `math/rand/v2` case expecting 4). both report 0 on the current rule and the expected counts only after the fix lands. the existing `rand.New(rand.NewSource(...))` / `rand.New(rand.NewPCG(...))` samples still report exactly 1, so the seed-constructor boundary is unchanged.

`go test ./rules/` green, `golangci-lint run ./rules/... ./testutils/...` clean, and gosec's own G404 self-scan stays at 0 issues (gosec doesn't use `math/rand` in its source).
