### PR TITLE
fix(taint): remove Result.Source field that is never populated

### DIFF
--- a/taint/analyzer.go
+++ b/taint/analyzer.go
@@ -25,9 +25,6 @@ type RuleInfo struct {
 // issueText builds the message for a taint finding, naming the sink so that
 // two findings of one rule at different sinks do not share a message. The
 // description alone is byte-identical for every finding a rule produces.
-//
-// The source is not named: Analyze never populates Result.Source, so
-// formatSourceKey would render a zero value here.
 func issueText(description string, sink Sink) string {
 	return fmt.Sprintf("%s: %s", description, formatSinkKey(sink))
 }

--- a/taint/taint.go
+++ b/taint/taint.go
@@ -197,10 +197,8 @@ type Sanitizer struct {
 	Pointer bool
 }
 
-// Result represents a detected taint flow from source to sink.
+// Result represents a detected taint flow to a sink.
 type Result struct {
-	// Source is the origin of the tainted data
-	Source Source
 	// Sink is the dangerous function that receives the tainted data
 	Sink Sink
 	// SinkPos is the source code position of the sink call


### PR DESCRIPTION
## What

Remove the `taint.Result.Source` field, which is declared and documented as the origin of the tainted data but is never populated by `Analyze`.

`Analyze` builds every `Result` with only `Sink`, `SinkPos`, and `Path` set:

```go
results = append(results, Result{
    Sink:    sink,
    SinkPos: call.Pos(),
    Path:    a.buildPath(fn),
})
```

`grep` for `Source:` in non-test `taint/*.go` returns nothing, and no consumer reads `Result.Source`. Any consumer reading the field gets a silent zero value (`Source{}`) with no error.

## Why

The field documents a guarantee the package does not keep. Since `isTainted` returns a `bool`, the matched `Source` is not carried back out by the time a flow is confirmed. Populating it correctly would require threading the matched source through the recursive walk — a larger change.

This removes the dead field so the struct no longer advertises a value that is always zero, rather than leaving it to mislead callers.

## Change

- Drop `Result.Source` and its doc comment in `taint/taint.go`.
- Remove the now-stale "source is not named" comment in `taint/analyzer.go`.

## Validation

- `go build ./...`
- `go test ./...` — all packages pass

Fixes #1732
