### PR TITLE
fix(csv): report a failed write instead of returning nil

### DIFF
--- a/report/csv/writer.go
+++ b/report/csv/writer.go
@@ -10,7 +10,6 @@ import (
 // WriteReport write a report in csv format to the output writer
 func WriteReport(w io.Writer, data *gosec.ReportInfo) error {
 	out := csv.NewWriter(w)
-	defer out.Flush()
 	for _, issue := range data.Issues {
 		err := out.Write([]string{
 			issue.File,
@@ -25,5 +24,7 @@ func WriteReport(w io.Writer, data *gosec.ReportInfo) error {
 			return err
 		}
 	}
-	return nil
+	// csv.Writer buffers its output, so write errors only surface on flush.
+	out.Flush()
+	return out.Error()
 }

--- a/report/csv/writer_test.go
+++ b/report/csv/writer_test.go
@@ -2,6 +2,7 @@ package csv_test
 
 import (
 	"bytes"
+	"errors"
 	"strings"
 	"testing"
 
@@ -12,6 +13,13 @@ import (
 	"github.com/securego/gosec/v2/issue"
 	"github.com/securego/gosec/v2/report/csv"
 )
+
+// failingWriter always fails, to check that write errors are reported.
+type failingWriter struct{}
+
+func (failingWriter) Write(p []byte) (int, error) {
+	return 0, errors.New("disk full")
+}
 
 func TestCSV(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -104,6 +112,30 @@ var _ = Describe("CSV Writer", func() {
 			Expect(lines).To(HaveLen(2))
 			Expect(result).To(ContainSubstring("/test1.go"))
 			Expect(result).To(ContainSubstring("/test2.go"))
+		})
+
+		It("should report an error when the writer fails", func() {
+			data := &gosec.ReportInfo{
+				Errors: map[string][]gosec.Error{},
+				Issues: []*issue.Issue{
+					{
+						File:       "/test.go",
+						Line:       "1",
+						Col:        "1",
+						RuleID:     "G101",
+						What:       "Hardcoded credentials",
+						Confidence: issue.High,
+						Severity:   issue.Medium,
+						Code:       "password := \"secret\"",
+						Cwe:        issue.GetCweByRule("G101"),
+					},
+				},
+				Stats: &gosec.Metrics{},
+			}
+
+			err := csv.WriteReport(failingWriter{}, data)
+			Expect(err).Should(HaveOccurred())
+			Expect(err).To(MatchError(ContainSubstring("disk full")))
 		})
 	})
 })


### PR DESCRIPTION
## What's broken

`-fmt=csv` returns success after a write that failed completely. It is the only one of the nine formatters that does.

Calling `report.CreateReport` with an `io.Writer` that always errors:

```
json       err=disk full
yaml       err=disk full
csv        err=<nil>          <- the bug
junit-xml  err=disk full
html       err=disk full
text       err=disk full
sonarqube  err=disk full
golint     err=disk full
sarif      err=disk full
```

With `-out report.csv` on a full disk or a broken pipe, gosec writes a truncated file and exits as though it had succeeded.

## The fix

`csv.Writer` buffers through a `bufio.Writer`, so the per-record `out.Write` returns nil and the real error only surfaces from `Flush` or `Error`. Both were discarded by `defer out.Flush()`.

Flushing explicitly and returning `out.Error()` puts csv back in line with the other eight. After the change its row reads `csv err=disk full`, and the other eight are unchanged.

A successful write is byte-identical to before:

```
/home/src/project/test.go,1,Hardcoded credentials,MEDIUM,HIGH,"password := ""secret""",CWE-798
/home/src/project/other.go,20,Binds to all interfaces,LOW,MEDIUM,"net.Listen(""tcp"", "":80"")",CWE-200
```

## Verification

A failing-writer spec in `report/csv/writer_test.go`, following the shape of the existing specs there. With the change reverted it fails with `Expected an error to have occurred. Got: <nil>`.

`go test ./...` passes everywhere except `autofix / TestGenerateSolution_ClaudeProvider`, which expects an error from a live Claude API call and fails identically on an untouched tree here. Every package under `report/` is green.
