### PR TITLE
fix(G702): skip the context argument of exec.CommandContext

### DIFF
--- a/analyzers/commandinjection.go
+++ b/analyzers/commandinjection.go
@@ -36,7 +36,8 @@ func CommandInjection() taint.Config {
 		Sinks: []taint.Sink{
 			// Detect at command creation, not execution (avoids double detection)
 			{Package: "os/exec", Method: "Command"},
-			{Package: "os/exec", Method: "CommandContext"},
+			// CommandContext takes ctx first: name is arg 1, argv slice is arg 2.
+			{Package: "os/exec", Method: "CommandContext", CheckArgs: []int{1, 2}},
 			{Package: "os", Method: "StartProcess"},
 			{Package: "syscall", Method: "Exec"},
 			{Package: "syscall", Method: "ForkExec"},

--- a/testutils/g702_samples.go
+++ b/testutils/g702_samples.go
@@ -43,4 +43,45 @@ func safeCommand() {
 	exec.Command("ls", "-la").Run()
 }
 `}, 0, gosec.NewConfig()},
+	{[]string{`
+package main
+
+import (
+	"net/http"
+	"os/exec"
+)
+
+func contextOnly(r *http.Request) {
+	// Safe - ctx carries no argv; command and args are constants
+	exec.CommandContext(r.Context(), "git", "rev-parse", "--show-toplevel").Run()
+}
+`}, 0, gosec.NewConfig()},
+	{[]string{`
+package main
+
+import (
+	"net/http"
+	"os/exec"
+)
+
+func contextAndTaintedArg(r *http.Request) {
+	// Unsafe - user-controlled argument
+	ref := r.URL.Query().Get("ref")
+	exec.CommandContext(r.Context(), "git", "checkout", ref).Run()
+}
+`}, 1, gosec.NewConfig()},
+	{[]string{`
+package main
+
+import (
+	"net/http"
+	"os/exec"
+)
+
+func contextAndTaintedName(r *http.Request) {
+	// Unsafe - user-controlled command name
+	bin := r.URL.Query().Get("bin")
+	exec.CommandContext(r.Context(), bin, "--version").Run()
+}
+`}, 1, gosec.NewConfig()},
 }


### PR DESCRIPTION
## What this changes

`{Package: "os/exec", Method: "CommandContext"}` is declared with no `CheckArgs`, and `taint.go:369-379` treats that as "check all arguments". For `exec.CommandContext(ctx, name, arg...)` the SSA arguments are `[ctx, name, argvSlice]`, so the context at `Args[0]` is checked alongside argv. A context derived from a `*http.Request` is tainted through the type source at `commandinjection.go:28`, so G702 reports at HIGH severity for a call whose executable name and every argv element are compile-time constants:

```go
func handler(w http.ResponseWriter, r *http.Request) {
	exec.CommandContext(r.Context(), "/bin/false").Run() // G702
}
```

This gives the sink the two positions that carry argv: `CheckArgs: []int{1, 2}`.

That matches every other configured sink with an explicit context parameter. `sqlinjection.go` pairs each plain `database/sql` method at `[]int{1}` with its `Context` form at `[]int{2}`, and `ssrf.go` pairs `NewRequest` at `[]int{1}` with `NewRequestWithContext` at `[]int{2}`. Of the sinks declared with no `CheckArgs`, `os/exec.CommandContext` is the only one that takes a context.

This is the taint-engine recurrence of #436, fixed for G204 in #449 by excluding the same argument.

## Tests

All three existing G702 samples call `exec.Command`, which takes no context, and every `exec.CommandContext` elsewhere in `testutils` passes `context.Background()`, so nothing covered this. Three samples close the gap:

- `contextOnly` expects 0. This is the false positive. Its command line is deliberately the same one as the #449 regression sample at `testutils/g204_samples.go:17`.
- `contextAndTaintedArg` expects 1, tainted argument after a constant executable name.
- `contextAndTaintedName` expects 1, tainted executable name.

The last two are what would catch an over-broad fix, such as dropping the sink or skipping the whole argument list.

## Verification

Reverting the one-line config change with the samples in place turns the G702 spec red on `contextOnly` at `159 Passed | 1 Failed`. The runner asserts inside its sample loop, so that failure ends the spec and the two expected-1 samples do not run in the red state; they are covered by the green run, where `go test -count=1 ./analyzers/` passes all six G702 samples. `go test -count=1 ./...` passes across every package, and `go vet` and `gofmt -l` are clean.

`tools/check_taint_benchmark.sh` passes with no global regression. It does not, however, exercise the changed path: `generateTaintStressProgram` in `analyzer_bench_test.go` emits only `exec.Command` and no `exec.CommandContext`, so treat these as a no-regression check rather than as a measurement of this sink. The cost the change actually adds is one small `argsToCheck` slice per `CommandContext` call site, since giving a sink `CheckArgs` moves it off the zero-copy `else` branch onto the appending one. The engine-level alternative below would add that per call site of every sink declared without `CheckArgs` instead of this one.

```
ns/op:     17714654 (baseline 33593865, limit 38632944)
B/op:      8350263  (baseline 8641204,  limit 9505324)
allocs/op: 49982    (baseline 51374,    limit 56511)
```

I built binaries with and without the change from the same tree and compared. These are local observational checks on code that is not in the PR, so the committed samples above are the reproducible evidence:

| Target | Before | After | Delta |
| --- | --- | --- | --- |
| Repository where I first saw this | 14 | 12 | the 2 constant-command G702 reports, nothing added |
| Three other repositories | 9, 2, 2 | 9, 2, 2 | no change |
| Corpus written to probe the boundary | 15 | 9 | the 6 intended false positives, the 9 intended positives kept |

The corpus keeps reporting a tainted element in the middle of explicit variadic arguments and a tainted slice passed as `args...`, so `Args[2]` covers every spelling of the tail.

## This does not hide taint smuggled through the context

Worth stating, since skipping an argument invites the question. A value stashed with `context.WithValue` has to be read back out before it can become argv, and the extraction produces a plain `string` that lands in `Args[1]` or `Args[2]`, both of which are still checked. Measured on a four-function corpus: the constant-command false positive, a smuggled value read into a local, a smuggled value read inline at the call, and a directly tainted argument as a control. Stock reports 4 and this change reports 3, dropping only the constant-command false positive and keeping both smuggling cases and the control.

The other sinks declared without `CheckArgs` are unaffected, and I checked rather than assumed: a tainted `*os.ProcAttr` passed to `os.StartProcess` is reported by neither build, and a tainted `envv` passed to `syscall.Exec` is reported by both, so this change neither introduces nor removes a finding there.

## Alternative considered

The engine-level form, skipping context-typed values wherever sink arguments are selected, would extend #1543's invariant to the fifth argument scan. I implemented it and measured identical findings on every target above, so it is not a behavioural difference. I did not go with it because it contradicts the documented meaning of an empty `CheckArgs` in both `taint/taint.go:82` and `DEVELOPMENT.md:180` without updating either, it adds roughly 1,400 allocs/op on the benchmarked taint path across all sinks declared without `CheckArgs` to fix the single one that takes a context, and `CheckArgs` is already the documented mechanism for skipping a non-data argument. Say the word if you would rather have it in the engine and I will switch this over.

Fixes #1729

