### PR TITLE
fix(G404): ignore non-cryptographic Shuffle calls

### DIFF
--- a/rules/rand.go
+++ b/rules/rand.go
@@ -31,9 +31,9 @@ func NewWeakRandCheck(id string, _ gosec.Config) (gosec.Rule, []ast.Node) {
 		"Use of weak random number generator (math/rand or math/rand/v2 instead of crypto/rand)",
 		issue.High, issue.Medium)}
 	rule.AddAll("math/rand", "New", "Read", "ExpFloat64", "Float32", "Float64", "Int", "Int31", "Int31n",
-		"Int63", "Int63n", "Intn", "NormFloat64", "Perm", "Shuffle", "Uint32", "Uint64")
+		"Int63", "Int63n", "Intn", "NormFloat64", "Perm", "Uint32", "Uint64")
 	rule.AddAll("math/rand/v2", "New", "ExpFloat64", "Float32", "Float64", "Int", "Int32", "Int32N",
-		"Int64", "Int64N", "IntN", "N", "NormFloat64", "Perm", "Shuffle", "Uint", "Uint32", "Uint32N", "Uint64", "Uint64N", "UintN")
+		"Int64", "Int64N", "IntN", "N", "NormFloat64", "Perm", "Uint", "Uint32", "Uint32N", "Uint64", "Uint64N", "UintN")
 
 	return rule, []ast.Node{(*ast.CallExpr)(nil)}
 }

--- a/testutils/g404_samples.go
+++ b/testutils/g404_samples.go
@@ -20,7 +20,19 @@ package main
 import "math/rand"
 
 func main() {
-	bad := rand.Int()
+nums := []int{1, 2, 3}
+rand.Shuffle(len(nums), func(i, j int) {
+nums[i], nums[j] = nums[j], nums[i]
+})
+}
+`}, 0, gosec.NewConfig()},
+	{[]string{`
+package main
+
+import "math/rand"
+
+func main() {
+bad := rand.Int()
 	println(bad)
 }
 `}, 1, gosec.NewConfig()},
@@ -30,7 +42,19 @@ package main
 import "math/rand/v2"
 
 func main() {
-	bad := rand.Int()
+nums := []int{1, 2, 3}
+rand.Shuffle(len(nums), func(i, j int) {
+nums[i], nums[j] = nums[j], nums[i]
+})
+}
+`}, 0, gosec.NewConfig()},
+	{[]string{`
+package main
+
+import "math/rand/v2"
+
+func main() {
+bad := rand.Int()
 	println(bad)
 }
 `}, 1, gosec.NewConfig()},

--- a/testutils/g404_samples.go
+++ b/testutils/g404_samples.go
@@ -195,12 +195,12 @@ func main() {
 	f := rand.ExpFloat64() // bad
 	println(f)
 	nums := []int{1, 2, 3}
-	rand.Shuffle(len(nums), func(i, j int) { // bad
+	rand.Shuffle(len(nums), func(i, j int) { // not security-sensitive
 		nums[i], nums[j] = nums[j], nums[i]
 	})
 	println(nums[0])
 }
-`}, 3, gosec.NewConfig()},
+`}, 2, gosec.NewConfig()},
 	{[]string{`
 package main
 
@@ -214,10 +214,10 @@ func main() {
 	f := rand.ExpFloat64() // bad
 	println(f)
 	nums := []int{1, 2, 3}
-	rand.Shuffle(len(nums), func(i, j int) { // bad
+	rand.Shuffle(len(nums), func(i, j int) { // not security-sensitive
 		nums[i], nums[j] = nums[j], nums[i]
 	})
 	println(nums[0])
 }
-`}, 4, gosec.NewConfig()},
+`}, 3, gosec.NewConfig()},
 }


### PR DESCRIPTION
## Summary

- stop reporting `math/rand.Shuffle` and `math/rand/v2.Shuffle` under G404
- retain coverage for the other weak-random APIs in the existing samples
- update the expected findings counts to prove `Shuffle` is not reported

`Shuffle` only changes ordering and is not itself a source of random values. Callers that require an unpredictable permutation should still use an appropriate cryptographic design; this change only avoids treating ordinary collection shuffling as a weak-randomness finding.

Fixes #1725

## Validation

- `go test ./rules -run TestRules -count=1`
- `git diff --check`
