### PR TITLE
fix(G202): don't flag strings.Builder built from constants

### DIFF
--- a/resolve.go
+++ b/resolve.go
@@ -14,7 +14,11 @@
 
 package gosec
 
-import "go/ast"
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+)
 
 func resolveIdent(n *ast.Ident, c *Context) bool {
 	if n.Obj == nil || n.Obj.Kind != ast.Var {
@@ -66,9 +70,152 @@ func resolveBinExpr(n *ast.BinaryExpr, c *Context) bool {
 	return (TryResolve(n.X, c) && TryResolve(n.Y, c))
 }
 
-func resolveCallExpr(_ *ast.CallExpr, _ *Context) bool {
+func resolveCallExpr(node *ast.CallExpr, c *Context) bool {
+	// A strings.Builder / bytes.Buffer .String() call resolves to a constant when
+	// every value written to the receiver is itself a constant. This keeps rules
+	// such as G202 consistent with their lenient handling of constant string
+	// concatenation (e.g. building a value with +=) and avoids false positives
+	// when a builder is used purely to assemble a constant string.
+	if obj, ok := builderStringReceiver(node, c); ok {
+		return builderWritesAreConst(obj, node, c)
+	}
 	// TODO(tkelsey): next step, full function resolution
 	return false
+}
+
+// builderStringReceiver returns the receiver's object when node is a call to
+// String() on a strings.Builder or bytes.Buffer value.
+func builderStringReceiver(node *ast.CallExpr, c *Context) (types.Object, bool) {
+	sel, ok := node.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "String" || len(node.Args) != 0 {
+		return nil, false
+	}
+	ident, ok := sel.X.(*ast.Ident)
+	if !ok || !isStringBuilderType(c.Info.TypeOf(ident)) {
+		return nil, false
+	}
+	obj := c.Info.ObjectOf(ident)
+	if obj == nil {
+		return nil, false
+	}
+	// Only reason about local builders; a package-level one may be written to
+	// in files we do not inspect here.
+	if c.Pkg != nil && obj.Parent() == c.Pkg.Scope() {
+		return nil, false
+	}
+	return obj, true
+}
+
+// isStringBuilderType reports whether t is strings.Builder or bytes.Buffer
+// (or a pointer to either).
+func isStringBuilderType(t types.Type) bool {
+	if ptr, ok := t.(*types.Pointer); ok {
+		t = ptr.Elem()
+	}
+	named, ok := t.(*types.Named)
+	if !ok {
+		return false
+	}
+	obj := named.Obj()
+	if obj == nil || obj.Pkg() == nil {
+		return false
+	}
+	switch obj.Pkg().Path() + "." + obj.Name() {
+	case "strings.Builder", "bytes.Buffer":
+		return true
+	}
+	return false
+}
+
+// builderWritesAreConst reports whether every value written to the builder
+// referenced by obj is a constant. It is conservative: any usage of the builder
+// that cannot be reasoned about (e.g. its address escaping to a function) makes
+// it return false.
+func builderWritesAreConst(obj types.Object, strCall *ast.CallExpr, c *Context) bool {
+	file := ContainingFile(strCall, c)
+	if file == nil {
+		return false
+	}
+
+	allRefs := map[*ast.Ident]bool{}
+	accounted := map[*ast.Ident]bool{}
+	safe := true
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.Ident:
+			if c.Info.ObjectOf(node) == obj {
+				allRefs[node] = true
+			}
+		case *ast.ValueSpec: // var b strings.Builder
+			for _, name := range node.Names {
+				if c.Info.ObjectOf(name) == obj {
+					accounted[name] = true
+				}
+			}
+		case *ast.AssignStmt:
+			if node.Tok != token.DEFINE {
+				return true
+			}
+			for i, lhs := range node.Lhs {
+				id, ok := lhs.(*ast.Ident)
+				if !ok || c.Info.ObjectOf(id) != obj {
+					continue
+				}
+				accounted[id] = true
+				// Only an empty composite literal (strings.Builder{}) is a
+				// known-empty starting point; anything else is opaque.
+				if len(node.Rhs) != len(node.Lhs) || !isEmptyCompositeLit(node.Rhs[i]) {
+					safe = false
+				}
+			}
+		case *ast.CallExpr: // b.WriteString(...), b.String(), ...
+			sel, ok := node.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			recv, ok := sel.X.(*ast.Ident)
+			if !ok || c.Info.ObjectOf(recv) != obj {
+				return true
+			}
+			accounted[recv] = true
+			switch sel.Sel.Name {
+			case "WriteString", "WriteByte", "WriteRune", "Write":
+				for _, arg := range node.Args {
+					if !TryResolve(arg, c) {
+						safe = false
+					}
+				}
+			case "String", "Len", "Cap", "Reset", "Grow":
+				// read-only or adds no content
+			default:
+				safe = false
+			}
+		}
+		return true
+	})
+
+	if !safe {
+		return false
+	}
+	// Any reference we could not account for (e.g. &b passed to a function)
+	// means the builder's contents are unknown.
+	for id := range allRefs {
+		if !accounted[id] {
+			return false
+		}
+	}
+	return true
+}
+
+// isEmptyCompositeLit reports whether e is an empty composite literal, optionally
+// address-taken (e.g. strings.Builder{} or &strings.Builder{}).
+func isEmptyCompositeLit(e ast.Expr) bool {
+	if u, ok := e.(*ast.UnaryExpr); ok && u.Op == token.AND {
+		e = u.X
+	}
+	cl, ok := e.(*ast.CompositeLit)
+	return ok && len(cl.Elts) == 0
 }
 
 // TryResolve will attempt, given a subtree starting at some AST node, to resolve

--- a/resolve_test.go
+++ b/resolve_test.go
@@ -337,5 +337,189 @@ var _ = Describe("Resolve ast node to concrete value", func() {
 			Expect(value).ShouldNot(BeNil())
 			Expect(gosec.TryResolve(value, ctx)).Should(BeFalse())
 		})
+
+		It("should resolve a strings.Builder built only from constants", func() {
+			var call *ast.CallExpr
+			pkg := testutils.NewTestPackage()
+			defer pkg.Close()
+			pkg.AddFile("foo.go", `package main; import "strings"; func main(){ var b strings.Builder; b.WriteString(","); b.WriteString("?"); println(b.String()) }`)
+			ctx := pkg.CreateContext("foo.go")
+			ctx.PkgFiles = []*ast.File{ctx.Root}
+			v := testutils.NewMockVisitor()
+			v.Callback = func(n ast.Node, ctx *gosec.Context) bool {
+				if node, ok := n.(*ast.CallExpr); ok {
+					if sel, ok := node.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "String" {
+						call = node
+						return false
+					}
+				}
+				return true
+			}
+			v.Context = ctx
+			ast.Walk(v, ctx.Root)
+			Expect(call).ShouldNot(BeNil())
+			Expect(gosec.TryResolve(call, ctx)).Should(BeTrue())
+		})
+
+		It("should resolve a *strings.Builder literal built only from constants", func() {
+			var call *ast.CallExpr
+			pkg := testutils.NewTestPackage()
+			defer pkg.Close()
+			pkg.AddFile("foo.go", `package main; import "strings"; func main(){ b := &strings.Builder{}; b.Grow(8); b.WriteString("?"); println(b.String()) }`)
+			ctx := pkg.CreateContext("foo.go")
+			ctx.PkgFiles = []*ast.File{ctx.Root}
+			v := testutils.NewMockVisitor()
+			v.Callback = func(n ast.Node, ctx *gosec.Context) bool {
+				if node, ok := n.(*ast.CallExpr); ok {
+					if sel, ok := node.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "String" {
+						call = node
+						return false
+					}
+				}
+				return true
+			}
+			v.Context = ctx
+			ast.Walk(v, ctx.Root)
+			Expect(call).ShouldNot(BeNil())
+			Expect(gosec.TryResolve(call, ctx)).Should(BeTrue())
+		})
+
+		It("should resolve a bytes.Buffer built only from constants", func() {
+			var call *ast.CallExpr
+			pkg := testutils.NewTestPackage()
+			defer pkg.Close()
+			pkg.AddFile("foo.go", `package main; import "bytes"; func main(){ var b bytes.Buffer; b.WriteString("?"); b.WriteByte(','); println(b.String()) }`)
+			ctx := pkg.CreateContext("foo.go")
+			ctx.PkgFiles = []*ast.File{ctx.Root}
+			v := testutils.NewMockVisitor()
+			v.Callback = func(n ast.Node, ctx *gosec.Context) bool {
+				if node, ok := n.(*ast.CallExpr); ok {
+					if sel, ok := node.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "String" {
+						call = node
+						return false
+					}
+				}
+				return true
+			}
+			v.Context = ctx
+			ast.Walk(v, ctx.Root)
+			Expect(call).ShouldNot(BeNil())
+			Expect(gosec.TryResolve(call, ctx)).Should(BeTrue())
+		})
+
+		It("should not resolve a builder written with non-constant input", func() {
+			var call *ast.CallExpr
+			pkg := testutils.NewTestPackage()
+			defer pkg.Close()
+			pkg.AddFile("foo.go", `package main; import ("os"; "strings"); func main(){ var b strings.Builder; b.WriteString(os.Args[0]); println(b.String()) }`)
+			ctx := pkg.CreateContext("foo.go")
+			ctx.PkgFiles = []*ast.File{ctx.Root}
+			v := testutils.NewMockVisitor()
+			v.Callback = func(n ast.Node, ctx *gosec.Context) bool {
+				if node, ok := n.(*ast.CallExpr); ok {
+					if sel, ok := node.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "String" {
+						call = node
+						return false
+					}
+				}
+				return true
+			}
+			v.Context = ctx
+			ast.Walk(v, ctx.Root)
+			Expect(call).ShouldNot(BeNil())
+			Expect(gosec.TryResolve(call, ctx)).Should(BeFalse())
+		})
+
+		It("should not resolve a builder whose address escapes", func() {
+			var call *ast.CallExpr
+			pkg := testutils.NewTestPackage()
+			defer pkg.Close()
+			pkg.AddFile("foo.go", `package main; import ("fmt"; "strings"); func main(){ var b strings.Builder; b.WriteString("?"); fmt.Fprintf(&b, "%s", "x"); println(b.String()) }`)
+			ctx := pkg.CreateContext("foo.go")
+			ctx.PkgFiles = []*ast.File{ctx.Root}
+			v := testutils.NewMockVisitor()
+			v.Callback = func(n ast.Node, ctx *gosec.Context) bool {
+				if node, ok := n.(*ast.CallExpr); ok {
+					if sel, ok := node.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "String" {
+						call = node
+						return false
+					}
+				}
+				return true
+			}
+			v.Context = ctx
+			ast.Walk(v, ctx.Root)
+			Expect(call).ShouldNot(BeNil())
+			Expect(gosec.TryResolve(call, ctx)).Should(BeFalse())
+		})
+
+		It("should not resolve a builder from an opaque initializer", func() {
+			var call *ast.CallExpr
+			pkg := testutils.NewTestPackage()
+			defer pkg.Close()
+			pkg.AddFile("foo.go", `package main; import "strings"; func makeB() strings.Builder { var b strings.Builder; b.WriteString("?"); return b }; func main(){ b := makeB(); println(b.String()) }`)
+			ctx := pkg.CreateContext("foo.go")
+			ctx.PkgFiles = []*ast.File{ctx.Root}
+			v := testutils.NewMockVisitor()
+			v.Callback = func(n ast.Node, ctx *gosec.Context) bool {
+				if node, ok := n.(*ast.CallExpr); ok {
+					if sel, ok := node.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "String" {
+						call = node
+						return false
+					}
+				}
+				return true
+			}
+			v.Context = ctx
+			ast.Walk(v, ctx.Root)
+			Expect(call).ShouldNot(BeNil())
+			Expect(gosec.TryResolve(call, ctx)).Should(BeFalse())
+		})
+
+		It("should not resolve a builder written with an unsupported method", func() {
+			var call *ast.CallExpr
+			pkg := testutils.NewTestPackage()
+			defer pkg.Close()
+			pkg.AddFile("foo.go", `package main; import "bytes"; func main(){ var b bytes.Buffer; b.WriteString("?"); b.Truncate(0); println(b.String()) }`)
+			ctx := pkg.CreateContext("foo.go")
+			ctx.PkgFiles = []*ast.File{ctx.Root}
+			v := testutils.NewMockVisitor()
+			v.Callback = func(n ast.Node, ctx *gosec.Context) bool {
+				if node, ok := n.(*ast.CallExpr); ok {
+					if sel, ok := node.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "String" {
+						call = node
+						return false
+					}
+				}
+				return true
+			}
+			v.Context = ctx
+			ast.Walk(v, ctx.Root)
+			Expect(call).ShouldNot(BeNil())
+			Expect(gosec.TryResolve(call, ctx)).Should(BeFalse())
+		})
+
+		It("should not resolve a package-level builder", func() {
+			var call *ast.CallExpr
+			pkg := testutils.NewTestPackage()
+			defer pkg.Close()
+			pkg.AddFile("foo.go", `package main; import "strings"; var b strings.Builder; func main(){ b.WriteString("?"); println(b.String()) }`)
+			ctx := pkg.CreateContext("foo.go")
+			ctx.PkgFiles = []*ast.File{ctx.Root}
+			v := testutils.NewMockVisitor()
+			v.Callback = func(n ast.Node, ctx *gosec.Context) bool {
+				if node, ok := n.(*ast.CallExpr); ok {
+					if sel, ok := node.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "String" {
+						call = node
+						return false
+					}
+				}
+				return true
+			}
+			v.Context = ctx
+			ast.Walk(v, ctx.Root)
+			Expect(call).ShouldNot(BeNil())
+			Expect(gosec.TryResolve(call, ctx)).Should(BeFalse())
+		})
 	})
 })

--- a/testutils/g202_samples.go
+++ b/testutils/g202_samples.go
@@ -494,4 +494,62 @@ func main() {
 	_, _ = db.Query(query)
 }
 `}, 1, gosec.NewConfig()},
+	{[]string{`
+// strings.Builder assembling a constant SQL fragment - should NOT flag
+package main
+
+import (
+	"database/sql"
+	"strings"
+)
+
+func main() {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		panic(err)
+	}
+	ids := []int{1, 2, 3}
+	var ph strings.Builder
+	for i := range ids {
+		if i > 0 {
+			ph.WriteString(",")
+		}
+		ph.WriteString("?")
+	}
+	placeholders := ph.String()
+	q := "SELECT col1 FROM table1 WHERE id IN (" + placeholders + ")"
+	rows, err := db.Query(q)
+	if err != nil {
+		panic(err)
+	}
+	defer rows.Close()
+}
+`}, 0, gosec.NewConfig()},
+	{[]string{`
+// strings.Builder fed with tainted input - should flag
+package main
+
+import (
+	"database/sql"
+	"os"
+	"strings"
+)
+
+func main() {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		panic(err)
+	}
+	var ph strings.Builder
+	for _, a := range os.Args {
+		ph.WriteString(a)
+	}
+	q := "SELECT col1 FROM table1 WHERE id IN (" + ph.String() + ")"
+	rows, err := db.Query(q)
+	if err != nil {
+		panic(err)
+	}
+	defer rows.Close()
+}
+`}, 1, gosec.NewConfig()},
 }


### PR DESCRIPTION
# fix(G202): don't flag `strings.Builder` built from constants

## Problem

G202 (SQL string concatenation) reports a false positive when a query is built by concatenating the result of a `strings.Builder` (or `bytes.Buffer`) whose content is only constant literals — the common, efficient idiom for building
SQL `IN (...)` placeholder lists.

The inconsistency: the equivalent `+=` construction is **not** flagged, but the `strings.Builder` replacement (recommended for efficiency) **is**.

Fixes: #1701 

```go
var ph strings.Builder
for i := range ids {
    if i > 0 {
        ph.WriteString(",")
    }
    ph.WriteString("?")
}
placeholders := ph.String()
q := "SELECT col1 FROM table1 WHERE id IN (" + placeholders + ")" // G202 (false positive)
```

## Root cause

`TryResolve` treats any function-call result as unresolved (tainted), so `builder.String()` was always considered non-constant, regardless of what was written into the builder.

## Fix

`resolveCallExpr` now recognizes `strings.Builder.String()` / `bytes.Buffer.String()` and resolves it to a constant **only when every write into that builder is a constant**. It stays conservative - a non-constant write, an opaque initializer, an escaping address, or a package-level builder all keep the query flagged. Genuinely tainted builders are still detected.

## How to test (quick)

Unit tests (covers the new positive + negative samples):

```bash
go test -run TestRules ./rules/
```

End-to-end — drop this into a file and scan it:

```go
// repro.go
package main

import (
	"database/sql"
	"os"
	"strings"
)

func main() {
	db, _ := sql.Open("sqlite3", ":memory:")

	// SAFE — builder fed only constants: should NOT be flagged
	var ok strings.Builder
	for i := 0; i < 3; i++ {
		if i > 0 {
			ok.WriteString(",")
		}
		ok.WriteString("?")
	}
	rows, _ := db.Query("SELECT * FROM t WHERE id IN (" + ok.String() + ")")
	defer rows.Close()

	// TAINTED — builder fed os.Args: should STILL be flagged
	var bad strings.Builder
	for _, a := range os.Args {
		bad.WriteString(a)
	}
	rows2, _ := db.Query("SELECT * FROM t WHERE id IN (" + bad.String() + ")")
	defer rows2.Close()
}
```

```bash
go run ./cmd/gosec/ -include=G202 ./path/to/repro/...
```

**Expected:** exactly **1 issue** — the tainted builder is reported, the constant-only builder is not. Before this change, both were reported.
