### PR TITLE
fix(report): sarif and sonarqube paths depend on scan target order

### DIFF
--- a/report/sarif/formatter.go
+++ b/report/sarif/formatter.go
@@ -186,9 +186,14 @@ func parseSarifLocation(i *issue.Issue, rootPaths []string) (*Location, error) {
 
 func parseSarifArtifactLocation(i *issue.Issue, rootPaths []string) *ArtifactLocation {
 	var filePath string
+	// Select the most specific root path which actually contains the file, so that the
+	// emitted path does not depend on the order the root paths were given on the command line.
+	longest := -1
 	for _, rootPath := range rootPaths {
-		if strings.HasPrefix(i.File, rootPath) {
-			filePath = strings.Replace(i.File, rootPath+"/", "", 1)
+		root := strings.TrimSuffix(rootPath, "/")
+		if len(root) > longest && strings.HasPrefix(i.File, root+"/") {
+			longest = len(root)
+			filePath = i.File[len(root)+1:]
 		}
 	}
 	return NewArtifactLocation(filePath)

--- a/report/sarif/sarif_test.go
+++ b/report/sarif/sarif_test.go
@@ -319,5 +319,37 @@ var _ = Describe("Sarif Formatter", func() {
 			Expect(resultRuleIndexes).Should(Equal(driverRuleIndexes))
 			Expect(validateSarifSchema(sarifReport)).To(Succeed())
 		})
+
+		It("sarif formatted report should not depend on the order of the root paths", func() {
+			buildReportInfo := func(file string) *gosec.ReportInfo {
+				return gosec.NewReportInfo([]*issue.Issue{
+					{
+						Severity:   2,
+						Confidence: 0,
+						RuleID:     "G101",
+						What:       "test",
+						File:       file,
+						Code:       "1: testcode",
+						Line:       "1",
+						Col:        "1",
+					},
+				}, &gosec.Metrics{}, map[string][]gosec.Error{}).WithVersion("v2.7.0")
+			}
+			artifactURI := func(file string, rootPaths []string) string {
+				sarifReport, err := sarif.GenerateReport(rootPaths, buildReportInfo(file))
+				Expect(err).ShouldNot(HaveOccurred())
+				return sarifReport.Runs[0].Results[0].Locations[0].PhysicalLocation.ArtifactLocation.URI
+			}
+
+			// Nested root paths: the most specific one must win, whatever the order.
+			nested := "/home/src/project/sub/test.go"
+			Expect(artifactURI(nested, []string{"/home/src/project", "/home/src/project/sub"})).To(Equal("test.go"))
+			Expect(artifactURI(nested, []string{"/home/src/project/sub", "/home/src/project"})).To(Equal("test.go"))
+
+			// Sibling root paths sharing a textual prefix must not match each other.
+			sibling := "/home/src/project2/test.go"
+			Expect(artifactURI(sibling, []string{"/home/src/project", "/home/src/project2"})).To(Equal("test.go"))
+			Expect(artifactURI(sibling, []string{"/home/src/project2", "/home/src/project"})).To(Equal("test.go"))
+		})
 	})
 })

--- a/report/sonar/formatter.go
+++ b/report/sonar/formatter.go
@@ -66,9 +66,14 @@ func GenerateReport(rootPaths []string, data *gosec.ReportInfo) (*Report, error)
 
 func parseFilePath(issue *issue.Issue, rootPaths []string) string {
 	var sonarFilePath string
+	// Select the most specific root path which actually contains the file, so that the
+	// emitted path does not depend on the order the root paths were given on the command line.
+	longest := -1
 	for _, rootPath := range rootPaths {
-		if strings.HasPrefix(issue.File, rootPath) {
-			sonarFilePath = strings.Replace(issue.File, rootPath+"/", "", 1)
+		root := strings.TrimSuffix(rootPath, "/")
+		if len(root) > longest && strings.HasPrefix(issue.File, root+"/") {
+			longest = len(root)
+			sonarFilePath = issue.File[len(root)+1:]
 		}
 	}
 	return sonarFilePath

--- a/report/sonar/sonar_test.go
+++ b/report/sonar/sonar_test.go
@@ -301,5 +301,41 @@ var _ = Describe("Sonar Formatter", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(*issues).To(Equal(*want))
 		})
+
+		It("it should not depend on the order of the root paths", func() {
+			buildData := func(file string) *gosec.ReportInfo {
+				return &gosec.ReportInfo{
+					Errors: map[string][]gosec.Error{},
+					Issues: []*issue.Issue{
+						{
+							Severity:   2,
+							Confidence: 0,
+							RuleID:     "test",
+							What:       "test",
+							File:       file,
+							Code:       "",
+							Line:       "1-2",
+						},
+					},
+					Stats: &gosec.Metrics{},
+				}
+			}
+			filePath := func(file string, rootPaths []string) string {
+				report, err := sonar.GenerateReport(rootPaths, buildData(file))
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(report.Issues).To(HaveLen(1))
+				return report.Issues[0].PrimaryLocation.FilePath
+			}
+
+			// Nested root paths: the most specific one must win, whatever the order.
+			nested := "/home/src/project/sub/test.go"
+			Expect(filePath(nested, []string{"/home/src/project", "/home/src/project/sub"})).To(Equal("test.go"))
+			Expect(filePath(nested, []string{"/home/src/project/sub", "/home/src/project"})).To(Equal("test.go"))
+
+			// Sibling root paths sharing a textual prefix must not match each other.
+			sibling := "/home/src/project2/test.go"
+			Expect(filePath(sibling, []string{"/home/src/project", "/home/src/project2"})).To(Equal("test.go"))
+			Expect(filePath(sibling, []string{"/home/src/project2", "/home/src/project"})).To(Equal("test.go"))
+		})
 	})
 })


### PR DESCRIPTION
## What's broken

The paths in the `sarif` and `sonarqube` reports depend on the order the scan targets were given on the command line.

Same project, same issues, two orderings:

```
$ gosec -fmt=sarif ./... ./sub/...     ->  "uri": "a.go"   "uri": "b.go"
$ gosec -fmt=sarif ./sub/... ./...     ->  "uri": "a.go"   "uri": "sub/b.go"
```

And with two sibling directories whose names share a prefix, `p` and `p2`:

```
$ gosec -fmt=sarif /tmp/d/p2/... /tmp/d/p/...   ->  "uri": "/tmp/d/p2/a.go"
$ gosec -fmt=sarif /tmp/d/p/... /tmp/d/p2/...   ->  "uri": "a.go"
```

The first one emits an absolute path into a report format whose paths are supposed to be relative to the project root. SonarQube resolves file paths against the project, so an absolute one there does not match any file and the issue lands nowhere.

## Cause

Two separate defects in the same four-line loop, duplicated in `report/sarif/formatter.go` and `report/sonar/formatter.go`.

**The loop never stops.** It assigns `filePath` for every root that matches, so the last match wins rather than the right one. With `./... ./sub/...` the enclosing root is checked last and `sub/b.go` gets trimmed against the wrong one.

**`HasPrefix` has no path boundary.** Root `/tmp/d/p` is a string prefix of file `/tmp/d/p2/a.go`, so the branch is taken. `strings.Replace(file, root+"/", "", 1)` then looks for `/tmp/d/p/` inside that path, finds nothing, and returns the file unchanged, which is how an absolute path reaches the report.

## The fix

Match on `root + "/"` so a sibling cannot match, and keep the longest matching root instead of the last.

Longest rather than a plain `break`: roots are one `filepath.Abs` per CLI argument (`getRootPaths`, `cmd/gosec/main.go:310`), so nested arguments are legitimate and both genuinely contain the file. The report should be relative to the innermost root that contains it, which is a property of the paths and not of the argument order. A `break` on first match would still give two different answers for two orderings.

The `root + "/"` boundary also makes the slice safe, replacing a `Replace` that could silently no-op on a false prefix.

After, all four commands above agree, and `-fmt=sarif ./a.go` on a single-file argument is unchanged.

## Verification

A spec in each of `report/sarif/sarif_test.go` and `report/sonar/sonar_test.go`, covering both orderings of a nested pair and both orderings of a sibling pair.

Reverting either formatter fails its own spec and nothing else:

```
[FAILED] Expected
    <string>: sub/test.go
to equal
    <string>: test.go
```

`go test ./report/...` is green. The full `go test ./...` ends in FAIL only on `autofix / TestGenerateSolution_ClaudeProvider`, which expects an error from a live Claude API call and fails identically on an untouched tree here.
