### PR TITLE
fix(report): correct Babel SRI hash

### DIFF
--- a/report/html/template.html
+++ b/report/html/template.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.12.0/styles/default.min.css" integrity="sha512-hasIneQUHlh06VNBe7f6ZcHmeRTLIaQWFd43YriJ0UND19bvYRauxthDg8E4eVNPm9bRUhr5JGeqH7FRFXQu5g==" crossorigin="anonymous"/>
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.12.0/highlight.min.js" integrity="sha512-gzqHAlI1hVdzJ4wiQj/MkppDr6zgEdCoBsrXKRidcaZsSPvNQ3Fy5p7PpMt/8mltxTxMHj1Ur5NWbJdqIfpxgA==" crossorigin="anonymous"></script>
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.12.0/languages/go.min.js" integrity="sha512-BA9llYIpkzm7tOoevj0uNMleYSysUOxNYfCq3JD3q8UBMzd7fTGeZdQfpAOf6JIH+sXeWTk1KfeAhyaDD4k4wQ==" crossorigin="anonymous"></script>
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/8.0.4/babel.min.js" integrity="sha512-0kogYX+JRNNH6mtJ3d4ZGS50A5IbSQdyOQRX4suqvLbIKjUmJ4/oMFlqhVLSO/hUVUKXJ6TS7Tvqa1wdEj/wHg==" crossorigin="anonymous"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/8.0.4/babel.min.js" integrity="sha512-4EbyfF7Lt/JPkr7+9dMHGqif4hJmqmE+cWGG3c9o4aGrHqyFH+IFE8iVFyAieEB0BtN8yHjL08DvQxFlbn31gw==" crossorigin="anonymous"></script>
   
   <script type="importmap">
   {

--- a/report/html/writer_test.go
+++ b/report/html/writer_test.go
@@ -151,5 +151,21 @@ var _ = Describe("HTML Writer", func() {
 			htmlCloseCount := strings.Count(result, "</html>")
 			Expect(htmlCloseCount).To(Equal(1))
 		})
+
+		It("should include the Babel script with the correct integrity hash", func() {
+			data := &gosec.ReportInfo{
+				Errors: map[string][]gosec.Error{},
+				Issues: []*issue.Issue{},
+				Stats:  &gosec.Metrics{},
+			}
+
+			buf := new(bytes.Buffer)
+			err := html.WriteReport(buf, data)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			result := buf.String()
+			Expect(result).To(ContainSubstring(`src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/8.0.4/babel.min.js" integrity="sha512-4EbyfF7Lt/JPkr7+9dMHGqif4hJmqmE+cWGG3c9o4aGrHqyFH+IFE8iVFyAieEB0BtN8yHjL08DvQxFlbn31gw=="`))
+			Expect(result).NotTo(ContainSubstring("sha512-0kogYX+JRNNH6mtJ3d4ZGS50A5IbSQdyOQRX4suqvLbIKjUmJ4/oMFlqhVLSO/hUVUKXJ6TS7Tvqa1wdEj/wHg=="))
+		})
 	})
 })


### PR DESCRIPTION
## Summary

- correct the Subresource Integrity hash for Babel standalone 8.0.4
- add generated-report coverage for the exact CDN URL and integrity value
- guard against reintroducing the known invalid digest

Fixes #1735

## Validation

- `go test ./report/html -count=1`
- `go vet ./report/html`
- `go vet ./report/...`
- `go build -o gosec-validation.exe ./cmd/gosec/`
- generated an HTML report and verified that it contains the corrected hash and not the invalid one
- independently SHA-512 checked all five CDN assets referenced by the template

`go test ./report/... -count=1` passes for the changed package and all report subpackages. The root `report` package still has two pre-existing Windows line-ending fixture failures in `formatter_test.go`.
