### PR TITLE
fix: make nosec suppression independent of comment order

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -16,6 +16,7 @@
 package gosec
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -31,6 +32,7 @@ import (
 	"reflect"
 	"regexp"
 	"runtime/debug"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -98,50 +100,30 @@ func (i ignores) parseLine(line string) (int, int) {
 }
 
 func (i ignores) add(file string, line string, suppressions map[string]issue.SuppressionInfo) {
-	is := []ignore{}
-	if _, ok := i[file]; ok {
-		is = i[file]
-	}
-	found := false
 	start, end := i.parseLine(line)
-	for _, ig := range is {
-		if ig.start <= start && ig.end >= end {
-			found = true
-			for r, s := range suppressions {
-				ss, ok := ig.suppressions[r]
-				if !ok {
-					ss = []issue.SuppressionInfo{}
-				}
-				ss = append(ss, s)
-				ig.suppressions[r] = ss
-			}
-			break
-		}
+	ig := ignore{
+		start:        start,
+		end:          end,
+		suppressions: make(map[string][]issue.SuppressionInfo, len(suppressions)),
 	}
-	if !found {
-		ig := ignore{
-			start:        start,
-			end:          end,
-			suppressions: map[string][]issue.SuppressionInfo{},
-		}
-		for r, s := range suppressions {
-			ig.suppressions[r] = []issue.SuppressionInfo{s}
-		}
-		is = append(is, ig)
+	for r, s := range suppressions {
+		ig.suppressions[r] = []issue.SuppressionInfo{s}
 	}
-	i[file] = is
+	// Keep each directive's range intact, even when it is nested in another.
+	i[file] = append(i[file], ig)
 }
 
 func (i ignores) get(file string, line string) map[string][]issue.SuppressionInfo {
 	start, end := i.parseLine(line)
-	if is, ok := i[file]; ok {
-		for _, i := range is {
-			if i.start <= start && i.end >= end || start <= i.start && end >= i.end {
-				return i.suppressions
+	suppressions := make(map[string][]issue.SuppressionInfo)
+	for _, ig := range i[file] {
+		if ig.start <= start && ig.end >= end || start <= ig.start && end >= ig.end {
+			for r, ss := range ig.suppressions {
+				suppressions[r] = append(suppressions[r], ss...)
 			}
 		}
 	}
-	return map[string][]issue.SuppressionInfo{}
+	return suppressions
 }
 
 // The Context is populated with data parsed from the source code as it is scanned.
@@ -911,7 +893,11 @@ func (v *astVisitor) Visit(n ast.Node) ast.Visitor {
 
 // updateIgnores parses comments to find and update ignored rules.
 func (v *astVisitor) updateIgnores() {
-	for c := range v.context.Comments {
+	// Keep tracked suppression justifications in source order.
+	nodes := slices.SortedFunc(maps.Keys(v.context.Comments), func(a, b ast.Node) int {
+		return cmp.Or(cmp.Compare(a.Pos(), b.Pos()), cmp.Compare(a.End(), b.End()))
+	})
+	for _, c := range nodes {
 		v.updateIgnoredRulesForNode(c)
 	}
 }

--- a/analyzer_ignores_internal_test.go
+++ b/analyzer_ignores_internal_test.go
@@ -1,0 +1,128 @@
+package gosec
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io"
+	"log"
+	"reflect"
+	"slices"
+	"testing"
+
+	"github.com/securego/gosec/v2/issue"
+)
+
+func TestIgnoresNestedRanges(t *testing.T) {
+	t.Parallel()
+
+	outer := issue.SuppressionInfo{Kind: "inSource", Justification: "outer directive"}
+	inner := issue.SuppressionInfo{Kind: "inSource", Justification: "inner directive"}
+	for _, innerRule := range []string{"G304", aliasOfAllRules} {
+		for _, order := range []struct {
+			name    string
+			reverse bool
+		}{
+			{name: "outer first"},
+			{name: "inner first", reverse: true},
+		} {
+			t.Run(innerRule+"/"+order.name, func(t *testing.T) {
+				ignores := newIgnores()
+				addOuter := func() {
+					ignores.add("test.go", "9-37", map[string]issue.SuppressionInfo{"G101": outer})
+				}
+				addInner := func() {
+					ignores.add("test.go", "24", map[string]issue.SuppressionInfo{innerRule: inner})
+				}
+				if order.reverse {
+					addInner()
+					addOuter()
+				} else {
+					addOuter()
+					addInner()
+				}
+
+				both := map[string][]issue.SuppressionInfo{"G101": {outer}, innerRule: {inner}}
+				outerOnly := map[string][]issue.SuppressionInfo{"G101": {outer}}
+				none := map[string][]issue.SuppressionInfo{}
+				for _, tt := range []struct {
+					name string
+					file string
+					line string
+					want map[string][]issue.SuppressionInfo
+				}{
+					{name: "outer finding", file: "test.go", line: "10-37", want: both},
+					{name: "inner finding", file: "test.go", line: "24", want: both},
+					{name: "outside inner range", file: "test.go", line: "15", want: outerOnly},
+					{name: "start boundary", file: "test.go", line: "9", want: outerOnly},
+					{name: "end boundary", file: "test.go", line: "37", want: outerOnly},
+					{name: "before ranges", file: "test.go", line: "8", want: none},
+					{name: "after ranges", file: "test.go", line: "38", want: none},
+					{name: "partial overlap", file: "test.go", line: "30-40", want: none},
+					{name: "other file", file: "other.go", line: "24", want: none},
+				} {
+					t.Run(tt.name, func(t *testing.T) {
+						if got := ignores.get(tt.file, tt.line); !reflect.DeepEqual(got, tt.want) {
+							t.Fatalf("unexpected suppressions: got %#v, want %#v", got, tt.want)
+						}
+					})
+				}
+			})
+		}
+	}
+}
+
+func TestIgnoresPreservesJustifications(t *testing.T) {
+	t.Parallel()
+
+	first := issue.SuppressionInfo{Kind: "inSource", Justification: "first directive"}
+	second := issue.SuppressionInfo{Kind: "inSource", Justification: "second directive"}
+	for _, line := range []string{"9-37", "24"} {
+		t.Run(line, func(t *testing.T) {
+			ignores := newIgnores()
+			ignores.add("test.go", "9-37", map[string]issue.SuppressionInfo{"G101": first})
+			ignores.add("test.go", line, map[string]issue.SuppressionInfo{"G101": second})
+
+			got := ignores.get("test.go", "24")["G101"]
+			if len(got) != 2 || !slices.Contains(got, first) || !slices.Contains(got, second) {
+				t.Fatalf("expected both justifications, got %#v", got)
+			}
+		})
+	}
+}
+
+func TestUpdateIgnoresSourceOrder(t *testing.T) {
+	t.Parallel()
+
+	const source = `package test
+
+// #nosec G101 -- outer directive
+func example() {
+	// #nosec G101 -- inner directive
+	println("example")
+}
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "test.go", source, parser.ParseComments)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	visitor := &astVisitor{
+		gosec: NewAnalyzer(NewConfig(), false, false, false, 1, log.New(io.Discard, "", 0)),
+		context: &Context{
+			FileSet:  fset,
+			Comments: ast.NewCommentMap(fset, file, file.Comments),
+		},
+		stats: &Metrics{},
+	}
+	visitor.updateIgnores()
+
+	want := []issue.SuppressionInfo{
+		{Kind: "inSource", Justification: "outer directive"},
+		{Kind: "inSource", Justification: "inner directive"},
+	}
+	if got := visitor.context.Ignores.get("test.go", "6")["G101"]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected suppressions in source order: got %#v, want %#v", got, want)
+	}
+}

--- a/testutils/g101_samples.go
+++ b/testutils/g101_samples.go
@@ -595,5 +595,44 @@ func main() {
 	}
 }
 `}, 1, gosec.NewConfig()},
+		{[]string{`
+package main
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+)
+
+// #nosec G101 -- example connection strings in help text are not real credentials
+var serveCmd = &struct {
+	Use, Long string
+	RunE      func(args []string) error
+}{
+	Use: "serve",
+	Long: ` + "`" + `Config file format:
+  databases:
+    db1:
+      url: "postgres://user:pass@host:5432/db1"
+    db2:
+      url: "postgres://user:pass@host:5432/db2"
+` + "`" + `,
+	RunE: func(args []string) error {
+		cfgPath := os.Getenv("CFG")
+		raw, err := os.ReadFile(cfgPath) // #nosec G304 -- operator-supplied path
+		if err != nil {
+			return fmt.Errorf("read: %w", err)
+		}
+		_ = raw
+		u, _ := url.Parse(os.Getenv("DB_URL"))
+		if u != nil && u.User != nil {
+			u.User = url.UserPassword(u.User.Username(), "x")
+		}
+		return nil
+	},
+}
+
+func main() { _ = serveCmd }
+`}, 0, gosec.NewConfig()},
 	}
 )


### PR DESCRIPTION
`#nosec` comments are read from a map, while lookup used only the first matching range. An inner `G304` directive could hide an outer `G101` suppression depending on iteration order. Merging nested ranges also widened the scope of inner directives.

Keep each directive's range, collect all matching suppressions, and process comments in source order so tracked justifications are stable. Added tests for both insertion orders, range boundaries, and multiple justifications, plus the issue's reproducer.

Tested on Go 1.26.8 with `make test-nocache`, `golangci-lint run`, and 60 runs of the reproducer with no G101 leaks. With `-nosec`, the expected G101 finding is still reported.

Fixes #1740. Thanks for the reproducer!
