### PR TITLE
fix(junit): escape XML in the JUnit report body

### DIFF
--- a/report/junit/formatter.go
+++ b/report/junit/formatter.go
@@ -1,7 +1,6 @@
 package junit
 
 import (
-	"html"
 	"strconv"
 
 	"github.com/securego/gosec/v2"
@@ -17,7 +16,7 @@ func generatePlaintext(issue *issue.Issue) string {
 		"[" + issue.File + ":" + issue.Line + "] - " +
 		issue.What + " (Confidence: " + strconv.Itoa(int(issue.Confidence)) +
 		", Severity: " + strconv.Itoa(int(issue.Severity)) +
-		", CWE: " + cweID + ")\n" + "> " + html.EscapeString(issue.Code) +
+		", CWE: " + cweID + ")\n" + "> " + issue.Code +
 		"\n Autofix: " + issue.Autofix
 }
 

--- a/report/junit/types.go
+++ b/report/junit/types.go
@@ -29,5 +29,5 @@ type Testcase struct {
 type Failure struct {
 	XMLName xml.Name `xml:"failure"`
 	Message string   `xml:"message,attr"`
-	Text    string   `xml:",innerxml"`
+	Text    string   `xml:",chardata"`
 }

--- a/report/junit/writer_test.go
+++ b/report/junit/writer_test.go
@@ -147,14 +147,14 @@ var _ = Describe("JUnit Writer", func() {
 				Errors: map[string][]gosec.Error{},
 				Issues: []*issue.Issue{
 					{
-						File:       "/test.go",
+						File:       "/a&b<c>.go",
 						Line:       "1",
 						Col:        "1",
 						RuleID:     "G101",
-						What:       "Test issue",
+						What:       "Test & <issue>",
 						Confidence: issue.High,
 						Severity:   issue.High,
-						Code:       "x := \"test\"",
+						Code:       "x := \"a & b < c\"",
 						Cwe:        issue.GetCweByRule("G101"),
 					},
 				},
@@ -165,9 +165,32 @@ var _ = Describe("JUnit Writer", func() {
 			err := junit.WriteReport(buf, data)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			result := buf.String()
-			Expect(result).To(ContainSubstring("<testsuites>"))
-			Expect(result).To(ContainSubstring("</testsuites>"))
+			type testcase struct {
+				Name    string `xml:"name,attr"`
+				Failure string `xml:"failure"`
+			}
+			type testsuite struct {
+				Testcases []testcase `xml:"testcase"`
+			}
+			type testsuites struct {
+				XMLName    xml.Name    `xml:"testsuites"`
+				Testsuites []testsuite `xml:"testsuite"`
+			}
+			var result testsuites
+			err = xml.Unmarshal(buf.Bytes(), &result)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			Expect(result.Testsuites).To(HaveLen(1))
+			Expect(result.Testsuites[0].Testcases).To(HaveLen(1))
+			tc := result.Testsuites[0].Testcases[0]
+			Expect(tc.Name).To(Equal("/a&b<c>.go"))
+			// The decoded failure body must contain the original characters
+			// exactly once, which proves it is neither raw nor double escaped.
+			Expect(tc.Failure).To(ContainSubstring("[/a&b<c>.go:1]"))
+			Expect(tc.Failure).To(ContainSubstring("Test & <issue>"))
+			Expect(tc.Failure).To(ContainSubstring("> x := \"a & b < c\""))
+			Expect(tc.Failure).ShouldNot(ContainSubstring("&amp;"))
+			Expect(tc.Failure).ShouldNot(ContainSubstring("&#34;"))
 		})
 
 		It("should handle multiple issues from different files", func() {


### PR DESCRIPTION
## What's broken

`-fmt=junit-xml` emits XML that no parser accepts as soon as the flagged code contains a `<` or a bare `&`.

```go
os.WriteFile("/tmp/x", []byte("a & b < c"), 0777)
```

```
$ gosec -fmt=junit-xml ./... | python3 -c "import sys,xml.dom.minidom as m; m.parseString(sys.stdin.read())"
xml.parsers.expat.ExpatError: not well-formed (invalid token): line 6, column 24
```

A filename containing `&` or `<` breaks it the same way. CI consuming the report, which is the only reason to ask for junit-xml, fails on the file instead of reporting the findings.

## The fix

`Failure.Text` was tagged `xml:",innerxml"`, which writes the string through as raw markup with no escaping at all. The formatter compensated with `html.EscapeString(issue.Code)`, but only on the code snippet, so the filename, the rule text and the `>` in the quoted line all still went out raw. And even the escaped part came out wrong, since `html.EscapeString` is not the XML escaper.

`xml:",chardata"` is the tag that means "this is text, escape it", and it applies to the whole body rather than one field of it. With it in place the manual `html.EscapeString` becomes a double-escape, so it goes away in the same edit along with the `html` import.

**No double-escaping.** Decoding the fixed output back gives the literal source:

```
name attr : '/tmp/x/a&b<c>.go'
body line : '6: \tos.WriteFile("/tmp/x", []byte("a & b < c"), 0777)'
```

Single `&`, single `<`, real quotes.

## Compatibility note

This changes the bytes on disk for every report whose text contains `&`, `<`, `>`, and additionally newlines and tabs, which `,chardata` writes as `&#xA;` and `&#x9;`. Every one of those decodes to the same string it did before, and reports that were already well formed stay semantically identical, but anyone diffing raw report files against an older run will see it.

## Verification

`report/junit/writer_test.go` already had a case named `should handle special characters in issue details`, but it used `x := "test"` as its special character, and a double quote is legal in character data, so it passed against the broken formatter. It also asserted only `ContainSubstring("<testsuites>")`.

It now uses `&` and `<` in the file, the message and the code, unmarshals the result instead of substring-matching it, and asserts the decoded values equal the originals plus that no `&amp;` or `&#34;` survives the decode.

Reverting `types.go` to `,innerxml` fails exactly that case, with `XML syntax error on line 6: invalid character entity &b (no semicolon)`, and nothing else.

`go test ./report/...` is green. The full `go test ./...` ends in FAIL only on `autofix / TestGenerateSolution_ClaudeProvider`, which expects an error from a live Claude API call and fails identically on an untouched tree here.
