### PR TITLE
Downgrade min Go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -66,4 +66,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.25.8
+go 1.25.0


### PR DESCRIPTION
The PR #1693 has reverted the changes from #1687 and updated the min Go version.

After that, the module `google.golang.org/api` has downgraded its min Go version in `v0.288.0`.

The PR #1703 updated the module `google.golang.org/api` to `v0.288.0` but the min Go version has not been changed.
