### PR TITLE
fix(config): -nosec-tag values from the help text silently do nothing

### DIFF
--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -1470,6 +1470,29 @@ func main() {
 			Expect(nosecIssues).Should(BeEmpty())
 		})
 
+		It("should be possible to use an alternative nosec tag which already starts with a hash", func() {
+			// Rule for MD5 weak crypto usage
+			sample := testutils.SampleCodeG401[0]
+			source := sample.Code[0]
+
+			// overwrite nosec option, using the documented '#'-prefixed form
+			nosecIgnoreConfig := gosec.NewConfig()
+			nosecIgnoreConfig.SetGlobal(gosec.NoSecAlternative, "#falsePositive")
+			customAnalyzer := gosec.NewAnalyzer(nosecIgnoreConfig, tests, false, false, 1, logger)
+			customAnalyzer.LoadRules(rules.Generate(false, rules.NewRuleFilter(false, "G401")).RulesInfo())
+
+			nosecPackage := testutils.NewTestPackage()
+			defer nosecPackage.Close()
+			nosecSource := strings.Replace(source, "h := md5.New()", "h := md5.New() // #falsePositive", 1)
+			nosecPackage.AddFile("md5.go", nosecSource)
+			err := nosecPackage.Build()
+			Expect(err).ShouldNot(HaveOccurred())
+			err = customAnalyzer.Process(buildTags, nosecPackage.Path)
+			Expect(err).ShouldNot(HaveOccurred())
+			nosecIssues, _, _ := customAnalyzer.Report()
+			Expect(nosecIssues).Should(BeEmpty())
+		})
+
 		It("should be possible to use an alternative nosec tag", func() {
 			// Rule for DES weak crypto usage
 			sample := testutils.SampleCodeG405[0]

--- a/config.go
+++ b/config.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 )
 
 const (
@@ -45,8 +46,10 @@ const (
 )
 
 // NoSecTag returns the tag used to disable gosec for a line of code.
+// A single leading '#' is tolerated, so that both "dontanalyze" and
+// "#dontanalyze" produce the same "#dontanalyze" tag.
 func NoSecTag(tag string) string {
-	return fmt.Sprintf("%s%s", "#", tag)
+	return fmt.Sprintf("%s%s", "#", strings.TrimPrefix(tag, "#"))
 }
 
 // Config is used to provide configuration and customization to each of the rules.

--- a/config_test.go
+++ b/config_test.go
@@ -206,4 +206,22 @@ var _ = Describe("Configuration", func() {
 			Expect(rules).Should(BeNil())
 		})
 	})
+
+	Context("when building the nosec tag", func() {
+		It("should prepend a hash to a bare tag", func() {
+			Expect(gosec.NoSecTag("dontanalyze")).Should(Equal("#dontanalyze"))
+		})
+
+		It("should not double the hash of an already prefixed tag", func() {
+			Expect(gosec.NoSecTag("#dontanalyze")).Should(Equal("#dontanalyze"))
+		})
+
+		It("should only trim a single leading hash", func() {
+			Expect(gosec.NoSecTag("##dontanalyze")).Should(Equal("##dontanalyze"))
+		})
+
+		It("should keep hashes which are not leading", func() {
+			Expect(gosec.NoSecTag("dont#analyze")).Should(Equal("#dont#analyze"))
+		})
+	})
 })


### PR DESCRIPTION
## What's broken

`-nosec-tag`'s own help text documents values that silently do nothing.

```
-nosec-tag string
      Set an alternative string for #nosec. Some examples: #dontanalyze, #falsepositive
```

Against a file with `// #dontanalyze` on the offending line:

```
$ gosec -fmt=golint ./...                            # baseline
a.go:6:2: [CWE-276] Expect WriteFile permissions to be 0600 or less (Rule:G306, ...)

$ gosec -nosec-tag=dontanalyze -fmt=golint ./...     # works
(no output)

$ gosec -nosec-tag='#dontanalyze' -fmt=golint ./...  # exactly what --help says
a.go:6:2: [CWE-276] Expect WriteFile permissions to be 0600 or less (Rule:G306, ...)
```

`NoSecTag` prepends a `#` unconditionally, so the documented value becomes `##dontanalyze` and matches nothing. Following the help verbatim silently disables nothing at all, which is the worst way for a suppression flag to fail: there is no error, and the report looks like the annotation was ignored on purpose.

## The fix

`NoSecTag` now trims a single leading `#` before prepending one, so both spellings produce the same tag.

The fix belongs there rather than at the flag, because `NoSecTag` is the single funnel used by all three tag sources in `analyzer.go`: the default, the `nosec` global from a JSON config, and `NoSecAlternative`. Fixing only the CLI flag would leave a `.gosec.json` carrying `"nosec": "#dontanalyze"` in exactly the same trap.

The existing spelling is unaffected: `-nosec-tag=dontanalyze` still works, as do the pre-existing `NoSecAlternative` specs.

No wording change was needed, since the help text already describes the behaviour this makes true.

## Verification

Cases in `config_test.go` for the bare tag, the `#`-prefixed tag, that only one `#` is trimmed, and that a non-leading `#` is preserved. Plus a spec in `analyzer_test.go` for an alternative tag that already starts with a hash, alongside the existing alternative-tag specs.

Reverting the trim fails exactly those, and nothing else.

`go test . ./cmd/gosec/` is green. The full `go test ./...` ends in FAIL only on `autofix / TestGenerateSolution_ClaudeProvider`, which expects an error from a live Claude API call and fails identically on an untouched tree here.
