### PR TITLE
feat(taint): name the sink in taint finding messages

### DIFF
--- a/taint/analyzer.go
+++ b/taint/analyzer.go
@@ -22,6 +22,27 @@ type RuleInfo struct {
 	CWE         string
 }
 
+// issueText builds the message for a taint finding, naming the sink so that
+// two findings of one rule at different sinks do not share a message. The
+// description alone is byte-identical for every finding a rule produces.
+//
+// The source is not named: Analyze never populates Result.Source, so
+// formatSourceKey would render a zero value here.
+func issueText(description string, sink Sink) string {
+	return fmt.Sprintf("%s: %s", description, formatSinkKey(sink))
+}
+
+// sinkID is the comparable identity of a sink, for use as a map key. Sink
+// itself holds a []int and so cannot be one.
+type sinkID struct {
+	pkg, receiver, method string
+	pointer               bool
+}
+
+func newSinkID(sink Sink) sinkID {
+	return sinkID{pkg: sink.Package, receiver: sink.Receiver, method: sink.Method, pointer: sink.Pointer}
+}
+
 // NewGosecAnalyzer creates a golang.org/x/tools/go/analysis.Analyzer
 // compatible with gosec's analyzer framework.
 func NewGosecAnalyzer(rule *RuleInfo, config *Config) *analysis.Analyzer {
@@ -63,6 +84,10 @@ func makeAnalyzerRunner(rule *RuleInfo, config *Config) func(*analysis.Pass) (in
 
 		// Convert results to gosec issues
 		var issues []*issue.Issue
+		// One message per distinct sink rather than per finding: a rule reports
+		// at a handful of sinks and can produce thousands of findings, and this
+		// path is gated for allocations.
+		texts := make(map[sinkID]string)
 		for _, result := range results {
 			// Map severity string to issue.Score
 			var severity issue.Score
@@ -79,10 +104,17 @@ func makeAnalyzerRunner(rule *RuleInfo, config *Config) func(*analysis.Pass) (in
 				severity = issue.Medium
 			}
 
+			id := newSinkID(result.Sink)
+			what, cached := texts[id]
+			if !cached {
+				what = issueText(rule.Description, result.Sink)
+				texts[id] = what
+			}
+
 			// Create gosec issue using the standard helper
 			newIssue := newIssue(
 				rule.ID,
-				rule.Description,
+				what,
 				pass.Fset,
 				result.SinkPos,
 				severity,
@@ -92,7 +124,7 @@ func makeAnalyzerRunner(rule *RuleInfo, config *Config) func(*analysis.Pass) (in
 			issues = append(issues, newIssue)
 
 			// Report to analysis pass (for use with go vet style tools)
-			pass.Reportf(result.SinkPos, "%s: %s", rule.ID, rule.Description)
+			pass.Reportf(result.SinkPos, "%s: %s", rule.ID, what)
 		}
 
 		if len(issues) > 0 {

--- a/taint/analyzer_internal_test.go
+++ b/taint/analyzer_internal_test.go
@@ -1135,3 +1135,97 @@ func lonely(r *http.Request) {}
 		t.Fatal("expected cache hit to return true")
 	}
 }
+
+func TestIssueTextNamesTheSink(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		sink Sink
+		want string
+	}{
+		"package function": {
+			sink: Sink{Package: "os/exec", Method: "CommandContext"},
+			want: "Command injection via taint analysis: os/exec.CommandContext",
+		},
+		"pointer method": {
+			sink: Sink{Package: "database/sql", Receiver: "DB", Method: "Query", Pointer: true},
+			want: "Command injection via taint analysis: (*database/sql.DB).Query",
+		},
+		"value method": {
+			sink: Sink{Package: "net/http", Receiver: "ResponseWriter", Method: "Write"},
+			want: "Command injection via taint analysis: (net/http.ResponseWriter).Write",
+		},
+	}
+
+	const description = "Command injection via taint analysis"
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got := issueText(description, tt.sink); got != tt.want {
+				t.Errorf("issueText(%q, %+v) = %q, want %q", description, tt.sink, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIssueTextDistinguishesSinksOfOneRule pins the property the sink name
+// exists for: one rule reporting at several sinks must not produce one repeated
+// string. It asserts distinctness rather than wording, so the message can be
+// reworded without touching this test, while a regression to a description-only
+// message fails it.
+func TestIssueTextDistinguishesSinksOfOneRule(t *testing.T) {
+	t.Parallel()
+
+	sinks := []Sink{
+		{Package: "os", Method: "Open"},
+		{Package: "os", Method: "Stat"},
+		{Package: "os", Method: "Remove"},
+		{Package: "os", Method: "Mkdir"},
+		{Package: "os", Method: "ReadFile"},
+	}
+
+	seen := make(map[string]Sink, len(sinks))
+	for _, sink := range sinks {
+		got := issueText("Path traversal via taint analysis", sink)
+		if prior, dup := seen[got]; dup {
+			t.Errorf("issueText produced %q for both %+v and %+v; findings at distinct sinks must not share a message", got, prior, sink)
+		}
+		seen[got] = sink
+	}
+
+	if len(seen) != len(sinks) {
+		t.Errorf("got %d distinct messages for %d sinks, want one each", len(seen), len(sinks))
+	}
+}
+
+// TestSinkIDMatchesIssueText pins the memo's correctness condition: the runner
+// caches one message per sinkID, so two sinks may share a sinkID only if they
+// also share a message. Sinks differing in any one identity field must differ in
+// both.
+func TestSinkIDMatchesIssueText(t *testing.T) {
+	t.Parallel()
+
+	sinks := []Sink{
+		{Package: "os", Method: "Open"},
+		{Package: "os", Method: "Stat"},
+		{Package: "io/ioutil", Method: "Open"},
+		{Package: "database/sql", Receiver: "DB", Method: "Query"},
+		{Package: "database/sql", Receiver: "DB", Method: "Query", Pointer: true},
+		{Package: "database/sql", Receiver: "Tx", Method: "Query", Pointer: true},
+		{Package: "database/sql", Receiver: "DB", Method: "Exec", Pointer: true},
+		// CheckArgs and ArgTypes are outside the sink's identity: two entries
+		// differing only there name the same function and share a message.
+		{Package: "os", Method: "Open", CheckArgs: []int{1}},
+	}
+
+	const description = "Path traversal via taint analysis"
+	for i, a := range sinks {
+		for _, b := range sinks[i+1:] {
+			sameID := newSinkID(a) == newSinkID(b)
+			sameText := issueText(description, a) == issueText(description, b)
+			if sameID != sameText {
+				t.Errorf("newSinkID equality %v disagrees with issueText equality %v for %+v and %+v", sameID, sameText, a, b)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Related: #1732 (`taint.Result.Source` is never assigned). Not fixed by this PR;
it is the reason this one names only the sink, so no closing keyword.

## What this changes

`taint/analyzer.go` passes `rule.Description` straight into `newIssue` and `pass.Reportf`, so every finding a taint analyzer produces carries a byte-identical message. This appends the sink, in the `%s: %s` shape the AST rules already use.

On a file with five G703 findings at five different `os` functions:

```text
# before
d.go:11:16: [CWE-22] Path traversal via taint analysis (Rule:G703, ...)
d.go:12:16: [CWE-22] Path traversal via taint analysis (Rule:G703, ...)
d.go:13:15: [CWE-22] Path traversal via taint analysis (Rule:G703, ...)

# after
d.go:11:16: [CWE-22] Path traversal via taint analysis: os.Open (Rule:G703, ...)
d.go:12:16: [CWE-22] Path traversal via taint analysis: os.Stat (Rule:G703, ...)
d.go:13:15: [CWE-22] Path traversal via taint analysis: os.Remove (Rule:G703, ...)
```

Five findings carrying one distinct message become five carrying five.

The spelling comes from `formatSinkKey`, already in this package, so `os/exec.CommandContext` and `(*database/sql.DB).Query` render as they do everywhere else.

## Why this is worth doing

**A consumer that groups or deduplicates by message text reads distinct findings as repeats.** golangci-lint's `max-same-issues` defaults to 3 and keys on the issue text alone, so on the file below it reports 3 of the 5 findings and drops 2. It does not say so at default verbosity: the count in the summary is 3, and nothing indicates two were withheld. Only `-v` names the cause.

```go
package msgdemo

import (
	"net/http"
	"os"
)

func H(w http.ResponseWriter, r *http.Request) {
	p := r.URL.Query().Get("p")
	_, _ = os.Open(p)
	_, _ = os.Stat(p)
	_ = os.Remove(p)
	_ = os.Mkdir(p, 0o750)
	_, _ = os.ReadFile(p)
}
```

```yaml
# .golangci.yaml -- G703 only, so G304 and uniq-by-line cannot confound the count
version: "2"
linters:
  default: none
  enable: [gosec]
  settings:
    gosec:
      includes: [G703]
```

At golangci-lint 2.13.1: `golangci-lint run ./...` reports `3 issues: * gosec: 3`, `--max-same-issues=0` reports 5, and `-v` shows `max_same_issues: 5/3` in the processor stats with `uniq_by_line: 5/5` beside it.

**A reader gets the sink on the surfaces that do not print the code.** The default text output and golangci-lint both show the offending line, so the sink is visible there. It is not visible in `-fmt=golint` (`report/golint/writer.go`), JUnit, Sonar, or a SARIF result message, nor in any editor or CI annotation that renders the message alone. `cmd/gosec/sort_issues.go` also sorts on `What` as its second key, so today every finding of one rule ties there; after this they group by sink.

Across the eleven taint configs in `analyzers/` there are 92 distinct sinks and 555 source-and-sink pairings, and today they collapse into eleven message strings.

## Following the existing convention

`rules/hardcoded_credentials.go` builds `fmt.Sprintf("%s: %s", r.What, patternName)` at four report sites (`:282`, `:313`, `:352`, `:389`), which is the same shape this uses. `rules/tls.go:59` and `rules/secret_serialization.go:140` likewise put the per-finding detail after a colon. The taint analyzers were the ones adding nothing.

Wording note: the descriptions all end "via taint analysis", so an explicit connective ("tainted data reaches …") reads redundant. The bare `: <sink>` matches the four sites above.

## Known interaction, disclosed

**SARIF and Sonar derive rule-level metadata from the first finding of each rule ID**, so a per-finding message leaks into it. `report/sarif/formatter.go:96-105` sets `ShortDescription`, `FullDescription` and `Help` from `i.What`, and `addRuleInOrder` keeps the descriptor built from the first issue with that ID; `report/sonar/formatter.go:46` falls back to `issue.What` when the rule is absent from `rules.Generate(false).Rules`, which every G7xx analyzer is. So after this change, rule G703's SARIF `ShortDescription` becomes `Path traversal via taint analysis: os.Open`: one arbitrary sink, order-dependent.

Three things about it:

- **It is pre-existing, not introduced here.** G101 already yields `Potential hardcoded credentials: <pattern>` as its SARIF rule description, and G402 `TLS Bad Cipher Suite: <cipher>`. This extends the population from those to the taint rules.
- **No message shape avoids it.** Any per-finding detail lands in rule-level metadata built from one finding, so this is an argument about that derivation, not about this wording.
- **The fix is separable and Sonar already shows its shape.** Sonar looks the description up by rule ID and only falls back to `What`; extending that lookup to `analyzers.Generate(false).AnalyzersInfo()` (whose `AnalyzerDefinition` carries `ID` and `Description`) would cover the G7xx rules, and having SARIF do the same would fix G101 and G402 too. Happy to file or write that separately. It is a formatter change with its own tests, and bundling it here would mix two concerns.

Two smaller consumers of `What`, for completeness: `report/junit/formatter.go:29-33` groups testsuites by message, so suites become per-sink instead of per-rule; and `autofix/ai.go:80-96` caches AI responses keyed on the message, so a rule reporting at N sinks makes N provider calls instead of 1, with a correspondingly more specific prompt.

## Why only the sink

`Result.Source` is declared and documented as "the origin of the tainted data" (`taint/taint.go:199-200`) and is never assigned: `Analyze` has one `Result` literal, at `taint/taint.go:384`, setting `Sink`, `SinkPos` and `Path`. `grep -n 'Source:' taint/*.go` outside tests returns nothing, and `formatSourceKey(Source{})` renders `.`.

Naming the source would make the better message, and it needs `isTainted` to report which configured source it matched instead of a bool. That is a bigger change, so it is not here; the unassigned field is filed as #1732.

`Path` is populated, and I left it out deliberately: it is a call chain whose rendering would dominate the line, and the position already identifies the function the sink sits in.

## On single-sink rules

G710 and G120 configure one sink each, so for them the suffix adds a name rather than a distinction. I still think it belongs: a reader does not know a rule's sink list, so `… : (*net/http.Request).ParseMultipartForm` tells them which call was flagged even when the rule only ever flags one kind. Special-casing on `len(config.Sinks) == 1` would make the message format depend on configuration, which seems worse than a slightly long line.

## Tests

Three, in `taint/analyzer_internal_test.go`:

- `TestIssueTextNamesTheSink` pins the rendering for the three sink shapes: package function, pointer method, value method.
- `TestIssueTextDistinguishesSinksOfOneRule` pins the property the change exists for: one rule at five sinks must not produce one repeated string. It asserts distinctness, not wording, so the message can be reworded without touching it while a regression to a description-only message fails it.
- `TestSinkIDMatchesIssueText` pins the memo's correctness condition: `newSinkID(a) == newSinkID(b)` exactly when the two sinks produce the same message. It covers the `Pointer` field and the deliberate exclusion of `CheckArgs`.

Red-checked, one mutation at a time: reducing `issueText` to `return description` fails all three; dropping `Pointer` from `newSinkID` fails the third.

## Memo correctness

The message is computed once per distinct sink. `Sink` holds a `[]int` and a `map[int]string`, so it cannot be a map key; `sinkID` carries the four fields `formatSinkKey` reads (`taint/taint.go:286-294`) and nothing else, which is why `CheckArgs` is excluded: two sink entries differing only there name the same function and owe the same message.

The memo cannot collide in the other direction either: `Result.Sink` is always a value from `a.sinks`, which is itself keyed by `formatSinkKey` (`taint/taint.go:262-265`), so no two reachable `Sink` values share a key while differing in an identity field.

## Verification

`go test -count=1 ./...` passes across all 23 packages; `go vet ./...` and `gofmt -l .` are clean. No existing test or fixture asserted a taint message.

`tools/check_taint_benchmark.sh` passes. Measured in one session, all three variants in the same tree, 5 samples each:

| | allocs/op | B/op |
| --- | --- | --- |
| without the change | 49,982 | 8,350,167 |
| with the change (memo) | 50,011 | 8,371,132 |
| delta | **+29 (+0.06%)** | +20,965 (+0.25%) |
| formatting per finding instead | 55,022 | 8,501,491 |

The memo is what makes the delta negligible: a rule reports at a handful of sinks and can produce thousands of findings. Formatting per finding costs +5,040 allocs/op, which is 98% of the gate's headroom above its recorded baseline (51,374 to a 56,511 limit). It still passes, so this is a margin argument rather than a correctness one, but there is no reason to spend it.

Built against master at `57f1613` (v2.29.0).
