### PR TITLE
analyzers/G703: stop treating Clean/Abs/PathEscape as path-traversal sanitizers

### DIFF
--- a/analyzers/pathtraversal.go
+++ b/analyzers/pathtraversal.go
@@ -66,22 +66,25 @@ func PathTraversal() taint.Config {
 			{Package: "net/http", Method: "ServeFileFS", CheckArgs: []int{3}},
 		},
 		Sanitizers: []taint.Sanitizer{
-			// filepath.Clean normalizes and removes traversal components
-			{Package: "path/filepath", Method: "Clean"},
-			// filepath.Abs calls Clean internally (per Go docs)
-			{Package: "path/filepath", Method: "Abs"},
 			// filepath.Base extracts just the filename, removing directory traversal
 			{Package: "path/filepath", Method: "Base"},
 			// filepath.Rel computes a relative path safely
 			{Package: "path/filepath", Method: "Rel"},
-			// url.PathEscape escapes path components
-			{Package: "net/url", Method: "PathEscape"},
 
-			// path.Base and path.Clean provide identical traversal-stripping
-			// semantics as their filepath counterparts (the only difference is
-			// separator handling, which is irrelevant for security).
+			// path.Base provides identical traversal-stripping semantics as its
+			// filepath counterpart (the only difference is separator handling,
+			// which is irrelevant for security).
 			{Package: "path", Method: "Base"},
-			{Package: "path", Method: "Clean"},
+
+			// NOTE: Clean/filepath.Clean, filepath.Abs and url.PathEscape are
+			// deliberately NOT sanitizers. Clean only lexically normalizes a
+			// path: it evaluates ".." elements instead of rejecting them, so
+			// Clean("/prefix/../../etc/passwd") yields "/etc/passwd" — the
+			// traversal succeeds. filepath.Abs calls Clean internally and
+			// inherits the same behavior, and url.PathUnescape reverses
+			// url.PathEscape, restoring any ".." that was escaped. Confining a
+			// path to a directory requires os.Root or an explicit prefix check,
+			// not Clean. See https://github.com/securego/gosec/issues/1721.
 
 			// Integer conversions eliminate path traversal vectors entirely —
 			// the result can never contain "/" or ".." characters.

--- a/testutils/g703_samples.go
+++ b/testutils/g703_samples.go
@@ -84,6 +84,8 @@ func openFromArgs() {
 	}
 }
 `}, 1, gosec.NewConfig()},
+	// True positive: filepath.Clean only normalizes, it does not confine the
+	// path, so ".." in the user input still traverses out of any prefix.
 	{[]string{`
 package main
 
@@ -93,12 +95,46 @@ import (
 	"path/filepath"
 )
 
-func safeHandler(r *http.Request) {
+func cleanHandler(r *http.Request) {
 	raw := r.URL.Query().Get("file")
 	cleaned := filepath.Clean(raw)
 	os.Open(cleaned)
 }
-`}, 0, gosec.NewConfig()},
+`}, 1, gosec.NewConfig()},
+	// True positive: path.Clean has the same normalize-only semantics as
+	// filepath.Clean and is likewise not a sanitizer.
+	{[]string{`
+package main
+
+import (
+	"net/http"
+	"os"
+	"path"
+)
+
+func pathCleanHandler(r *http.Request) {
+	raw := r.URL.Query().Get("file")
+	cleaned := path.Clean(raw)
+	os.Open(cleaned)
+}
+`}, 1, gosec.NewConfig()},
+	// True positive: url.PathEscape can be reversed by url.PathUnescape, which
+	// restores any traversal components, so it does not sanitize the path.
+	{[]string{`
+package main
+
+import (
+	"net/http"
+	"net/url"
+	"os"
+)
+
+func escapeHandler(r *http.Request) {
+	raw := r.URL.Query().Get("file")
+	restored, _ := url.PathUnescape(url.PathEscape(raw))
+	os.Open(restored)
+}
+`}, 1, gosec.NewConfig()},
 	// Test: path.Base sanitizer
 	{[]string{`
 package main
@@ -115,7 +151,8 @@ func handler(r *http.Request) {
 	os.Open(safe)
 }
 `}, 0, gosec.NewConfig()},
-	// Safe: filepath.Abs sanitizer (calls Clean internally)
+	// True positive: filepath.Abs calls Clean internally, so it inherits the
+	// same normalize-only behavior and does not confine the path.
 	{[]string{`
 package main
 
@@ -129,7 +166,7 @@ func main() {
 	filename, _ = filepath.Abs(filename)
 	os.ReadFile(filename)
 }
-`}, 0, gosec.NewConfig()},
+`}, 1, gosec.NewConfig()},
 	// Test: strconv sanitizer
 	{[]string{`
 package main


### PR DESCRIPTION
This makes G703 stop treating `path.Clean`, `filepath.Clean`, `filepath.Abs` and `url.PathEscape` as path-traversal sanitizers, because none of them actually confine a path — they only normalize it, so tainted input still traverses.

`Clean` (both `path` and `path/filepath`) *evaluates* `..` elements instead of rejecting them, per the [docs](https://pkg.go.dev/path#Clean): "Eliminate each inner .. path name element (the parent directory) along with the non-.. element that precedes it." So `Clean("/prefix/../../../../etc/passwd")` returns `/etc/passwd` — the traversal has already happened. `filepath.Abs` calls `Clean` internally and inherits exactly this behavior, and `url.PathEscape` is reversible: `url.PathUnescape(url.PathEscape(p))` restores any `..` that was escaped. Treating these as sanitizers caused G703 to silently drop real traversal flows (a false negative), as reported in #1721 with a runnable reproducer.

The change drops those four from the `Sanitizers` set in `analyzers/pathtraversal.go` and rewrites the misleading "normalizes and removes traversal components" comment to explain why. `filepath.Base` / `path.Base` (which strip to the final path element and genuinely cannot traverse) and `filepath.Rel` are left in place.

Testing: the two G703 samples that previously flowed a tainted path through `filepath.Clean` and `filepath.Abs` and expected zero findings are now true positives (expected count updated to 1), and I added new samples covering `path.Clean` and the `url.PathEscape`/`url.PathUnescape` round-trip. The `path.Base` and `strconv` samples still expect zero, confirming the remaining sanitizers are unaffected. `go test ./analyzers/` (G703 spec) passes, and running the built binary against the issue's reproducer now reports the previously-missed flows through `Clean`/`Abs` while leaving `Base` clean.

Fixes #1721
