### PR TITLE
ci: allow fork PR checkout in barry-ai-security-review job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
       - name: Run Barry AI Security Review
         id: barry
         uses: ccojocar/barry@main # zizmor: ignore[unpinned-uses]


### PR DESCRIPTION
This fixes the barry-ai-security-review job failing on every fork PR after the recent actions/checkout v7 bump, which added a guard that refuses to check out fork PR code from a pull_request_target workflow unless explicitly opted in. 

Since this job intentionally checks out the PR head (github.event.pull_request.head.sha) to scan the incoming changes, this adds `allow-unsafe-pr-checkout: true` to that checkout step to restore the intended behavior. The job remains gated behind the security-review environment, so maintainer approval still guards secret access before any fork code runs.