### PR TITLE
fix: min+max G115 false positives

### DIFF
--- a/analyzers/range_analyzer.go
+++ b/analyzers/range_analyzer.go
@@ -1009,7 +1009,7 @@ func (ra *RangeAnalyzer) ComputeRange(v ssa.Value, block *ssa.BasicBlock) *range
 							res.minValue = minBounds(res.minValue, res.minValueSet, argRes.minValue, argRes.minValueSet, isSrcUnsigned)
 							res.minValueSet = res.minValueSet && argRes.minValueSet
 							res.maxValue = minBounds(res.maxValue, res.maxValueSet, argRes.maxValue, argRes.maxValueSet, isSrcUnsigned)
-							res.maxValueSet = res.maxValueSet && argRes.maxValueSet
+							res.maxValueSet = res.maxValueSet || argRes.maxValueSet
 						}
 						ra.releaseResult(argRes)
 					}
@@ -1023,7 +1023,7 @@ func (ra *RangeAnalyzer) ComputeRange(v ssa.Value, block *ssa.BasicBlock) *range
 							res.CopyFrom(argRes)
 						} else {
 							res.minValue = maxBounds(res.minValue, res.minValueSet, argRes.minValue, argRes.minValueSet, isSrcUnsigned)
-							res.minValueSet = res.minValueSet && argRes.minValueSet
+							res.minValueSet = res.minValueSet || argRes.minValueSet
 							res.maxValue = maxBounds(res.maxValue, res.maxValueSet, argRes.maxValue, argRes.maxValueSet, isSrcUnsigned)
 							res.maxValueSet = res.maxValueSet && argRes.maxValueSet
 						}

--- a/testutils/g115_samples.go
+++ b/testutils/g115_samples.go
@@ -1940,6 +1940,36 @@ func loopMissingLower(data []int) uint8 {
 	{[]string{`
 package main
 
+import (
+	"math"
+)
+
+func minMaxChecked(data []int) uint8 {
+	var out uint8
+	for i := 0; i < len(data); i++ {
+		out = uint8(max(0, min(math.MaxUint8, data[i])))
+	}
+	return out
+}
+	`}, 0, gosec.NewConfig()},
+	{[]string{`
+package main
+
+import (
+	"math"
+)
+
+func maxMinChecked(data []int) uint8 {
+	var out uint8
+	for i := 0; i < len(data); i++ {
+		out = uint8(min(math.MaxUint8, max(0, data[i])))
+	}
+	return out
+}
+	`}, 0, gosec.NewConfig()},
+	{[]string{`
+package main
+
 func issue1577RangeChecked(v int64) byte {
 	if v < -128 || v > 255 {
 		return 0


### PR DESCRIPTION
Good day,

I was doing some work and noticed that using `min` + `max` triggered an incorrect G115 warning.

The root cause (in `analyzers/range_analyzer.go:1002-1034`) was that the min/max builtin handlers combined argument ranges using `&&` on both the minValueSet and maxValueSet flags. This was incorrect as only one direction needs `&&`.

per builtin:
- `min(a, b)`: upper bound is `min(a.max, b.max)` and either known max bounds the result. Should be `||` for `maxValueSet`.
- `max(a, b)`: lower bound is `max(a.min, b.min)` and either known min bounds the result. Should be `||` for `minValueSet`.

For `uint8(max(0, min(MaxUint8, data[i])))`, `data[i]` has no derivable range,
so the `&&` clobbered the constant bound from the other arg and the analyzer lost the `[0, 255]` envelope.

Thank you for reviewing this PR and maintaining this very useful tool!