### PR TITLE
fix(taint): make wide caller traversal deterministic

### DIFF
--- a/taint/analyzer_internal_test.go
+++ b/taint/analyzer_internal_test.go
@@ -506,7 +506,8 @@ func caller%d(w W, data []byte) { w.Write(data) }
 const wideCallerCount = 600
 
 // buildWideCallerTaintFixture creates a sink helper with a wide set of incoming
-// callers, optionally including one caller that passes a source-typed field.
+// callers and multiple call sites, optionally including one caller that passes a
+// source-typed field.
 func buildWideCallerTaintFixture(tb testing.TB, fillerCount int, includeTainted bool) (*ssa.Program, *ssa.Function) {
 	tb.Helper()
 
@@ -522,7 +523,7 @@ func logIt(message string) { sink(message) }
 		src += "\nfunc tainted(r *Request) { logIt(r.Path) }\n"
 	}
 	for i := 0; i < fillerCount; i++ {
-		src += fmt.Sprintf("func filler%d() { logIt(\"static %d\") }\n", i, i)
+		src += fmt.Sprintf("func filler%d() { logIt(\"static %d\"); logIt(\"static duplicate %d\") }\n", i, i, i)
 	}
 
 	fset := token.NewFileSet()

--- a/taint/analyzer_internal_test.go
+++ b/taint/analyzer_internal_test.go
@@ -503,6 +503,8 @@ func caller%d(w W, data []byte) { w.Write(data) }
 	return prog, srcFuncs
 }
 
+// The issue reproducer has roughly 600 incoming call sites. Keep a focused
+// fixture at that scale to cover the reported false-negative case.
 const wideCallerCount = 600
 
 // buildWideCallerTaintFixture creates a sink helper with a wide set of incoming
@@ -520,10 +522,14 @@ func sink(message string) {}
 func logIt(message string) { sink(message) }
 `
 	if includeTainted {
-		src += "\nfunc tainted(r *Request) { logIt(r.Path) }\n"
+		src += "\nfunc aTainted(r *Request) { logIt(r.Path) }\n"
 	}
 	for i := 0; i < fillerCount; i++ {
-		src += fmt.Sprintf("func filler%d() { logIt(\"static %d\"); logIt(\"static duplicate %d\") }\n", i, i, i)
+		if i == 0 {
+			src += fmt.Sprintf("func filler%d() { logIt(\"static %d\"); logIt(\"static duplicate %d\") }\n", i, i, i)
+			continue
+		}
+		src += fmt.Sprintf("func filler%d() { logIt(\"static %d\") }\n", i, i)
 	}
 
 	fset := token.NewFileSet()
@@ -554,7 +560,7 @@ func logIt(message string) { sink(message) }
 	return prog, logFn
 }
 
-func TestTaintAnalysisFindsTaintedCallerRegardlessOfCallerEdgeOrder(t *testing.T) {
+func TestTaintAnalysisFindsTaintedCallerBeyondPreviousEdgeLimit(t *testing.T) {
 	t.Parallel()
 
 	prog, logFn := buildWideCallerTaintFixture(t, wideCallerCount, true)
@@ -565,11 +571,11 @@ func TestTaintAnalysisFindsTaintedCallerRegardlessOfCallerEdgeOrder(t *testing.T
 		t.Fatalf("expected logIt to have more than %d incoming edges, got %d", previousMaxCallerEdges, len(node.In))
 	}
 
-	// Put the tainted caller after the retained prefix. This models an
-	// otherwise valid CHA edge order in which the current cap hides the flow.
+	// Put the tainted caller after the previous retained prefix. This models an
+	// otherwise valid CHA edge order in which the old cap hid the flow.
 	taintedIndex := -1
 	for i, edge := range node.In {
-		if edge.Caller != nil && edge.Caller.Func != nil && edge.Caller.Func.Name() == "tainted" {
+		if edge.Caller != nil && edge.Caller.Func != nil && edge.Caller.Func.Name() == "aTainted" {
 			taintedIndex = i
 			break
 		}
@@ -593,10 +599,50 @@ func TestTaintAnalysisFindsTaintedCallerRegardlessOfCallerEdgeOrder(t *testing.T
 	}
 }
 
+func TestTaintAnalysisSortsCallerEdgesWhenCapIsReached(t *testing.T) {
+	t.Parallel()
+
+	// This fixture is deliberately just beyond maxCallerEdges. The tainted
+	// caller is moved to the end of the unordered input slice, but its name
+	// sorts before the filler callers and should remain in the retained prefix.
+	prog, logFn := buildWideCallerTaintFixture(t, maxCallerEdges, true)
+	callGraph := cha.CallGraph(prog)
+	node := callGraph.Nodes[logFn]
+	if node == nil || len(node.In) <= maxCallerEdges {
+		t.Fatalf("expected more than %d incoming edges, got %d", maxCallerEdges, len(node.In))
+	}
+
+	taintedIndex := -1
+	for i, edge := range node.In {
+		if edge.Caller != nil && edge.Caller.Func != nil && edge.Caller.Func.Name() == "aTainted" {
+			taintedIndex = i
+			break
+		}
+	}
+	if taintedIndex < 0 {
+		t.Fatal("tainted caller edge not found")
+	}
+	taintedEdge := node.In[taintedIndex]
+	node.In = append(node.In[:taintedIndex], node.In[taintedIndex+1:]...)
+	node.In = append(node.In, taintedEdge)
+
+	analyzer := New(&Config{
+		Sources: []Source{{Package: "p", Name: "Request", Pointer: true}},
+		Sinks:   []Sink{{Package: "p", Method: "sink", CheckArgs: []int{0}}},
+	})
+	analyzer.SetCallGraph(callGraph)
+
+	results := analyzer.Analyze(prog, []*ssa.Function{logFn})
+	if len(results) != 1 {
+		t.Fatalf("expected one taint result after sorting caller edges at the cap, got %d", len(results))
+	}
+}
+
 func TestTaintAnalysisDoesNotReportSafeWideCallerSet(t *testing.T) {
 	t.Parallel()
 
-	prog, logFn := buildWideCallerTaintFixture(t, wideCallerCount, false)
+	// Exercise the bounded path with more edges than the retained prefix.
+	prog, logFn := buildWideCallerTaintFixture(t, maxCallerEdges+1, false)
 	analyzer := New(&Config{
 		Sources: []Source{{Package: "p", Name: "Request", Pointer: true}},
 		Sinks:   []Sink{{Package: "p", Method: "sink", CheckArgs: []int{0}}},
@@ -649,6 +695,30 @@ func BenchmarkTaintAnalysisManySinkCalls(b *testing.B) {
 	for b.Loop() {
 		analyzer := New(cfg)
 		analyzer.Analyze(prog, srcFuncs)
+	}
+}
+
+func BenchmarkTaintAnalysisAtCallerEdgeCap(b *testing.B) {
+	// Include just over the retained prefix so this measures the
+	// sorting and bounded traversal path at the configured edge limit.
+	prog, logFn := buildWideCallerTaintFixture(b, maxCallerEdges, true)
+	callGraph := cha.CallGraph(prog)
+	node := callGraph.Nodes[logFn]
+	if node == nil || len(node.In) <= maxCallerEdges {
+		b.Fatalf("expected more than %d incoming edges, got %d", maxCallerEdges, len(node.In))
+	}
+
+	analyzer := New(&Config{
+		Sources: []Source{{Package: "p", Name: "Request", Pointer: true}},
+		Sinks:   []Sink{{Package: "p", Method: "sink", CheckArgs: []int{0}}},
+	})
+	analyzer.SetCallGraph(callGraph)
+
+	b.ResetTimer()
+	for b.Loop() {
+		if results := analyzer.Analyze(prog, []*ssa.Function{logFn}); len(results) != 1 {
+			b.Fatalf("expected one taint result, got %d", len(results))
+		}
 	}
 }
 

--- a/taint/analyzer_internal_test.go
+++ b/taint/analyzer_internal_test.go
@@ -503,6 +503,110 @@ func caller%d(w W, data []byte) { w.Write(data) }
 	return prog, srcFuncs
 }
 
+const wideCallerCount = 600
+
+// buildWideCallerTaintFixture creates a sink helper with a wide set of incoming
+// callers, optionally including one caller that passes a source-typed field.
+func buildWideCallerTaintFixture(tb testing.TB, fillerCount int, includeTainted bool) (*ssa.Program, *ssa.Function) {
+	tb.Helper()
+
+	src := `package p
+
+type Request struct{ Path string }
+
+func sink(message string) {}
+
+func logIt(message string) { sink(message) }
+`
+	if includeTainted {
+		src += "\nfunc tainted(r *Request) { logIt(r.Path) }\n"
+	}
+	for i := 0; i < fillerCount; i++ {
+		src += fmt.Sprintf("func filler%d() { logIt(\"static %d\") }\n", i, i)
+	}
+
+	fset := token.NewFileSet()
+	parsed, err := parser.ParseFile(fset, "p.go", src, 0)
+	if err != nil {
+		tb.Fatalf("parse: %v", err)
+	}
+	info := &types.Info{
+		Types:      make(map[ast.Expr]types.TypeAndValue),
+		Defs:       make(map[*ast.Ident]types.Object),
+		Uses:       make(map[*ast.Ident]types.Object),
+		Implicits:  make(map[ast.Node]types.Object),
+		Scopes:     make(map[ast.Node]*types.Scope),
+		Selections: make(map[*ast.SelectorExpr]*types.Selection),
+	}
+	pkg, err := (&types.Config{}).Check("p", fset, []*ast.File{parsed}, info)
+	if err != nil {
+		tb.Fatalf("type-check: %v", err)
+	}
+	prog := ssa.NewProgram(fset, ssa.BuilderMode(0))
+	ssaPkg := prog.CreatePackage(pkg, []*ast.File{parsed}, info, true)
+	prog.Build()
+
+	logFn := ssaPkg.Func("logIt")
+	if logFn == nil {
+		tb.Fatal("SSA function logIt not found")
+	}
+	return prog, logFn
+}
+
+func TestTaintAnalysisFindsTaintedCallerRegardlessOfCallerEdgeOrder(t *testing.T) {
+	t.Parallel()
+
+	prog, logFn := buildWideCallerTaintFixture(t, wideCallerCount, true)
+	callGraph := cha.CallGraph(prog)
+	node := callGraph.Nodes[logFn]
+	const previousMaxCallerEdges = 32
+	if node == nil || len(node.In) <= previousMaxCallerEdges {
+		t.Fatalf("expected logIt to have more than %d incoming edges, got %d", previousMaxCallerEdges, len(node.In))
+	}
+
+	// Put the tainted caller after the retained prefix. This models an
+	// otherwise valid CHA edge order in which the current cap hides the flow.
+	taintedIndex := -1
+	for i, edge := range node.In {
+		if edge.Caller != nil && edge.Caller.Func != nil && edge.Caller.Func.Name() == "tainted" {
+			taintedIndex = i
+			break
+		}
+	}
+	if taintedIndex < 0 {
+		t.Fatal("tainted caller edge not found")
+	}
+	taintedEdge := node.In[taintedIndex]
+	node.In = append(node.In[:taintedIndex], node.In[taintedIndex+1:]...)
+	node.In = append(node.In, taintedEdge)
+
+	analyzer := New(&Config{
+		Sources: []Source{{Package: "p", Name: "Request", Pointer: true}},
+		Sinks:   []Sink{{Package: "p", Method: "sink", CheckArgs: []int{0}}},
+	})
+	analyzer.SetCallGraph(callGraph)
+
+	results := analyzer.Analyze(prog, []*ssa.Function{logFn})
+	if len(results) != 1 {
+		t.Fatalf("expected one taint result when the tainted caller is beyond the edge limit, got %d", len(results))
+	}
+}
+
+func TestTaintAnalysisDoesNotReportSafeWideCallerSet(t *testing.T) {
+	t.Parallel()
+
+	prog, logFn := buildWideCallerTaintFixture(t, wideCallerCount, false)
+	analyzer := New(&Config{
+		Sources: []Source{{Package: "p", Name: "Request", Pointer: true}},
+		Sinks:   []Sink{{Package: "p", Method: "sink", CheckArgs: []int{0}}},
+	})
+
+	results := analyzer.Analyze(prog, []*ssa.Function{logFn})
+	if len(results) != 0 {
+		t.Fatalf("expected no taint results for callers that pass only constants, got %d", len(results))
+	}
+}
+
 func TestTaintAnalysisPerformanceWithManySinkCalls(t *testing.T) {
 	t.Parallel()
 

--- a/taint/taint.go
+++ b/taint/taint.go
@@ -28,8 +28,9 @@ const maxTaintDepth = 50
 // in isParameterTainted. CHA over-approximates call graphs (every interface method
 // call fans out to ALL implementations), so a function can have thousands of callers.
 // Incoming edges are sorted before this cap is applied so that any truncation is
-// deterministic, while the higher limit covers ordinary functions with many direct callers.
-const maxCallerEdges = 4096
+// deterministic, while the limit covers the reported ~600-edge case without
+// removing the bound that prevents combinatorial explosion on CHA graphs.
+const maxCallerEdges = 1024
 
 // isContextType checks if a type is context.Context.
 // context.Context is a control-flow mechanism (deadlines, cancellation, request-scoped values)
@@ -948,31 +949,37 @@ func (a *Analyzer) isParameterTainted(param *ssa.Parameter, fn *ssa.Function, vi
 		adjustedIdx = paramIdx
 	}
 
-	// Sort incoming edges before capping so the result does not depend on the
-	// iteration order used while CHA builds its graph.
-	inEdges := append([]*callgraph.Edge(nil), node.In...)
-	sort.SliceStable(inEdges, func(i, j int) bool {
-		left, right := inEdges[i], inEdges[j]
-		leftName, rightName := "", ""
-		if left.Caller != nil && left.Caller.Func != nil {
-			leftName = left.Caller.Func.String()
-		}
-		if right.Caller != nil && right.Caller.Func != nil {
-			rightName = right.Caller.Func.String()
-		}
-		if leftName != rightName {
-			return leftName < rightName
-		}
+	// Sorting only matters when the cap will truncate the edge set. For smaller
+	// caller sets, inspect the call graph's existing slice directly so ordinary
+	// functions do not pay an unnecessary O(n log n) cost.
+	inEdges := node.In
+	if len(node.In) > maxCallerEdges {
+		// Sort incoming edges before capping so the result does not depend on the
+		// iteration order used while CHA builds its graph.
+		inEdges = append([]*callgraph.Edge(nil), node.In...)
+		sort.SliceStable(inEdges, func(i, j int) bool {
+			left, right := inEdges[i], inEdges[j]
+			leftName, rightName := "", ""
+			if left.Caller != nil && left.Caller.Func != nil {
+				leftName = left.Caller.Func.String()
+			}
+			if right.Caller != nil && right.Caller.Func != nil {
+				rightName = right.Caller.Func.String()
+			}
+			if leftName != rightName {
+				return leftName < rightName
+			}
 
-		leftPos, rightPos := token.NoPos, token.NoPos
-		if left.Site != nil {
-			leftPos = left.Site.Pos()
-		}
-		if right.Site != nil {
-			rightPos = right.Site.Pos()
-		}
-		return leftPos < rightPos
-	})
+			leftPos, rightPos := token.NoPos, token.NoPos
+			if left.Site != nil {
+				leftPos = left.Site.Pos()
+			}
+			if right.Site != nil {
+				rightPos = right.Site.Pos()
+			}
+			return leftPos < rightPos
+		})
+	}
 
 	// Check each caller, capping at maxCallerEdges to avoid combinatorial
 	// explosion from CHA over-approximation of interface method calls.

--- a/taint/taint.go
+++ b/taint/taint.go
@@ -13,6 +13,7 @@ package taint
 import (
 	"go/token"
 	"go/types"
+	"sort"
 	"strings"
 
 	"golang.org/x/tools/go/callgraph"
@@ -26,8 +27,9 @@ const maxTaintDepth = 50
 // maxCallerEdges caps the number of incoming call graph edges examined per function
 // in isParameterTainted. CHA over-approximates call graphs (every interface method
 // call fans out to ALL implementations), so a function can have thousands of callers.
-// Real taint flows come from direct/nearby callers, not the 33rd+ CHA-generated edge.
-const maxCallerEdges = 32
+// Incoming edges are sorted before this cap is applied so that any truncation is
+// deterministic, while the higher limit covers ordinary functions with many direct callers.
+const maxCallerEdges = 4096
 
 // isContextType checks if a type is context.Context.
 // context.Context is a control-flow mechanism (deadlines, cancellation, request-scoped values)
@@ -946,10 +948,36 @@ func (a *Analyzer) isParameterTainted(param *ssa.Parameter, fn *ssa.Function, vi
 		adjustedIdx = paramIdx
 	}
 
+	// Sort incoming edges before capping so the result does not depend on the
+	// iteration order used while CHA builds its graph.
+	inEdges := append([]*callgraph.Edge(nil), node.In...)
+	sort.SliceStable(inEdges, func(i, j int) bool {
+		left, right := inEdges[i], inEdges[j]
+		leftName, rightName := "", ""
+		if left.Caller != nil && left.Caller.Func != nil {
+			leftName = left.Caller.Func.String()
+		}
+		if right.Caller != nil && right.Caller.Func != nil {
+			rightName = right.Caller.Func.String()
+		}
+		if leftName != rightName {
+			return leftName < rightName
+		}
+
+		leftPos, rightPos := token.NoPos, token.NoPos
+		if left.Site != nil {
+			leftPos = left.Site.Pos()
+		}
+		if right.Site != nil {
+			rightPos = right.Site.Pos()
+		}
+		return leftPos < rightPos
+	})
+
 	// Check each caller, capping at maxCallerEdges to avoid combinatorial
 	// explosion from CHA over-approximation of interface method calls.
 	edgesChecked := 0
-	for _, inEdge := range node.In {
+	for _, inEdge := range inEdges {
 		if edgesChecked >= maxCallerEdges {
 			break
 		}


### PR DESCRIPTION
Fixes #1712

## Summary

Taint analysis could miss a real flow when a helper or sink function has many incoming CHA caller edges. The incoming edge set is explicitly unordered, so truncating it at an arbitrary prefix made the result depend on call-graph construction order.

## Root cause

isParameterTainted previously examined only the first 32 incoming edges from node.In. CHA can produce a wide caller set, and node.In does not guarantee a stable order. A tainted caller beyond that prefix could therefore be skipped.

## Changes

- Keep bounded traversal, with maxCallerEdges set to 1024. The issue reproducer has about 604 incoming call sites; 1024 covers that case with headroom, while preserving the safety bound introduced by #1610.
- Sort incoming edges by caller function and call-site position only when the edge set exceeds the cap. Smaller caller sets avoid the additional sorting and allocation cost.
- Keep the focused issue-scale regression with roughly 600 incoming call sites.
- Add a cap-boundary regression with more than maxCallerEdges incoming edges. It moves the tainted edge to the end of the unordered input and verifies that deterministic ordering retains it.
- Extend the safe wide-caller regression beyond the cap.
- Add BenchmarkTaintAnalysisAtCallerEdgeCap to measure the sorting and bounded traversal path at the configured limit.

## Scope

This PR remains limited to taint caller-edge traversal and its regression/performance coverage. It does not change individual analyzer rules, remove the hang-prevention bound, redesign the taint engine, or introduce unrelated refactoring.

## Validation

Passed locally:

- go test ./taint -count=1
- Focused caller-edge regression tests repeated 20 times
- go test ./taint -run '^$' -bench '^BenchmarkTaintAnalysis(ManySinkCalls|AtCallerEdgeCap)$' -benchmem -count=1 -benchtime=1s
- go test ./... -run '^$' -count=1
- go vet ./...
- go build ./...
- gofmt and git diff --check

On the same Windows host, the cap-boundary benchmark measured approximately 4.4 ms/op, 1.25 MB/op, and 77k allocations/op. The existing many-sink benchmark remains below the cap and therefore does not sort incoming edges.

The full go test ./... -short -count=1 -timeout=120s run still exposes unrelated Windows/environment baseline failures: analyzer and report expectations, temporary-file locking, and timeouts in the cmd/gosec, cmd/gosecutil, and rules suites. The changed taint package passes. The local race command cannot run because this Windows environment has CGO disabled and no gcc toolchain.